### PR TITLE
feat: ✨ 增强请求日志列表与详情

### DIFF
--- a/server/internal/admin/handler_requests.go
+++ b/server/internal/admin/handler_requests.go
@@ -256,48 +256,52 @@ func requestLogPayload(item store.RequestLogDetail, includeMetadata bool) map[st
 	metadata := requestLogMetadata(item.Metadata)
 	attempt := intFromAny(metadata["attempt"])
 	credentialAttempt := intFromAny(metadata["credential_attempt"])
+	credential := requestLogCredentialProjection(metadata)
 	payload := map[string]any{
-		"id":                   item.ID.String(),
-		"request_id":           item.RequestID,
-		"parent_request_id":    metadataString(metadata, "parent_request_id"),
-		"scope":                metadataString(metadata, "scope"),
-		"is_test":              metadata["test"] == true,
-		"stream":               metadata["stream"],
-		"response_mode":        metadata["response_mode"],
-		"stream_started":       metadata["stream_started"],
-		"stream_completed":     metadata["stream_completed"],
-		"stream_received_done": metadata["stream_received_done"],
-		"stream_incomplete":    metadata["stream_incomplete"],
-		"stream_end_reason":    metadata["stream_end_reason"],
-		"stream_failure_scope": metadata["stream_failure_scope"],
-		"protocol_conversion":  metadata["protocol_conversion"],
-		"stage":                metadataString(metadata, "stage"),
-		"requested_model":      metadataString(metadata, "requested_model"),
-		"original_model":       metadataString(metadata, "original_model"),
-		"mapped_model":         metadataString(metadata, "mapped_model"),
-		"mapping_mode":         metadataString(metadata, "mapping_mode"),
-		"attempt":              attempt,
-		"credential_attempt":   credentialAttempt,
-		"credential_total":     intFromAny(metadata["credential_total"]),
-		"failover":             attempt > 1 || credentialAttempt > 1,
-		"endpoint":             item.Endpoint,
-		"downstream_path":      valueOrFallback(metadata["downstream_path"], item.Endpoint),
-		"upstream_path":        metadata["upstream_path"],
-		"upstream_url":         metadata["upstream_url"],
-		"status_code":          item.StatusCode,
-		"upstream_status_code": metadata["upstream_status_code"],
-		"success":              item.Success,
-		"error_type":           nullStringValue(item.ErrorType),
-		"latency_ms":           nullInt64Value(item.LatencyMS),
-		"upstream_latency_ms":  nullInt64Value(item.UpstreamLatencyMS),
-		"request_tokens":       nullInt64Value(item.RequestTokens),
-		"response_tokens":      nullInt64Value(item.ResponseTokens),
-		"pricing_group":        metadata["pricing_group"],
+		"id":                    item.ID.String(),
+		"request_id":            item.RequestID,
+		"parent_request_id":     metadataString(metadata, "parent_request_id"),
+		"scope":                 metadataString(metadata, "scope"),
+		"is_test":               metadata["test"] == true,
+		"stream":                metadata["stream"],
+		"response_mode":         metadata["response_mode"],
+		"stream_started":        metadata["stream_started"],
+		"stream_completed":      metadata["stream_completed"],
+		"stream_received_done":  metadata["stream_received_done"],
+		"stream_incomplete":     metadata["stream_incomplete"],
+		"stream_end_reason":     metadata["stream_end_reason"],
+		"stream_failure_scope":  metadata["stream_failure_scope"],
+		"protocol_conversion":   metadata["protocol_conversion"],
+		"stage":                 metadataString(metadata, "stage"),
+		"requested_model":       metadataString(metadata, "requested_model"),
+		"original_model":        metadataString(metadata, "original_model"),
+		"mapped_model":          metadataString(metadata, "mapped_model"),
+		"mapping_mode":          metadataString(metadata, "mapping_mode"),
+		"attempt":               attempt,
+		"credential_attempt":    credentialAttempt,
+		"credential_total":      intFromAny(metadata["credential_total"]),
+		"failover":              attempt > 1 || credentialAttempt > 1,
+		"endpoint":              item.Endpoint,
+		"downstream_path":       valueOrFallback(metadata["downstream_path"], item.Endpoint),
+		"upstream_path":         metadata["upstream_path"],
+		"upstream_url":          metadata["upstream_url"],
+		"status_code":           item.StatusCode,
+		"upstream_status_code":  metadata["upstream_status_code"],
+		"success":               item.Success,
+		"error_type":            nullStringValue(item.ErrorType),
+		"latency_ms":            nullInt64Value(item.LatencyMS),
+		"first_byte_latency_ms": requestMetadataInt64(metadata, "first_byte_latency"),
+		"reasoning_effort":      metadataString(metadata, "reasoning_effort"),
+		"upstream_latency_ms":   nullInt64Value(item.UpstreamLatencyMS),
+		"request_tokens":        nullInt64Value(item.RequestTokens),
+		"response_tokens":       nullInt64Value(item.ResponseTokens),
+		"pricing_group":         metadata["pricing_group"],
 		"api_key": map[string]any{
 			"id":         nullUUIDValue(item.APIKeyID),
 			"name":       nullStringValue(item.APIKeyName),
 			"masked_key": nullStringValue(item.APIKeyMaskedKey),
 		},
+		"credential": credential,
 		"site": map[string]any{
 			"id":        valueOrFallback(metadata["site_id"], nullUUIDValue(item.SiteID)),
 			"name":      valueOrFallback(metadata["site_name"], nullStringValue(item.SiteName)),
@@ -328,8 +332,92 @@ func requestLogPayload(item store.RequestLogDetail, includeMetadata bool) map[st
 		payload["failure_response"] = valueOrFallback(metadata["upstream_response"], metadata["error_response"])
 	}
 	if includeMetadata {
-		payload["metadata"] = metadata
+		payload["metadata"] = requestLogMetadataForResponse(metadata)
 	}
 
 	return payload
+}
+
+func requestLogCredentialProjection(metadata map[string]any) any {
+	credentialMeta, _ := metadata["credential"].(map[string]any)
+	id := metadataString(metadata, "credential_id")
+	name := metadataString(metadata, "credential_name")
+	if credentialMeta != nil {
+		id = valueOrFallback(metadataString(credentialMeta, "id"), id)
+		name = valueOrFallback(metadataString(credentialMeta, "name"), name)
+	}
+	if id == nil && name == nil {
+		return nil
+	}
+	return map[string]any{
+		"id":   id,
+		"name": name,
+	}
+}
+
+func requestMetadataInt64(metadata map[string]any, key string) any {
+	var value int64
+	switch raw := metadata[key].(type) {
+	case int:
+		value = int64(raw)
+	case int8:
+		value = int64(raw)
+	case int16:
+		value = int64(raw)
+	case int32:
+		value = int64(raw)
+	case int64:
+		value = raw
+	case uint:
+		value = int64(raw)
+	case uint8:
+		value = int64(raw)
+	case uint16:
+		value = int64(raw)
+	case uint32:
+		value = int64(raw)
+	case uint64:
+		if raw > uint64(^uint64(0)>>1) {
+			return nil
+		}
+		value = int64(raw)
+	case float32:
+		if float32(int64(raw)) != raw {
+			return nil
+		}
+		value = int64(raw)
+	case float64:
+		if float64(int64(raw)) != raw {
+			return nil
+		}
+		value = int64(raw)
+	default:
+		return nil
+	}
+	if value <= 0 {
+		return nil
+	}
+	return value
+}
+
+// requestLogMetadataForResponse removes historical masked credential values
+// before exposing the raw metadata object in a request detail response.
+func requestLogMetadataForResponse(metadata map[string]any) map[string]any {
+	if metadata == nil {
+		return map[string]any{}
+	}
+	result := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	delete(result, "credential_masked")
+	if credential, ok := metadata["credential"].(map[string]any); ok {
+		clean := make(map[string]any, len(credential))
+		for key, value := range credential {
+			clean[key] = value
+		}
+		delete(clean, "masked_secret")
+		result["credential"] = clean
+	}
+	return result
 }

--- a/server/internal/admin/handler_requests.go
+++ b/server/internal/admin/handler_requests.go
@@ -400,8 +400,6 @@ func requestMetadataInt64(metadata map[string]any, key string) any {
 	return value
 }
 
-// requestLogMetadataForResponse removes historical masked credential values
-// before exposing the raw metadata object in a request detail response.
 func requestLogMetadataForResponse(metadata map[string]any) map[string]any {
 	if metadata == nil {
 		return map[string]any{}

--- a/server/internal/admin/handler_requests_test.go
+++ b/server/internal/admin/handler_requests_test.go
@@ -203,3 +203,84 @@ func TestRequestLogPayloadMarksFailoverAttempt(t *testing.T) {
 		t.Fatalf("unexpected failover fields: %#v", payload)
 	}
 }
+
+func TestRequestLogPayloadProjectsTimingReasoningAndSecretFreeCredential(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := json.Marshal(map[string]any{
+		"first_byte_latency": 37,
+		"reasoning_effort":   "high",
+		"credential_id":      "credential-fallback",
+		"credential_name":    "Fallback name",
+		"credential_masked":  "sk-...fallback",
+		"credential": map[string]any{
+			"id":            "credential-123",
+			"name":          "Production key",
+			"masked_secret": "sk-...123",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := requestLogPayload(store.RequestLogDetail{
+		RequestLog: store.RequestLog{
+			ID:        uuid.New(),
+			RequestID: "req_reasoning",
+			Metadata:  metadata,
+		},
+	}, true)
+	if got := payload["first_byte_latency_ms"]; got != int64(37) {
+		t.Fatalf("first_byte_latency_ms = %#v, want 37", got)
+	}
+	if got := payload["reasoning_effort"]; got != "high" {
+		t.Fatalf("reasoning_effort = %#v, want high", got)
+	}
+	credential, ok := payload["credential"].(map[string]any)
+	if !ok || credential["id"] != "credential-123" || credential["name"] != "Production key" {
+		t.Fatalf("unexpected credential projection: %#v", payload["credential"])
+	}
+	if _, ok := credential["masked_secret"]; ok {
+		t.Fatalf("credential projection must not include masked secret: %#v", credential)
+	}
+	responseMetadata, ok := payload["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata payload = %#v", payload["metadata"])
+	}
+	if _, ok := responseMetadata["credential_masked"]; ok {
+		t.Fatalf("metadata must not expose credential_masked: %#v", responseMetadata)
+	}
+	responseCredential, ok := responseMetadata["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata credential = %#v", responseMetadata["credential"])
+	}
+	if _, ok := responseCredential["masked_secret"]; ok {
+		t.Fatalf("metadata must not expose credential masked_secret: %#v", responseCredential)
+	}
+}
+
+func TestRequestLogPayloadOmitsUnknownFirstByteLatencyAndCredential(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := json.Marshal(map[string]any{
+		"first_byte_latency": 0,
+		"reasoning_effort":   42,
+		"credential":         map[string]any{"masked_secret": "sk-...123"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := requestLogPayload(store.RequestLogDetail{
+		RequestLog: store.RequestLog{ID: uuid.New(), RequestID: "req_legacy", Metadata: metadata},
+	}, false)
+	if payload["first_byte_latency_ms"] != nil {
+		t.Fatalf("unknown first byte latency = %#v, want nil", payload["first_byte_latency_ms"])
+	}
+	if payload["reasoning_effort"] != nil {
+		t.Fatalf("invalid reasoning effort = %#v, want nil", payload["reasoning_effort"])
+	}
+	if payload["credential"] != nil {
+		t.Fatalf("credential without id/name = %#v, want nil", payload["credential"])
+	}
+}

--- a/server/internal/gateway/execution.go
+++ b/server/internal/gateway/execution.go
@@ -582,9 +582,6 @@ func (h Handler) finishBufferedSemanticFailure(
 	failure *upstreamSemanticFailure,
 ) gatewayAttemptResult {
 	result.statusCode = http.StatusBadGateway
-	// Keep buffered failures internal while eligible alternatives are retried.
-	// Preserve the provider status for classification and diagnostics, while
-	// exposing a JSON-compatible response if this is the final failure.
 	result.contentType = "application/json"
 	result.errorType = "upstream_response_failed"
 	result.errorMessage = failure.Error()

--- a/server/internal/gateway/handler_chat.go
+++ b/server/internal/gateway/handler_chat.go
@@ -89,7 +89,8 @@ func (h Handler) serveEndpoint(
 		return
 	}
 
-	ctx := r.Context()
+	ctx := withReasoningEffort(r.Context(), reasoningEffortFromPayload(request.Payload))
+	r = r.WithContext(ctx)
 	originalModel := request.RequestedModel
 	mappingRule, hasMapping := h.resolveModelMapping(apiKey, request.RequestedModel)
 	softFallbackTarget := ""

--- a/server/internal/gateway/recording_metadata.go
+++ b/server/internal/gateway/recording_metadata.go
@@ -12,6 +12,7 @@ import (
 
 type modelMappingContextKey struct{}
 type retryAfterContextKey struct{}
+type reasoningEffortContextKey struct{}
 
 type modelMappingInfo struct {
 	OriginalModel string
@@ -42,6 +43,45 @@ func withRetryAfter(ctx context.Context, seconds int64) context.Context {
 func retryAfterFromContext(ctx context.Context) (int64, bool) {
 	v, ok := ctx.Value(retryAfterContextKey{}).(int64)
 	return v, ok && v > 0
+}
+
+// withReasoningEffort carries only the explicit scalar effort requested by the
+// downstream client. The request payload itself is intentionally not retained
+// in the recording context.
+func withReasoningEffort(ctx context.Context, effort string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	effort = strings.TrimSpace(effort)
+	if effort == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, reasoningEffortContextKey{}, effort)
+}
+
+func reasoningEffortFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	effort, ok := ctx.Value(reasoningEffortContextKey{}).(string)
+	effort = strings.TrimSpace(effort)
+	return effort, ok && effort != ""
+}
+
+// reasoningEffortFromPayload extracts only the supported scalar request
+// fields. Non-string, blank, and all unrelated payload values are ignored.
+func reasoningEffortFromPayload(payload map[string]any) string {
+	if reasoning, ok := payload["reasoning"].(map[string]any); ok {
+		if effort, ok := reasoning["effort"].(string); ok {
+			if effort = strings.TrimSpace(effort); effort != "" {
+				return effort
+			}
+		}
+	}
+	if effort, ok := payload["reasoning_effort"].(string); ok {
+		return strings.TrimSpace(effort)
+	}
+	return ""
 }
 
 const (
@@ -154,6 +194,9 @@ func attemptMetadata(
 		"billing_mode":       emptyToNil(result.billingMode),
 		"pricing":            pricingMetadata(result.pricing),
 		"cost_calculation":   costCalculation,
+	}
+	if effort, ok := reasoningEffortFromContext(ctx); ok {
+		meta["reasoning_effort"] = effort
 	}
 	if result.diagnostic {
 		meta["test"] = true
@@ -281,6 +324,9 @@ func requestFailureMetadata(
 	}
 	if rateLimit, ok := rateLimitMetadataFromContext(ctx); ok {
 		meta["rate_limit"] = rateLimit
+	}
+	if effort, ok := reasoningEffortFromContext(ctx); ok {
+		meta["reasoning_effort"] = effort
 	}
 	applyResponsesWebSocketMetadata(meta, ctx)
 	return meta

--- a/server/internal/gateway/recording_metadata.go
+++ b/server/internal/gateway/recording_metadata.go
@@ -45,9 +45,6 @@ func retryAfterFromContext(ctx context.Context) (int64, bool) {
 	return v, ok && v > 0
 }
 
-// withReasoningEffort carries only the explicit scalar effort requested by the
-// downstream client. The request payload itself is intentionally not retained
-// in the recording context.
 func withReasoningEffort(ctx context.Context, effort string) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -68,8 +65,6 @@ func reasoningEffortFromContext(ctx context.Context) (string, bool) {
 	return effort, ok && effort != ""
 }
 
-// reasoningEffortFromPayload extracts only the supported scalar request
-// fields. Non-string, blank, and all unrelated payload values are ignored.
 func reasoningEffortFromPayload(payload map[string]any) string {
 	if reasoning, ok := payload["reasoning"].(map[string]any); ok {
 		if effort, ok := reasoning["effort"].(string); ok {

--- a/server/internal/gateway/recording_metadata_test.go
+++ b/server/internal/gateway/recording_metadata_test.go
@@ -203,15 +203,16 @@ func TestAttemptMetadataIncludesFastBillingCalculation(t *testing.T) {
 			Model: routeengine.CandidateModel{SiteModelID: uuid.MustParse("44444444-4444-4444-4444-444444444444"), UpstreamName: "gpt-5.5-codex"},
 		},
 		gatewayAttemptResult{
-			promptTokens:       100,
-			completionTokens:   50,
-			cachedPromptTokens: 20,
-			estimatedCost:      &finalCost,
-			baseEstimatedCost:  &baseCost,
-			serviceTier:        "fast",
-			billingMode:        "fast",
-			costMultiplier:     2.5,
-			multiplierReason:   "codex_fast_mode",
+			promptTokens:             100,
+			completionTokens:         50,
+			cachedPromptTokens:       20,
+			estimatedCost:            &finalCost,
+			baseEstimatedCost:        &baseCost,
+			serviceTier:              "fast",
+			billingMode:              "fast",
+			costMultiplier:           2.5,
+			credentialCostMultiplier: 1.2,
+			multiplierReason:         "codex_fast_mode",
 			pricing: selectedPricing{
 				Currency:    "USD",
 				InputValue:  &inputValue,
@@ -244,6 +245,12 @@ func TestAttemptMetadataIncludesFastBillingCalculation(t *testing.T) {
 	}
 	if got := calculation["cost_multiplier_reason"]; got != "codex_fast_mode" {
 		t.Fatalf("cost_multiplier_reason = %#v, want codex_fast_mode", got)
+	}
+	if got := calculation["credential_upstream_cost_multiplier"]; got != 1.2 {
+		t.Fatalf("credential_upstream_cost_multiplier = %#v, want 1.2", got)
+	}
+	if got := calculation["service_tier_multiplier"]; got != 2.5 {
+		t.Fatalf("service_tier_multiplier = %#v, want 2.5", got)
 	}
 }
 
@@ -511,5 +518,72 @@ func TestRequestFailureMetadataDefaultsEndpointAndIncludesContextMetadata(t *tes
 	rateLimit, ok := metadata["rate_limit"].(map[string]any)
 	if !ok || rateLimit["scope"] != "global" || rateLimit["limit_type"] != "tpm" {
 		t.Fatalf("unexpected rate limit metadata: %#v", metadata["rate_limit"])
+	}
+}
+
+func TestReasoningEffortFromPayloadAcceptsOnlyExplicitScalar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    string
+	}{
+		{name: "nested effort", payload: map[string]any{"reasoning": map[string]any{"effort": " high "}}, want: "high"},
+		{name: "scalar fallback", payload: map[string]any{"reasoning_effort": "medium"}, want: "medium"},
+		{name: "nested wins", payload: map[string]any{"reasoning": map[string]any{"effort": "high"}, "reasoning_effort": "low"}, want: "high"},
+		{name: "blank nested falls back", payload: map[string]any{"reasoning": map[string]any{"effort": "  "}, "reasoning_effort": "low"}, want: "low"},
+		{name: "invalid nested and scalar", payload: map[string]any{"reasoning": map[string]any{"effort": 3}, "reasoning_effort": true}},
+		{name: "missing", payload: map[string]any{"model": "gpt-5"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := reasoningEffortFromPayload(tt.payload); got != tt.want {
+				t.Fatalf("reasoning effort = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAttemptMetadataPersistsReasoningEffortWithoutPayload(t *testing.T) {
+	t.Parallel()
+
+	ctx := withReasoningEffort(context.Background(), " high ")
+	metadata := attemptMetadata(
+		ctx,
+		"req-attempt",
+		"req-parent",
+		uuid.Nil,
+		uuid.Nil,
+		routeengine.Candidate{},
+		gatewayAttemptResult{},
+	)
+	if got := metadata["reasoning_effort"]; got != "high" {
+		t.Fatalf("reasoning_effort metadata = %#v, want high", got)
+	}
+	if _, ok := metadata["request_payload"]; ok {
+		t.Fatalf("request payload must not be recorded: %#v", metadata)
+	}
+}
+
+func TestRequestFailureMetadataPersistsReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	metadata := requestFailureMetadata(
+		withReasoningEffort(context.Background(), "medium"),
+		"req-parent",
+		uuid.Nil,
+		400,
+		"bad_request",
+		"bad request",
+		"gpt-5",
+		false,
+		"validate",
+		gatewayEndpointChatCompletions,
+	)
+	if got := metadata["reasoning_effort"]; got != "medium" {
+		t.Fatalf("reasoning_effort metadata = %#v, want medium", got)
 	}
 }

--- a/server/internal/gateway/semantic_failure.go
+++ b/server/internal/gateway/semantic_failure.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-// upstreamSemanticFailure represents a provider-declared failure carried in a
-// successful HTTP response.
 type upstreamSemanticFailure struct {
 	Code    string
 	Message string

--- a/server/internal/gateway/stream_runtime.go
+++ b/server/internal/gateway/stream_runtime.go
@@ -103,9 +103,6 @@ func proxyUpstreamStreamWithInspector(
 			return capture, headersWritten, nil
 		}
 		if capture.endReason == "" && (capture.streamCompleted || capture.sawDone) {
-			// Providers may close the connection with a transport error immediately
-			// after sending the terminal event. The downstream response is already
-			// complete, so the late read error must not turn it into a failed attempt.
 			capture.streamCompleted = true
 			capture.endReason = "done"
 			return capture, headersWritten, nil

--- a/server/internal/gateway/stream_runtime_test.go
+++ b/server/internal/gateway/stream_runtime_test.go
@@ -170,8 +170,6 @@ func TestProxyUpstreamStreamDoesNotStartResponseOnEmptyBody(t *testing.T) {
 func TestProxyResponsesStreamPassthroughPreservesEndReasonOnReadError(t *testing.T) {
 	t.Parallel()
 
-	// response.failed sets endReason="upstream_stream_error"; a subsequent
-	// transport error must not overwrite it to "upstream_stream_read_failed".
 	data := "data: " + `{"type":"response.failed","response":{"status":"failed","error":{"code":"rate_limit_exceeded","message":"limit hit"}}}` + "\n\n"
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -188,8 +186,6 @@ func TestProxyResponsesStreamPassthroughPreservesEndReasonOnReadError(t *testing
 func TestProxyUpstreamStreamPreservesEndReasonOnReadError(t *testing.T) {
 	t.Parallel()
 
-	// Anthropic inspector sets endReason="upstream_stream_error" on an error event;
-	// a subsequent transport error must not overwrite it to "upstream_stream_read_failed".
 	data := "data: " + `{"type":"error","error":{"message":"upstream returned an error"}}` + "\n\n"
 	resp := &http.Response{
 		StatusCode: http.StatusOK,

--- a/web/src/features/requests/api/requests.ts
+++ b/web/src/features/requests/api/requests.ts
@@ -6,6 +6,11 @@ type RequestLogAPIKey = {
   masked_key?: string | null
 }
 
+export type RequestLogCredential = {
+  id?: string | null
+  name?: string | null
+}
+
 type RequestLogSite = {
   id?: string | null
   name?: string | null
@@ -82,6 +87,8 @@ type RequestLogCostCalculation = {
   cache_write_1h_cost?: number | null
   base_estimated_cost?: number | null
   cost_multiplier?: number | null
+  credential_upstream_cost_multiplier?: number | null
+  service_tier_multiplier?: number | null
   cost_multiplier_reason?: string | null
   estimated_cost?: number | null
   billing_type?: string | null
@@ -133,11 +140,14 @@ export type RequestLogItem = {
   success: boolean
   error_type?: string | null
   latency_ms?: number | null
+  first_byte_latency_ms?: number | null
+  reasoning_effort?: string | null
   upstream_latency_ms?: number | null
   request_tokens?: number | null
   response_tokens?: number | null
   pricing_group?: string | null
   api_key: RequestLogAPIKey
+  credential?: RequestLogCredential | null
   site: RequestLogSite
   model: RequestLogModel
   usage: RequestLogUsage

--- a/web/src/features/requests/components/request-detail-row.tsx
+++ b/web/src/features/requests/components/request-detail-row.tsx
@@ -87,8 +87,8 @@ export function RequestDetailContent({ item }: { item: RequestLogItem }) {
   return (
     <div className="space-y-2.5 text-left text-sm">
       <DetailRow label={t('detail.requestId')}>
-        <Badge variant="neutral" className="w-fit max-w-full justify-start rounded-md px-2 py-0.5 text-left text-xs tracking-normal">
-          <span className="min-w-0 break-all">{detail.request_id}</span>
+        <Badge variant="neutral" className="w-full max-w-full justify-start overflow-x-auto rounded-md px-2 py-0.5 text-left text-xs tracking-normal sm:w-fit">
+          <span className="block w-max min-w-full whitespace-nowrap">{detail.request_id}</span>
         </Badge>
       </DetailRow>
 

--- a/web/src/features/requests/components/request-detail-row.tsx
+++ b/web/src/features/requests/components/request-detail-row.tsx
@@ -17,6 +17,9 @@ import {
   requestCacheRatio,
   requestCacheTokens,
   requestCacheWriteTokens,
+  formatCostMultiplier,
+  requestCredentialMultiplier,
+  requestCredentialName,
   requestCostFormula,
   requestDownstreamTransportLabel,
   requestGroupName,
@@ -104,6 +107,7 @@ export function RequestDetailContent({ item }: { item: RequestLogItem }) {
         </InlineItem>
         <InlineItem label={t('detail.statusCode')} value={String(detail.upstream_status_code ?? detail.status_code ?? '-')} tone="badge" />
         <InlineItem label={t('detail.site')} value={detail.site.name} tone="badge" />
+        <InlineItem label={t('detail.upstreamCredential')} value={requestCredentialName(detail)} tone="badge" />
         <InlineItem label={t('detail.group')} value={groupName} tone="badge" />
       </DetailRow>
 
@@ -124,6 +128,7 @@ export function RequestDetailContent({ item }: { item: RequestLogItem }) {
             <InlineItem label={t('detail.outputPrice')} value={formatPrice(detail.pricing?.output_value, detail.pricing?.currency)} tone="badge" />
             <InlineItem label={t('detail.cachePrice')} value={formatPrice(cachePrice, detail.pricing?.currency)} tone="badge" />
             <InlineItem label={t('detail.perRequestPrice')} value={formatPerRequestPrice(detail.pricing?.per_request_value, detail.pricing?.currency, t)} tone="badge" />
+            <InlineItem label={t('detail.credentialMultiplier')} value={formatCostMultiplier(requestCredentialMultiplier(detail))} tone="badge" />
             {fastBilling ? (
               <InlineItem label={t('detail.mode')}>
                 <Badge variant="secondary" className="rounded-md px-2 py-0.5 text-xs tracking-normal">

--- a/web/src/features/requests/components/request-model-mapping.tsx
+++ b/web/src/features/requests/components/request-model-mapping.tsx
@@ -34,9 +34,9 @@ export function RequestModelMapping({
   }
 
   return (
-    <span className={cn('group/model-map relative inline-flex min-w-0 flex-col', inline ? 'max-w-full' : 'w-full', className)}>
-      <span className="inline-flex min-w-0 items-center gap-1.5">
-        <span className="min-w-0 truncate">{requestedModel}</span>
+    <span className={cn('group/model-map relative inline-flex min-w-0', inline ? 'max-w-full flex-row items-center gap-1.5 overflow-x-auto' : 'w-full flex-col', className)}>
+      <span className={cn('inline-flex min-w-0 items-center gap-1.5', inline && 'shrink-0')}>
+        <span className={cn('min-w-0', inline ? 'whitespace-nowrap' : 'truncate')}>{requestedModel}</span>
         <ArrowRightLeft className="h-3.5 w-3.5 shrink-0 text-[hsl(var(--accent))]" />
         {isSoftFallback ? (
           <span className="shrink-0 rounded border border-amber-500/40 bg-amber-500/10 px-1 text-[10px] leading-4 text-amber-500">
@@ -44,7 +44,7 @@ export function RequestModelMapping({
           </span>
         ) : null}
       </span>
-      <span className={cn('text-muted-soft min-w-0 truncate text-xs', secondaryClassName)}>
+      <span className={cn('text-muted-soft min-w-0 text-xs', inline ? 'shrink-0 whitespace-nowrap' : 'truncate', secondaryClassName)}>
         {upstreamModel}
       </span>
       <span className="pointer-events-none absolute left-0 top-full z-50 mt-2 hidden min-w-64 max-w-96 rounded-md border border-[hsl(var(--glass-border))] bg-[hsl(var(--surface-panel))] px-3 py-2 text-xs shadow-lg group-hover/model-map:block">

--- a/web/src/features/requests/components/request-timing.tsx
+++ b/web/src/features/requests/components/request-timing.tsx
@@ -23,23 +23,19 @@ export function RequestTiming({ item, className }: RequestTimingProps) {
   const totalTone = requestTotalLatencyTone(item.latency_ms)
 
   return (
-    <div className={cn('relative min-w-0 space-y-1 border-l-2 border-transparent pl-3', className)}>
-      <span aria-hidden="true" className="absolute inset-y-0 left-0 flex w-1.5 flex-col overflow-hidden rounded-full">
-        <span className={cn('flex-1', timingToneClasses[firstByteTone].bar)} />
-        <span className={cn('flex-1', timingToneClasses[totalTone].bar)} />
-      </span>
+    <div className={cn('min-w-0 space-y-0 lg:space-y-1', className)}>
       <TimingLine label={t('table.headers.firstByte')} value={firstByteLatency} tone={firstByteTone} />
       <TimingLine label={t('table.headers.totalDuration')} value={totalLatency} tone={totalTone} />
     </div>
   )
 }
 
-const timingToneClasses: Record<RequestLatencyTone, { bar: string; value: string }> = {
-  healthy: { bar: 'bg-emerald-500', value: 'text-emerald-500' },
-  slow: { bar: 'bg-amber-500', value: 'text-amber-500' },
-  'very-slow': { bar: 'bg-orange-500', value: 'text-orange-500' },
-  critical: { bar: 'bg-red-500', value: 'text-red-500' },
-  muted: { bar: 'bg-[hsl(var(--text-muted-soft))]', value: 'text-muted-soft' },
+const timingToneClasses: Record<RequestLatencyTone, { dot: string; value: string }> = {
+  healthy: { dot: 'bg-emerald-500', value: 'text-emerald-500' },
+  slow: { dot: 'bg-amber-500', value: 'text-amber-500' },
+  'very-slow': { dot: 'bg-orange-500', value: 'text-orange-500' },
+  critical: { dot: 'bg-red-500', value: 'text-red-500' },
+  muted: { dot: 'bg-[hsl(var(--text-muted-soft))]', value: 'text-muted-soft' },
 }
 
 function TimingLine({
@@ -52,9 +48,10 @@ function TimingLine({
   tone: RequestLatencyTone
 }) {
   return (
-    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5 text-[10px] leading-4">
+    <div className="grid min-w-0 grid-cols-[0.375rem_minmax(0,1fr)_auto] items-center gap-x-1 text-xs leading-4 lg:gap-x-1.5 lg:leading-5">
+      <span aria-hidden="true" className={cn('h-1.5 w-1.5 shrink-0 rounded-full', timingToneClasses[tone].dot)} />
       <span className="truncate text-muted-soft" title={label}>{label}</span>
-      <span className={cn('shrink-0 whitespace-nowrap font-semibold tabular-nums', timingToneClasses[tone].value)}>
+      <span className={cn('shrink-0 whitespace-nowrap font-medium tabular-nums lg:text-sm lg:font-semibold', timingToneClasses[tone].value)}>
         {value}
       </span>
     </div>

--- a/web/src/features/requests/components/request-timing.tsx
+++ b/web/src/features/requests/components/request-timing.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from 'react-i18next'
+import type { RequestLogItem } from '@/features/requests/api/requests'
+import {
+  formatLatency,
+  requestFirstByteLatency,
+  requestFirstByteLatencyTone,
+  requestTotalLatencyTone,
+  type RequestLatencyTone,
+} from '@/features/requests/lib/request-utils'
+import { cn } from '@/lib/utils'
+
+type RequestTimingProps = {
+  item: RequestLogItem
+  className?: string
+}
+
+export function RequestTiming({ item, className }: RequestTimingProps) {
+  const { t } = useTranslation('requests')
+  const firstByteLatencyValue = requestFirstByteLatency(item)
+  const firstByteLatency = formatLatency(firstByteLatencyValue)
+  const totalLatency = formatLatency(item.latency_ms)
+  const firstByteTone = requestFirstByteLatencyTone(firstByteLatencyValue)
+  const totalTone = requestTotalLatencyTone(item.latency_ms)
+
+  return (
+    <div className={cn('relative min-w-0 space-y-1 border-l-2 border-transparent pl-3', className)}>
+      <span aria-hidden="true" className="absolute inset-y-0 left-0 flex w-1.5 flex-col overflow-hidden rounded-full">
+        <span className={cn('flex-1', timingToneClasses[firstByteTone].bar)} />
+        <span className={cn('flex-1', timingToneClasses[totalTone].bar)} />
+      </span>
+      <TimingLine label={t('table.headers.firstByte')} value={firstByteLatency} tone={firstByteTone} />
+      <TimingLine label={t('table.headers.totalDuration')} value={totalLatency} tone={totalTone} />
+    </div>
+  )
+}
+
+const timingToneClasses: Record<RequestLatencyTone, { bar: string; value: string }> = {
+  healthy: { bar: 'bg-emerald-500', value: 'text-emerald-500' },
+  slow: { bar: 'bg-amber-500', value: 'text-amber-500' },
+  'very-slow': { bar: 'bg-orange-500', value: 'text-orange-500' },
+  critical: { bar: 'bg-red-500', value: 'text-red-500' },
+  muted: { bar: 'bg-[hsl(var(--text-muted-soft))]', value: 'text-muted-soft' },
+}
+
+function TimingLine({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string
+  tone: RequestLatencyTone
+}) {
+  return (
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5 text-[10px] leading-4">
+      <span className="truncate text-muted-soft" title={label}>{label}</span>
+      <span className={cn('shrink-0 whitespace-nowrap font-semibold tabular-nums', timingToneClasses[tone].value)}>
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/web/src/features/requests/components/requests-mobile-list.tsx
+++ b/web/src/features/requests/components/requests-mobile-list.tsx
@@ -7,12 +7,13 @@ import { Card } from '@/components/ui/card'
 import type { RequestLogItem } from '@/features/requests/api/requests'
 import { RequestDetailContent } from '@/features/requests/components/request-detail-row'
 import { RequestModelMapping } from '@/features/requests/components/request-model-mapping'
+import { RequestTiming } from '@/features/requests/components/request-timing'
 import {
   formatCurrency,
   formatDateTime,
   formatInteger,
-  formatLatency,
   formatTokenCompact,
+  requestReasoningEffort,
   requestCacheTokens,
   requestCacheWriteTokens,
   requestResponseModeLabel,
@@ -52,6 +53,7 @@ export function RequestsMobileList({
         const hasCacheRead = typeof cacheTokens === 'number' && cacheTokens > 0
         const hasCacheWrite = typeof cacheWriteTokens === 'number' && cacheWriteTokens > 0
         const statusCode = item.upstream_status_code ?? item.status_code ?? '-'
+        const reasoningEffort = requestReasoningEffort(item)
 
         return (
           <Card key={item.id} className="overflow-hidden rounded-lg p-0">
@@ -64,6 +66,9 @@ export function RequestsMobileList({
                 <div className="flex min-w-0 items-start justify-between gap-3">
                   <div className="min-w-0 space-y-1">
                     <RequestModelMapping item={item} className="text-sm font-semibold text-foreground" />
+                    <div className="min-w-0 text-xs text-foreground">
+                      <span className="block truncate" title={reasoningEffort ?? '-'}>{reasoningEffort ?? '-'}</span>
+                    </div>
                     <div className="text-muted-soft text-xs">
                       {formatDateTime(item.created_at, i18n.language)}
                     </div>
@@ -84,7 +89,7 @@ export function RequestsMobileList({
                     label={t('table.headers.apiKey')}
                     value={item.is_test ? t('table.test') : item.api_key.name ?? '-'}
                   />
-                  <MobileField label={t('table.headers.latency')} value={formatLatency(item.latency_ms)} />
+                  <RequestTiming item={item} className="col-span-2" />
                   <MobileField label={t('table.headers.cost')} value={formatCurrency(item.usage.estimated_cost, item.usage.currency)} />
                 </div>
 

--- a/web/src/features/requests/components/requests-mobile-list.tsx
+++ b/web/src/features/requests/components/requests-mobile-list.tsx
@@ -65,13 +65,17 @@ export function RequestsMobileList({
               <div className="min-w-0 space-y-3">
                 <div className="flex min-w-0 items-start justify-between gap-3">
                   <div className="min-w-0 space-y-1">
-                    <RequestModelMapping item={item} className="text-sm font-semibold text-foreground" />
-                    <div className="min-w-0 text-xs text-foreground">
-                      <span className="block truncate" title={reasoningEffort ?? '-'}>{reasoningEffort ?? '-'}</span>
-                    </div>
-                    <div className="text-muted-soft text-xs">
-                      {formatDateTime(item.created_at, i18n.language)}
-                    </div>
+                    <RequestModelMapping item={item} inline className="text-sm font-semibold text-foreground" />
+                    {reasoningEffort ? (
+                      <div className="flex min-w-0 items-center gap-2 text-xs">
+                        <span className="truncate text-foreground" title={reasoningEffort}>{reasoningEffort}</span>
+                        <span className="shrink-0 text-muted-soft">{formatDateTime(item.created_at, i18n.language)}</span>
+                      </div>
+                    ) : (
+                      <div className="text-muted-soft text-xs">
+                        {formatDateTime(item.created_at, i18n.language)}
+                      </div>
+                    )}
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     <StatusBadge status={item.success ? 'healthy' : 'error'}>
@@ -89,7 +93,7 @@ export function RequestsMobileList({
                     label={t('table.headers.apiKey')}
                     value={item.is_test ? t('table.test') : item.api_key.name ?? '-'}
                   />
-                  <RequestTiming item={item} className="col-span-2" />
+                  <RequestTiming item={item} className="pr-2" />
                   <MobileField label={t('table.headers.cost')} value={formatCurrency(item.usage.estimated_cost, item.usage.currency)} />
                 </div>
 

--- a/web/src/features/requests/components/requests-table.tsx
+++ b/web/src/features/requests/components/requests-table.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type RefObject } from 'react'
+import { Fragment, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type RefObject, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { EmptyState } from '@/components/common/empty-state'
@@ -8,12 +8,22 @@ import { cn } from '@/lib/utils'
 import type { RequestLogItem } from '@/features/requests/api/requests'
 import { RequestDetailRow } from '@/features/requests/components/request-detail-row'
 import { RequestModelMapping } from '@/features/requests/components/request-model-mapping'
+import { RequestTiming } from '@/features/requests/components/request-timing'
+import {
+  readRequestsTableColumnWidthsPreference,
+  writeRequestsTableColumnWidthsPreference,
+} from '@/features/requests/lib/request-preferences'
+import {
+  REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS,
+  resizeRequestTableColumnBoundary,
+  type RequestTableColumnWidths,
+} from '@/features/requests/lib/request-table-columns'
 import {
   formatCurrency,
   formatDateTime,
   formatInteger,
-  formatLatency,
   formatTokenCompact,
+  requestReasoningEffort,
   requestCacheTokens,
   requestCacheWriteTokens,
   requestResponseModeLabel,
@@ -28,6 +38,27 @@ type RequestsTableProps = {
   className?: string
 }
 
+const requestTableHeaders = [
+  { id: 'expand', label: 'table.headers.expand', className: 'px-4 py-3 font-medium' },
+  { id: 'time', label: 'table.headers.time', className: 'px-4 py-3 font-medium' },
+  { id: 'model', label: 'table.headers.model', className: 'px-4 py-3 font-medium' },
+  { id: 'api-key', label: 'table.headers.apiKey', className: 'px-4 py-3 font-medium' },
+  { id: 'site', label: 'table.headers.site', className: 'px-4 py-3 font-medium' },
+  { id: 'status', label: 'table.headers.status', className: 'px-1 py-3 font-medium text-center' },
+  { id: 'latency', label: 'table.headers.latency', className: 'px-4 py-3 font-medium' },
+  { id: 'input', label: 'table.headers.input', className: 'px-4 py-3 font-medium text-right' },
+  { id: 'output', label: 'table.headers.output', className: 'px-4 py-3 font-medium text-right' },
+  { id: 'cost', label: 'table.headers.cost', className: 'px-4 py-3 font-medium text-right' },
+] as const
+
+type ColumnResizeState = {
+  boundaryIndex: number
+  pointerID: number
+  startX: number
+  tableWidth: number
+  widths: RequestTableColumnWidths
+}
+
 export function RequestsTable({
   items,
   expandedId,
@@ -36,6 +67,73 @@ export function RequestsTable({
   className,
 }: RequestsTableProps) {
   const { t, i18n } = useTranslation('requests')
+  const [columnWidths, setColumnWidths] = useState<RequestTableColumnWidths>(() => readRequestsTableColumnWidthsPreference())
+  const columnWidthsRef = useRef(columnWidths)
+  const resizeStateRef = useRef<ColumnResizeState | null>(null)
+  const tableRef = useRef<HTMLTableElement>(null)
+
+  function updateColumnWidths(widths: RequestTableColumnWidths) {
+    columnWidthsRef.current = widths
+    setColumnWidths(widths)
+  }
+
+  function resizeColumnBoundary(boundaryIndex: number, deltaPercent: number) {
+    const widths = resizeRequestTableColumnBoundary(columnWidthsRef.current, boundaryIndex, deltaPercent)
+    updateColumnWidths(widths)
+    return widths
+  }
+
+  function handleColumnResizerPointerDown(boundaryIndex: number, event: ReactPointerEvent<HTMLSpanElement>) {
+    if (event.button !== 0) return
+
+    const tableWidth = tableRef.current?.getBoundingClientRect().width ?? 0
+    if (tableWidth <= 0) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    resizeStateRef.current = {
+      boundaryIndex,
+      pointerID: event.pointerId,
+      startX: event.clientX,
+      tableWidth,
+      widths: columnWidthsRef.current,
+    }
+  }
+
+  function handleColumnResizerPointerMove(event: ReactPointerEvent<HTMLSpanElement>) {
+    const resizeState = resizeStateRef.current
+    if (!resizeState || resizeState.pointerID !== event.pointerId) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    const deltaPercent = ((event.clientX - resizeState.startX) / resizeState.tableWidth) * 100
+    const widths = resizeRequestTableColumnBoundary(resizeState.widths, resizeState.boundaryIndex, deltaPercent)
+    updateColumnWidths(widths)
+  }
+
+  function handleColumnResizerPointerEnd(event: ReactPointerEvent<HTMLSpanElement>) {
+    const resizeState = resizeStateRef.current
+    if (!resizeState || resizeState.pointerID !== event.pointerId) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    resizeStateRef.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    writeRequestsTableColumnWidthsPreference(columnWidthsRef.current)
+  }
+
+  function handleColumnResizerKeyDown(boundaryIndex: number, event: KeyboardEvent<HTMLSpanElement>) {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+    event.preventDefault()
+    event.stopPropagation()
+    const direction = event.key === 'ArrowLeft' ? -1 : 1
+    const widths = resizeColumnBoundary(boundaryIndex, direction * (event.shiftKey ? 5 : 1))
+    writeRequestsTableColumnWidthsPreference(widths)
+  }
 
   if (!items.length) {
     return (
@@ -50,19 +148,46 @@ export function RequestsTable({
       ref={scrollContainerRef}
       className={cn('rounded-lg', className)}
     >
-      <table className="w-full table-fixed border-collapse text-left">
+      <table ref={tableRef} className="w-full table-fixed border-collapse text-left">
+        <colgroup>
+          {columnWidths.map((width, index) => (
+            <col key={requestTableHeaders[index].id} style={{ width: `${width}%` }} />
+          ))}
+        </colgroup>
         <thead className="sticky -top-6 z-10 bg-[hsl(var(--surface-base))] shadow-[0_1px_0_hsl(var(--glass-divider))] lg:-top-8">
           <tr className="text-faint text-xs uppercase tracking-[0.16em]">
-            <th className="w-[4%] px-4 py-3 font-medium" />
-            <th className="w-[12%] px-4 py-3 font-medium">{t('table.headers.time')}</th>
-            <th className="w-[15%] px-4 py-3 font-medium">{t('table.headers.model')}</th>
-            <th className="w-[12%] px-4 py-3 font-medium">{t('table.headers.apiKey')}</th>
-            <th className="w-[10%] px-4 py-3 font-medium">{t('table.headers.site')}</th>
-            <th className="w-[9%] px-4 py-3 font-medium text-center">{t('table.headers.status')}</th>
-            <th className="w-[10%] px-4 py-3 font-medium text-right">{t('table.headers.latency')}</th>
-            <th className="w-[10%] px-4 py-3 font-medium text-right">{t('table.headers.input')}</th>
-            <th className="w-[8%] px-4 py-3 font-medium text-right">{t('table.headers.output')}</th>
-            <th className="w-[10%] px-4 py-3 font-medium text-right">{t('table.headers.cost')}</th>
+            {requestTableHeaders.map((header, index) => {
+              const boundaryIndex = index - 1
+              const canResize = boundaryIndex >= 0
+              const maximumWidth = canResize
+                ? 100 - REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS.reduce((total, minimum, minimumIndex) => minimumIndex === boundaryIndex ? total : total + minimum, 0)
+                : 0
+              const headerLabel = t(header.label)
+              const resizerColumnLabel = canResize ? t(requestTableHeaders[boundaryIndex].label) : ''
+              return (
+                <th key={header.id} className={cn('relative', header.id === 'status' && 'overflow-hidden', header.className)}>
+                  {header.id === 'expand' ? <span className="sr-only">{headerLabel}</span> : headerLabel}
+                  {canResize ? (
+                    <span
+                      role="separator"
+                      aria-orientation="vertical"
+                      aria-label={t('table.resizeColumn', { column: resizerColumnLabel })}
+                      aria-valuenow={columnWidths[boundaryIndex]}
+                      aria-valuemin={REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[boundaryIndex]}
+                      aria-valuemax={maximumWidth}
+                      tabIndex={0}
+                      className="absolute -left-2 top-0 z-20 h-full w-4 cursor-col-resize touch-none select-none outline-none after:absolute after:inset-y-2 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-[hsl(var(--glass-divider))] after:opacity-50 hover:after:bg-primary hover:after:opacity-100 focus-visible:after:bg-primary focus-visible:after:opacity-100"
+                      style={{ cursor: 'col-resize' }}
+                      onPointerDown={(event) => handleColumnResizerPointerDown(boundaryIndex, event)}
+                      onPointerMove={handleColumnResizerPointerMove}
+                      onPointerUp={handleColumnResizerPointerEnd}
+                      onPointerCancel={handleColumnResizerPointerEnd}
+                      onKeyDown={(event) => handleColumnResizerKeyDown(boundaryIndex, event)}
+                    />
+                  ) : null}
+                </th>
+              )
+            })}
           </tr>
         </thead>
         <tbody>
@@ -70,6 +195,7 @@ export function RequestsTable({
             const expanded = expandedId === item.id
             const cacheTokens = requestCacheTokens(item)
             const cacheWriteTokens = requestCacheWriteTokens(item)
+            const reasoningEffort = requestReasoningEffort(item)
             const hasCacheRead = typeof cacheTokens === 'number' && cacheTokens > 0
             const hasCacheWrite = typeof cacheWriteTokens === 'number' && cacheWriteTokens > 0
 
@@ -90,8 +216,11 @@ export function RequestsTable({
                         {formatDateTime(item.created_at, i18n.language)}
                       </td>
                       <td className="px-4 py-4 align-middle">
-                        <div className="min-w-0">
+                        <div className="min-w-0 space-y-1">
                           <RequestModelMapping item={item} className="text-sm font-medium text-foreground" />
+                          <div className="min-w-0 text-xs text-foreground">
+                            <span className="block truncate" title={reasoningEffort ?? '-'}>{reasoningEffort ?? '-'}</span>
+                          </div>
                         </div>
                       </td>
                       <td className="px-4 py-4 align-middle">
@@ -112,26 +241,24 @@ export function RequestsTable({
                           {item.site.name ?? '-'}
                         </div>
                       </td>
-                      <td className="px-4 py-4 align-middle text-center">
-                        <div className="flex flex-col items-center gap-2">
-                          <StatusBadge status={item.success ? 'healthy' : 'error'}>
+                      <td className="overflow-hidden px-1 py-4 align-middle text-center">
+                        <div className="flex items-center justify-center gap-1 whitespace-nowrap">
+                          <StatusBadge status={item.success ? 'healthy' : 'error'} className="shrink-0 px-1.5 py-0.5 text-[10px] leading-4">
                             {item.success ? t('table.success') : t('table.failure')}
                           </StatusBadge>
-                          <span className="text-muted-soft text-xs">
+                          <Badge
+                            variant={requestResponseModeVariant(item)}
+                            className="shrink-0 px-1.5 py-0.5 text-[10px] font-medium tracking-wide"
+                          >
+                            {requestResponseModeLabel(item, t)}
+                          </Badge>
+                          <span className="shrink-0 text-[10px] text-muted-soft">
                             {item.upstream_status_code ?? item.status_code ?? '-'}
                           </span>
                         </div>
                       </td>
-                      <td className="px-4 py-4 align-middle text-right text-sm text-foreground">
-                        <div className="flex flex-col items-end gap-2">
-                          <Badge
-                            variant={requestResponseModeVariant(item)}
-                            className="px-2.5 py-1 text-xs font-medium tracking-wide"
-                          >
-                            {requestResponseModeLabel(item, t)}
-                          </Badge>
-                          <span>{formatLatency(item.latency_ms)}</span>
-                        </div>
+                      <td className="px-4 py-4 align-middle">
+                        <RequestTiming item={item} />
                       </td>
                       <td className="px-4 py-4 align-middle text-right text-sm text-foreground">
                         <div>{formatInteger(item.usage.prompt_tokens)}</div>

--- a/web/src/features/requests/components/requests-table.tsx
+++ b/web/src/features/requests/components/requests-table.tsx
@@ -218,9 +218,11 @@ export function RequestsTable({
                       <td className="px-4 py-4 align-middle">
                         <div className="min-w-0 space-y-1">
                           <RequestModelMapping item={item} className="text-sm font-medium text-foreground" />
-                          <div className="min-w-0 text-xs text-foreground">
-                            <span className="block truncate" title={reasoningEffort ?? '-'}>{reasoningEffort ?? '-'}</span>
-                          </div>
+                          {reasoningEffort ? (
+                            <div className="min-w-0 text-xs text-foreground">
+                              <span className="block truncate" title={reasoningEffort}>{reasoningEffort}</span>
+                            </div>
+                          ) : null}
                         </div>
                       </td>
                       <td className="px-4 py-4 align-middle">
@@ -242,17 +244,19 @@ export function RequestsTable({
                         </div>
                       </td>
                       <td className="overflow-hidden px-1 py-4 align-middle text-center">
-                        <div className="flex items-center justify-center gap-1 whitespace-nowrap">
-                          <StatusBadge status={item.success ? 'healthy' : 'error'} className="shrink-0 px-1.5 py-0.5 text-[10px] leading-4">
-                            {item.success ? t('table.success') : t('table.failure')}
-                          </StatusBadge>
-                          <Badge
-                            variant={requestResponseModeVariant(item)}
-                            className="shrink-0 px-1.5 py-0.5 text-[10px] font-medium tracking-wide"
-                          >
-                            {requestResponseModeLabel(item, t)}
-                          </Badge>
-                          <span className="shrink-0 text-[10px] text-muted-soft">
+                        <div className="flex flex-col items-center gap-1 text-xs leading-4">
+                          <div className="flex items-center justify-center gap-1.5 whitespace-nowrap">
+                            <StatusBadge status={item.success ? 'healthy' : 'error'} className="shrink-0 px-2 py-0.5 text-xs leading-4">
+                              {item.success ? t('table.success') : t('table.failure')}
+                            </StatusBadge>
+                            <Badge
+                              variant={requestResponseModeVariant(item)}
+                              className="shrink-0 px-2 py-0.5 text-xs font-medium tracking-wide"
+                            >
+                              {requestResponseModeLabel(item, t)}
+                            </Badge>
+                          </div>
+                          <span className="shrink-0 text-xs text-muted-soft">
                             {item.upstream_status_code ?? item.status_code ?? '-'}
                           </span>
                         </div>

--- a/web/src/features/requests/components/requests-workspace.tsx
+++ b/web/src/features/requests/components/requests-workspace.tsx
@@ -19,6 +19,7 @@ import {
   requestFiltersToListFilters,
   type RequestFilterState,
 } from '@/features/requests/lib/types'
+import { readRequestsAutoRefreshPreference, writeRequestsAutoRefreshPreference } from '@/features/requests/lib/request-preferences'
 import { listSites, sitesQueryKeys } from '@/features/sites/api/sites'
 import { useMobileLayout } from '@/hooks/use-media-query'
 
@@ -32,7 +33,7 @@ export function RequestsWorkspace({ initialSearch = '' }: { initialSearch?: stri
   const initialSearchParams = useMemo(() => new URLSearchParams(initialSearch), [initialSearch])
   const [filters, setFilters] = useState<RequestFilterState>(() => requestFiltersFromSearchParams(initialSearchParams))
   const [expandedId, setExpandedId] = useState<string | null>(null)
-  const [autoRefresh, setAutoRefresh] = useState(false)
+  const [autoRefresh, setAutoRefresh] = useState(readRequestsAutoRefreshPreference)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
   const tableScrollRef = useRef<HTMLDivElement | null>(null)
@@ -127,6 +128,11 @@ export function RequestsWorkspace({ initialSearch = '' }: { initialSearch?: stri
     }
   }
 
+  function handleAutoRefreshChange(enabled: boolean) {
+    setAutoRefresh(enabled)
+    writeRequestsAutoRefreshPreference(enabled)
+  }
+
   if (requestsQuery.isLoading) {
     return <RequestsWorkspaceSkeleton />
   }
@@ -181,7 +187,7 @@ export function RequestsWorkspace({ initialSearch = '' }: { initialSearch?: stri
               currency={requestSummary?.currency}
               rateLimitUsage={rateLimitUsage}
               onFiltersChange={handleFiltersChange}
-              onAutoRefreshChange={setAutoRefresh}
+              onAutoRefreshChange={handleAutoRefreshChange}
               onRefresh={refreshRequests}
             />
           </div>
@@ -221,7 +227,7 @@ export function RequestsWorkspace({ initialSearch = '' }: { initialSearch?: stri
           currency={requestSummary?.currency}
           rateLimitUsage={rateLimitUsage}
           onFiltersChange={handleFiltersChange}
-          onAutoRefreshChange={setAutoRefresh}
+          onAutoRefreshChange={handleAutoRefreshChange}
           onRefresh={refreshRequests}
         />
       </div>

--- a/web/src/features/requests/lib/request-preferences.test.ts
+++ b/web/src/features/requests/lib/request-preferences.test.ts
@@ -64,8 +64,8 @@ describe('request table column width preference', () => {
 
   it('reads and writes only validated width ratios', () => {
     const widths = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
-    widths[1] = 12.5
-    widths[2] = 14.5
+    widths[1] += 1.5
+    widths[2] -= 1.5
     vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(widths))
 
     expect(readRequestsTableColumnWidthsPreference()).toEqual(widths)

--- a/web/src/features/requests/lib/request-preferences.test.ts
+++ b/web/src/features/requests/lib/request-preferences.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readRequestsAutoRefreshPreference,
+  readRequestsTableColumnWidthsPreference,
+  writeRequestsAutoRefreshPreference,
+  writeRequestsTableColumnWidthsPreference,
+} from '@/features/requests/lib/request-preferences'
+import { REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS } from '@/features/requests/lib/request-table-columns'
+
+beforeEach(() => {
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    },
+  })
+})
+
+describe('request auto-refresh preference', () => {
+  it('defaults to false and only accepts strict true', () => {
+    const getItem = vi.mocked(window.localStorage.getItem)
+    getItem.mockReturnValueOnce(null).mockReturnValueOnce('false').mockReturnValueOnce('true').mockReturnValueOnce('TRUE')
+
+    expect(readRequestsAutoRefreshPreference()).toBe(false)
+    expect(readRequestsAutoRefreshPreference()).toBe(false)
+    expect(readRequestsAutoRefreshPreference()).toBe(true)
+    expect(readRequestsAutoRefreshPreference()).toBe(false)
+  })
+
+  it('handles storage failures without throwing', () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation(() => { throw new Error('denied') })
+    expect(readRequestsAutoRefreshPreference()).toBe(false)
+
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => { throw new Error('denied') })
+    expect(() => writeRequestsAutoRefreshPreference(true)).not.toThrow()
+  })
+
+  it('writes strict boolean values', () => {
+    writeRequestsAutoRefreshPreference(true)
+    writeRequestsAutoRefreshPreference(false)
+    expect(window.localStorage.setItem).toHaveBeenNthCalledWith(1, 'xlyra:requests:auto-refresh', 'true')
+    expect(window.localStorage.setItem).toHaveBeenNthCalledWith(2, 'xlyra:requests:auto-refresh', 'false')
+  })
+})
+
+describe('request table column width preference', () => {
+  it('falls back to defaults for missing, malformed, stale, or invalid values', () => {
+    const getItem = vi.mocked(window.localStorage.getItem)
+    const belowMinimum = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    belowMinimum[0] = 1
+    belowMinimum[1] = 13
+
+    getItem
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce('not-json')
+      .mockReturnValueOnce(JSON.stringify(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS.slice(0, -1)))
+      .mockReturnValueOnce(JSON.stringify(belowMinimum))
+
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+  })
+
+  it('reads and writes only validated width ratios', () => {
+    const widths = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    widths[1] = 12.5
+    widths[2] = 14.5
+    vi.mocked(window.localStorage.getItem).mockReturnValue(JSON.stringify(widths))
+
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(widths)
+    expect(writeRequestsTableColumnWidthsPreference(widths)).toBe(true)
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('xlyra:requests:table-column-widths:v1', JSON.stringify(widths))
+    expect(writeRequestsTableColumnWidthsPreference([...widths, 0])).toBe(false)
+    expect(window.localStorage.setItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles unavailable storage without throwing', () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation(() => { throw new Error('denied') })
+    expect(readRequestsTableColumnWidthsPreference()).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => { throw new Error('denied') })
+    expect(writeRequestsTableColumnWidthsPreference(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)).toBe(false)
+  })
+})

--- a/web/src/features/requests/lib/request-preferences.ts
+++ b/web/src/features/requests/lib/request-preferences.ts
@@ -1,0 +1,51 @@
+import {
+  defaultRequestTableColumnWidths,
+  isRequestTableColumnWidths,
+  type RequestTableColumnWidths,
+} from '@/features/requests/lib/request-table-columns'
+
+const REQUESTS_AUTO_REFRESH_STORAGE_KEY = 'xlyra:requests:auto-refresh'
+const REQUESTS_TABLE_COLUMN_WIDTHS_STORAGE_KEY = 'xlyra:requests:table-column-widths:v1'
+
+export function readRequestsAutoRefreshPreference(): boolean {
+  try {
+    return typeof window !== 'undefined' && window.localStorage.getItem(REQUESTS_AUTO_REFRESH_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function writeRequestsAutoRefreshPreference(enabled: boolean): void {
+  try {
+    window.localStorage.setItem(REQUESTS_AUTO_REFRESH_STORAGE_KEY, enabled ? 'true' : 'false')
+  } catch {
+    // Storage can be disabled or unavailable; the in-memory preference remains authoritative.
+  }
+}
+
+export function readRequestsTableColumnWidthsPreference(): RequestTableColumnWidths {
+  try {
+    if (typeof window === 'undefined') return defaultRequestTableColumnWidths()
+    const value = window.localStorage.getItem(REQUESTS_TABLE_COLUMN_WIDTHS_STORAGE_KEY)
+    if (!value) return defaultRequestTableColumnWidths()
+
+    const parsed: unknown = JSON.parse(value)
+    return isRequestTableColumnWidths(parsed) ? [...parsed] : defaultRequestTableColumnWidths()
+  } catch {
+    return defaultRequestTableColumnWidths()
+  }
+}
+
+export function writeRequestsTableColumnWidthsPreference(widths: RequestTableColumnWidths): boolean {
+  if (!isRequestTableColumnWidths(widths)) return false
+
+  try {
+    if (typeof window === 'undefined') return false
+    window.localStorage.setItem(REQUESTS_TABLE_COLUMN_WIDTHS_STORAGE_KEY, JSON.stringify(widths))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export { REQUESTS_AUTO_REFRESH_STORAGE_KEY, REQUESTS_TABLE_COLUMN_WIDTHS_STORAGE_KEY }

--- a/web/src/features/requests/lib/request-table-columns.test.ts
+++ b/web/src/features/requests/lib/request-table-columns.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS,
+  REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS,
+  isRequestTableColumnWidths,
+  resizeRequestTableColumnBoundary,
+} from '@/features/requests/lib/request-table-columns'
+
+describe('request table column resizing', () => {
+  it('resizes the target and proportionally links all other columns', () => {
+    const initial = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    const resized = resizeRequestTableColumnBoundary(initial, 2, 4.25)
+
+    expect(resized[2]).toBe(20.25)
+    expect(resized[1]).toBeLessThan(initial[1])
+    expect(resized[5]).toBeLessThan(initial[5])
+    expect(resized.every((width, index) => width >= REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index])).toBe(true)
+    expect(totalWidthUnits(resized)).toBe(10_000)
+    expect(initial).toEqual(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS)
+  })
+
+  it('distributes released width to every other column', () => {
+    const initial = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    const resized = resizeRequestTableColumnBoundary(initial, 2, -4.25)
+
+    expect(resized[2]).toBe(11.75)
+    expect(resized[1]).toBeGreaterThan(initial[1])
+    expect(resized[5]).toBeGreaterThan(initial[5])
+    expect(totalWidthUnits(resized)).toBe(10_000)
+  })
+
+  it('clamps growth against every other column minimum and permits a zero-width status column', () => {
+    const initial = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    const resized = resizeRequestTableColumnBoundary(initial, 2, 100)
+    const statusCollapsed = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    statusCollapsed[1] += statusCollapsed[5]
+    statusCollapsed[5] = 0
+
+    expect(resized[2]).toBe(100 - REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS.reduce((total, minimum, index) => index === 2 ? total : total + minimum, 0))
+    expect(resized.every((width, index) => width >= REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index])).toBe(true)
+    expect(isRequestTableColumnWidths(statusCollapsed)).toBe(true)
+    expect(totalWidthUnits(resized)).toBe(10_000)
+  })
+
+  it('accepts stored ratios with valid hundredth-percent floating-point representations', () => {
+    const widths = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+    widths[5] = 0.07
+    widths[9] = 24.93
+
+    expect(isRequestTableColumnWidths(widths)).toBe(true)
+  })
+})
+
+function totalWidthUnits(widths: readonly number[]) {
+  return widths.reduce((total, width) => total + Math.round(width * 100), 0)
+}

--- a/web/src/features/requests/lib/request-table-columns.test.ts
+++ b/web/src/features/requests/lib/request-table-columns.test.ts
@@ -7,11 +7,16 @@ import {
 } from '@/features/requests/lib/request-table-columns'
 
 describe('request table column resizing', () => {
+  it('uses a compact timing column by default', () => {
+    expect(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS[2]).toBe(18)
+    expect(REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS[6]).toBe(10)
+  })
+
   it('resizes the target and proportionally links all other columns', () => {
     const initial = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
     const resized = resizeRequestTableColumnBoundary(initial, 2, 4.25)
 
-    expect(resized[2]).toBe(20.25)
+    expect(resized[2]).toBe(initial[2] + 4.25)
     expect(resized[1]).toBeLessThan(initial[1])
     expect(resized[5]).toBeLessThan(initial[5])
     expect(resized.every((width, index) => width >= REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index])).toBe(true)
@@ -23,7 +28,7 @@ describe('request table column resizing', () => {
     const initial = [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
     const resized = resizeRequestTableColumnBoundary(initial, 2, -4.25)
 
-    expect(resized[2]).toBe(11.75)
+    expect(resized[2]).toBe(initial[2] - 4.25)
     expect(resized[1]).toBeGreaterThan(initial[1])
     expect(resized[5]).toBeGreaterThan(initial[5])
     expect(totalWidthUnits(resized)).toBe(10_000)

--- a/web/src/features/requests/lib/request-table-columns.ts
+++ b/web/src/features/requests/lib/request-table-columns.ts
@@ -1,0 +1,104 @@
+export type RequestTableColumnWidths = readonly number[]
+
+const REQUEST_TABLE_TOTAL_WIDTH_UNITS = 10_000
+const REQUEST_TABLE_WIDTH_PRECISION = 100
+
+export const REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS: RequestTableColumnWidths = [3, 11, 16, 11, 7, 15, 12, 8, 7, 10]
+export const REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS: RequestTableColumnWidths = [3, 7, 10, 7, 6, 0, 8, 6, 6, 7]
+
+export function defaultRequestTableColumnWidths(): number[] {
+  return [...REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS]
+}
+
+export function isRequestTableColumnWidths(value: unknown): value is RequestTableColumnWidths {
+  if (!Array.isArray(value) || value.length !== REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS.length) return false
+
+  let totalUnits = 0
+  for (let index = 0; index < value.length; index += 1) {
+    const width = value[index]
+    const widthUnits = toWidthUnits(width)
+    if (widthUnits == null || widthUnits < REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index] * REQUEST_TABLE_WIDTH_PRECISION) {
+      return false
+    }
+    totalUnits += widthUnits
+  }
+
+  return totalUnits === REQUEST_TABLE_TOTAL_WIDTH_UNITS
+}
+
+export function resizeRequestTableColumnBoundary(
+  widths: RequestTableColumnWidths,
+  boundaryIndex: number,
+  deltaPercent: number,
+): number[] {
+  if (!isRequestTableColumnWidths(widths) || !Number.isFinite(deltaPercent)) {
+    return defaultRequestTableColumnWidths()
+  }
+  if (boundaryIndex < 0 || boundaryIndex >= widths.length - 1) {
+    return [...widths]
+  }
+
+  const deltaUnits = Math.round(deltaPercent * REQUEST_TABLE_WIDTH_PRECISION)
+  if (deltaUnits === 0) return [...widths]
+
+  const widthUnits = widths.map((width) => toWidthUnits(width) ?? 0)
+  const targetMinimum = REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[boundaryIndex] * REQUEST_TABLE_WIDTH_PRECISION
+  const otherIndexes = widthUnits.map((_, index) => index).filter((index) => index !== boundaryIndex)
+  const otherMinimum = otherIndexes.reduce(
+    (total, index) => total + REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index] * REQUEST_TABLE_WIDTH_PRECISION,
+    0,
+  )
+  const nextTarget = clamp(
+    widthUnits[boundaryIndex] + deltaUnits,
+    targetMinimum,
+    REQUEST_TABLE_TOTAL_WIDTH_UNITS - otherMinimum,
+  )
+  const targetDelta = nextTarget - widthUnits[boundaryIndex]
+  if (targetDelta === 0) return [...widths]
+
+  const otherWeights = otherIndexes.map((index) => targetDelta > 0
+    ? widthUnits[index] - REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS[index] * REQUEST_TABLE_WIDTH_PRECISION
+    : widthUnits[index],
+  )
+  const linkedChanges = distributeUnits(Math.abs(targetDelta), otherWeights)
+
+  widthUnits[boundaryIndex] = nextTarget
+  otherIndexes.forEach((index, otherIndex) => {
+    widthUnits[index] += targetDelta > 0 ? -linkedChanges[otherIndex] : linkedChanges[otherIndex]
+  })
+  return widthUnits.map((units) => units / REQUEST_TABLE_WIDTH_PRECISION)
+}
+
+function distributeUnits(total: number, weights: number[]) {
+  const weightTotal = weights.reduce((sum, weight) => sum + weight, 0)
+  if (weightTotal === 0) return weights.map(() => 0)
+
+  const allocations = weights.map((weight) => Math.floor((total * weight) / weightTotal))
+  let remaining = total - allocations.reduce((sum, allocation) => sum + allocation, 0)
+  const fractions = weights
+    .map((weight, index) => ({ index, remainder: (total * weight) % weightTotal }))
+    .sort((left, right) => right.remainder - left.remainder || left.index - right.index)
+
+  for (const { index } of fractions) {
+    if (remaining === 0) break
+    allocations[index] += 1
+    remaining -= 1
+  }
+  return allocations
+}
+
+function toWidthUnits(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const scaled = value * REQUEST_TABLE_WIDTH_PRECISION
+  const units = Math.round(scaled)
+  // Decimal percentages from JSON are subject to binary floating-point noise
+  // (for example, 0.07 * 100). Accept only values that round to 0.01%.
+  if (Math.abs(scaled - units) > Number.EPSILON * Math.max(1, Math.abs(scaled)) * 4) {
+    return null
+  }
+  return Number.isSafeInteger(units) ? units : null
+}
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), maximum)
+}

--- a/web/src/features/requests/lib/request-table-columns.ts
+++ b/web/src/features/requests/lib/request-table-columns.ts
@@ -3,7 +3,7 @@ export type RequestTableColumnWidths = readonly number[]
 const REQUEST_TABLE_TOTAL_WIDTH_UNITS = 10_000
 const REQUEST_TABLE_WIDTH_PRECISION = 100
 
-export const REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS: RequestTableColumnWidths = [3, 11, 16, 11, 7, 15, 12, 8, 7, 10]
+export const REQUEST_TABLE_COLUMN_DEFAULT_WIDTHS: RequestTableColumnWidths = [3, 11, 18, 11, 7, 15, 10, 8, 7, 10]
 export const REQUEST_TABLE_COLUMN_MINIMUM_WIDTHS: RequestTableColumnWidths = [3, 7, 10, 7, 6, 0, 8, 6, 6, 7]
 
 export function defaultRequestTableColumnWidths(): number[] {

--- a/web/src/features/requests/lib/request-utils.test.ts
+++ b/web/src/features/requests/lib/request-utils.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import type { RequestLogDetail } from '@/features/requests/api/requests'
-import { requestDownstreamTransportLabel } from '@/features/requests/lib/request-utils'
+import {
+  formatLatency,
+  requestCostFormula,
+  requestCredentialMultiplier,
+  requestDownstreamTransportLabel,
+  requestFirstByteLatency,
+  requestFirstByteLatencyTone,
+  requestReasoningEffort,
+  requestTotalLatencyTone,
+} from '@/features/requests/lib/request-utils'
 
 describe('requestDownstreamTransportLabel', () => {
   it('labels websocket request metadata as WS', () => {
@@ -13,6 +22,109 @@ describe('requestDownstreamTransportLabel', () => {
     const legacyDetail = requestDetail()
     expect(requestDownstreamTransportLabel(httpDetail)).toBe('HTTP')
     expect(requestDownstreamTransportLabel(legacyDetail)).toBe('HTTP')
+  })
+})
+
+describe('request log display helpers', () => {
+  it('keeps missing first-byte latency unknown', () => {
+    expect(formatLatency()).toBe('-')
+    expect(formatLatency(12.6)).toBe('13 ms')
+    expect(formatLatency(Number.NaN)).toBe('-')
+
+    const nonStream = requestDetail()
+    nonStream.stream = false
+    nonStream.first_byte_latency_ms = 12
+    expect(requestFirstByteLatency(nonStream)).toBeNull()
+
+    const stream = requestDetail()
+    stream.stream = true
+    stream.first_byte_latency_ms = 12
+    expect(requestFirstByteLatency(stream)).toBe(12)
+
+    stream.first_byte_latency_ms = Number.NaN
+    expect(requestFirstByteLatency(stream)).toBeNull()
+
+    const legacy = requestDetail()
+    legacy.first_byte_latency_ms = 12
+    expect(requestFirstByteLatency(legacy)).toBeNull()
+  })
+
+  it.each([
+    [0, 'healthy'],
+    [5000, 'healthy'],
+    [5001, 'slow'],
+    [10000, 'slow'],
+    [10001, 'very-slow'],
+    [20000, 'very-slow'],
+    [20001, 'critical'],
+    [null, 'muted'],
+    [undefined, 'muted'],
+    [Number.NaN, 'muted'],
+    [-1, 'muted'],
+  ] as const)('assigns first-byte latency %s to the %s tone', (latency, tone) => {
+    expect(requestFirstByteLatencyTone(latency)).toBe(tone)
+  })
+
+  it.each([
+    [0, 'healthy'],
+    [20000, 'healthy'],
+    [20001, 'slow'],
+    [40000, 'slow'],
+    [40001, 'very-slow'],
+    [60000, 'very-slow'],
+    [60001, 'critical'],
+    [null, 'muted'],
+    [undefined, 'muted'],
+    [Number.NaN, 'muted'],
+    [-1, 'muted'],
+  ] as const)('assigns total latency %s to the %s tone', (latency, tone) => {
+    expect(requestTotalLatencyTone(latency)).toBe(tone)
+  })
+
+  it('only exposes a non-empty typed reasoning effort', () => {
+    const detail = requestDetail()
+    detail.reasoning_effort = ' high '
+    expect(requestReasoningEffort(detail)).toBe('high')
+    detail.reasoning_effort = 2 as unknown as string
+    expect(requestReasoningEffort(detail)).toBeNull()
+    detail.reasoning_effort = null
+    expect(requestReasoningEffort(detail)).toBeNull()
+  })
+
+  it('shows saved component multipliers, including x1 values', () => {
+    const detail = requestDetail()
+    detail.pricing = { input_value: 1, output_value: 1 }
+    detail.cost_calculation = {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      base_estimated_cost: 1,
+      estimated_cost: 2,
+      credential_upstream_cost_multiplier: 1,
+      service_tier_multiplier: 2,
+      currency: 'USD',
+    }
+    expect(requestCredentialMultiplier(detail)).toBe(1)
+    expect(requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)).toContain('credentialMultiplier x1 * detail.formula.serviceTierMultiplier x2')
+
+    detail.cost_calculation.service_tier_multiplier = 1
+    expect(requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)).toContain('credentialMultiplier x1 * detail.formula.serviceTierMultiplier x1')
+
+    detail.cost_calculation.credential_upstream_cost_multiplier = -1
+    expect(requestCredentialMultiplier(detail)).toBeNull()
+  })
+
+  it('falls back to the legacy aggregate multiplier', () => {
+    const detail = requestDetail()
+    detail.cost_calculation = {
+      base_estimated_cost: 1,
+      estimated_cost: 2,
+      cost_multiplier: 2,
+      currency: 'USD',
+    }
+    detail.pricing = { input_value: 1, output_value: 1 }
+    detail.usage.prompt_tokens = 10
+    detail.usage.completion_tokens = 5
+    expect(requestCostFormula(detail, (key) => key)).toContain('* 2')
   })
 })
 

--- a/web/src/features/requests/lib/request-utils.test.ts
+++ b/web/src/features/requests/lib/request-utils.test.ts
@@ -91,7 +91,7 @@ describe('request log display helpers', () => {
     expect(requestReasoningEffort(detail)).toBeNull()
   })
 
-  it('shows saved component multipliers, including x1 values', () => {
+  it('shows the fast service multiplier and omits the standard service multiplier', () => {
     const detail = requestDetail()
     detail.pricing = { input_value: 1, output_value: 1 }
     detail.cost_calculation = {
@@ -101,13 +101,20 @@ describe('request log display helpers', () => {
       estimated_cost: 2,
       credential_upstream_cost_multiplier: 1,
       service_tier_multiplier: 2,
+      billing_mode: 'fast',
       currency: 'USD',
     }
     expect(requestCredentialMultiplier(detail)).toBe(1)
     expect(requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)).toContain('credentialMultiplier x1 * detail.formula.serviceTierMultiplier x2')
 
+    detail.cost_calculation.billing_mode = 'standard'
     detail.cost_calculation.service_tier_multiplier = 1
-    expect(requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)).toContain('credentialMultiplier x1 * detail.formula.serviceTierMultiplier x1')
+    const standardFormula = requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)
+    expect(standardFormula).toContain('credentialMultiplier x1')
+    expect(standardFormula).not.toContain('serviceTierMultiplier')
+
+    detail.cost_calculation.billing_mode = 'fast'
+    expect(requestCostFormula(detail, (key, options) => `${key} ${String(options?.multiplier ?? '')}`)).not.toContain('serviceTierMultiplier')
 
     detail.cost_calculation.credential_upstream_cost_multiplier = -1
     expect(requestCredentialMultiplier(detail)).toBeNull()

--- a/web/src/features/requests/lib/request-utils.ts
+++ b/web/src/features/requests/lib/request-utils.ts
@@ -3,6 +3,11 @@ import type { RequestLogDetail, RequestLogItem } from '@/features/requests/api/r
 
 type TFunction = (key: string, options?: Record<string, unknown>) => string
 
+export type RequestLatencyTone = 'healthy' | 'slow' | 'very-slow' | 'critical' | 'muted'
+
+const firstByteLatencyThresholds = [5_000, 10_000, 20_000] as const
+const totalLatencyThresholds = [20_000, 40_000, 60_000] as const
+
 export function requestModelName(item: RequestLogItem) {
   return requestDownstreamModelName(item)
 }
@@ -25,6 +30,56 @@ export function requestMappedModel(item: RequestLogItem): string | null {
 export function requestGroupName(item: RequestLogItem) {
   if (item.site.site_type !== 'newapi') return null
   return item.pricing?.group_name || item.pricing_group || null
+}
+
+export function requestReasoningEffort(detail: RequestLogDetail | RequestLogItem) {
+  const value = detail.reasoning_effort
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function requestFirstByteLatency(item: RequestLogItem) {
+  if (item.stream !== true && item.response_mode !== 'stream') return null
+  if (!isPositiveFiniteNumber(item.first_byte_latency_ms)) return null
+  return item.first_byte_latency_ms
+}
+
+export function requestCredentialName(detail: RequestLogDetail | RequestLogItem) {
+  const value = detail.credential?.name
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function requestCredentialMultiplier(detail: RequestLogDetail | RequestLogItem) {
+  const value = detail.cost_calculation?.credential_upstream_cost_multiplier
+  return isPositiveFiniteNumber(value) ? value : null
+}
+
+export function requestServiceTierMultiplier(detail: RequestLogDetail | RequestLogItem) {
+  const value = detail.cost_calculation?.service_tier_multiplier
+  return isPositiveFiniteNumber(value) ? value : null
+}
+
+export function formatCostMultiplier(value?: number | null) {
+  if (!isPositiveFiniteNumber(value)) return null
+  return `x${formatDecimal(value)}`
+}
+
+function requestCostMultiplierSuffix(detail: RequestLogDetail | RequestLogItem, t: TFunction) {
+  const credentialMultiplier = requestCredentialMultiplier(detail)
+  const serviceTierMultiplier = requestServiceTierMultiplier(detail)
+  const parts: string[] = []
+  const credentialSuffix = formatCostMultiplier(credentialMultiplier)
+  const serviceTierSuffix = formatCostMultiplier(serviceTierMultiplier)
+  if (credentialSuffix) {
+    parts.push(t('detail.formula.credentialMultiplier', { multiplier: credentialSuffix }))
+  }
+  if (serviceTierSuffix) {
+    parts.push(t('detail.formula.serviceTierMultiplier', { multiplier: serviceTierSuffix }))
+  }
+  if (parts.length) {
+    return parts.join(' * ')
+  }
+  const multiplier = detail.cost_calculation?.cost_multiplier
+  return isPositiveFiniteNumber(multiplier) && multiplier > 1 ? formatDecimal(multiplier) : null
 }
 
 export function requestResponseModeLabel(item: RequestLogItem, t: TFunction) {
@@ -133,15 +188,15 @@ export function requestCostFormula(detail: RequestLogDetail | RequestLogItem, t:
   const groupRatio = requestGroupRatio(detail)
   const totalCost = detail.cost_calculation?.estimated_cost ?? detail.usage.estimated_cost
   const baseCost = detail.cost_calculation?.base_estimated_cost
-  const multiplier = detail.cost_calculation?.cost_multiplier
   const currency = detail.cost_calculation?.currency ?? detail.usage.currency
   const parts: string[] = []
   const hasGroupRatio = typeof groupRatio === 'number' && groupRatio !== 1
+  const multiplierSuffix = requestCostMultiplierSuffix(detail, t)
 
   if (typeof perRequestValue === 'number') {
     const summary = t('detail.formula.perRequest', { price: formatCurrency(perRequestValue, currency) })
-    if (typeof totalCost === 'number' && typeof baseCost === 'number' && typeof multiplier === 'number' && multiplier > 1) {
-      return `${summary} = ${formatCurrency(baseCost, currency)} * ${formatDecimal(multiplier)} = ${formatCurrency(totalCost, currency)}`
+    if (typeof totalCost === 'number' && typeof baseCost === 'number' && multiplierSuffix) {
+      return `${summary} = ${formatCurrency(baseCost, currency)} * ${multiplierSuffix} = ${formatCurrency(totalCost, currency)}`
     }
     if (typeof totalCost === 'number' && typeof perRequestCost === 'number') {
       return `${summary} = ${formatCurrency(totalCost, currency)}`
@@ -175,8 +230,8 @@ export function requestCostFormula(detail: RequestLogDetail | RequestLogItem, t:
     if (hasGroupRatio) {
       summary = `(${summary}) * ${formatDecimal(groupRatio)}`
     }
-    if (typeof totalCost === 'number' && typeof baseCost === 'number' && typeof multiplier === 'number' && multiplier > 1) {
-      return `${summary} = ${formatCurrency(baseCost, currency)} * ${formatDecimal(multiplier)} = ${formatCurrency(totalCost, currency)}`
+    if (typeof totalCost === 'number' && typeof baseCost === 'number' && multiplierSuffix) {
+      return `${summary} = ${formatCurrency(baseCost, currency)} * ${multiplierSuffix} = ${formatCurrency(totalCost, currency)}`
     }
     if (typeof totalCost === 'number') {
       return `${summary} = ${formatCurrency(totalCost, currency)}`
@@ -222,6 +277,14 @@ function firstNumber(...values: Array<number | null | undefined>) {
   return null
 }
 
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
 function firstPositiveNumber(...values: Array<number | null | undefined>) {
   for (const value of values) {
     if (typeof value === 'number' && value > 0) {
@@ -258,8 +321,27 @@ export function formatDateTime(value?: string | null, language?: string) {
 }
 
 export function formatLatency(value?: number | null) {
-  if (typeof value !== 'number') return '-'
+  if (!isNonNegativeFiniteNumber(value)) return '-'
   return `${Math.round(value)} ms`
+}
+
+export function requestFirstByteLatencyTone(value?: number | null): RequestLatencyTone {
+  return latencyToneForThresholds(value, firstByteLatencyThresholds)
+}
+
+export function requestTotalLatencyTone(value?: number | null): RequestLatencyTone {
+  return latencyToneForThresholds(value, totalLatencyThresholds)
+}
+
+function latencyToneForThresholds(
+  value: number | null | undefined,
+  [healthyMax, slowMax, verySlowMax]: readonly [number, number, number],
+): RequestLatencyTone {
+  if (!isNonNegativeFiniteNumber(value)) return 'muted'
+  if (value <= healthyMax) return 'healthy'
+  if (value <= slowMax) return 'slow'
+  if (value <= verySlowMax) return 'very-slow'
+  return 'critical'
 }
 
 export function formatInteger(value?: number | null) {

--- a/web/src/features/requests/lib/request-utils.ts
+++ b/web/src/features/requests/lib/request-utils.ts
@@ -65,10 +65,12 @@ export function formatCostMultiplier(value?: number | null) {
 
 function requestCostMultiplierSuffix(detail: RequestLogDetail | RequestLogItem, t: TFunction) {
   const credentialMultiplier = requestCredentialMultiplier(detail)
-  const serviceTierMultiplier = requestServiceTierMultiplier(detail)
+  const serviceTierMultiplier = requestIsFastBilling(detail) ? requestServiceTierMultiplier(detail) : null
   const parts: string[] = []
   const credentialSuffix = formatCostMultiplier(credentialMultiplier)
-  const serviceTierSuffix = formatCostMultiplier(serviceTierMultiplier)
+  const serviceTierSuffix = serviceTierMultiplier != null && serviceTierMultiplier > 1
+    ? formatCostMultiplier(serviceTierMultiplier)
+    : null
   if (credentialSuffix) {
     parts.push(t('detail.formula.credentialMultiplier', { multiplier: credentialSuffix }))
   }

--- a/web/src/locales/en/requests.json
+++ b/web/src/locales/en/requests.json
@@ -1,12 +1,16 @@
 {
   "table": {
     "headers": {
+      "expand": "Expand",
       "time": "Time",
       "model": "Model",
       "apiKey": "API Key",
       "site": "Site",
       "status": "Status",
-      "latency": "Latency",
+      "latency": "Timing",
+      "firstByte": "First byte",
+      "totalDuration": "Total duration",
+      "reasoning": "Reasoning effort",
       "input": "Input",
       "output": "Output",
       "cost": "Cost"
@@ -21,6 +25,7 @@
     "cache": "Cache {{tokens}}",
     "cacheWrite": "Cache write {{tokens}}",
     "cacheReadWrite": "Cache {{read}}/{{write}}",
+    "resizeColumn": "Resize {{column}} column width",
     "empty": {
       "title": "No request logs",
       "description": "No forwarded request records to display."
@@ -71,6 +76,7 @@
     "failure": "Failure",
     "statusCode": "Status code",
     "site": "Site",
+    "upstreamCredential": "Upstream API key",
     "group": "Group",
     "usage": "Usage",
     "input": "Input",
@@ -83,6 +89,7 @@
     "outputPrice": "Output price",
     "cachePrice": "Cache price",
     "perRequestPrice": "Per-request price",
+    "credentialMultiplier": "Upstream API key multiplier",
     "mode": "Mode",
     "totalCost": "Total cost",
     "path": "Path",
@@ -101,6 +108,8 @@
       "cacheWrite5m": "Cache write(5m) {{tokens}} tokens / 1M tokens * {{price}}",
       "cacheWrite1h": "Cache write(1h) {{tokens}} tokens / 1M tokens * {{price}}",
       "output": "Output {{tokens}} tokens / 1M tokens * {{price}}",
+      "credentialMultiplier": "Upstream API key {{multiplier}}",
+      "serviceTierMultiplier": "Service tier {{multiplier}}",
       "perRequestUnit": "{{price}}/req"
     },
     "longContext": "Long context billing",

--- a/web/src/locales/jp/requests.json
+++ b/web/src/locales/jp/requests.json
@@ -1,12 +1,16 @@
 {
   "table": {
     "headers": {
+      "expand": "展開",
       "time": "時刻",
       "model": "モデル",
       "apiKey": "API Key",
       "site": "サイト",
       "status": "ステータス",
-      "latency": "レイテンシ",
+      "latency": "所要時間",
+      "firstByte": "最初のバイト",
+      "totalDuration": "総時間",
+      "reasoning": "推論の強度",
       "input": "入力",
       "output": "出力",
       "cost": "コスト"
@@ -19,6 +23,7 @@
       "nonStream": "非ストリーム"
     },
     "cache": "キャッシュ {{tokens}}",
+    "resizeColumn": "{{column}} 列の幅を調整",
     "empty": {
       "title": "リクエストログがありません",
       "description": "表示できる転送リクエスト記録はありません。"
@@ -69,6 +74,7 @@
     "failure": "失敗",
     "statusCode": "ステータスコード",
     "site": "サイト",
+    "upstreamCredential": "上流 API キー",
     "group": "グループ",
     "usage": "使用量",
     "input": "入力",
@@ -81,6 +87,7 @@
     "outputPrice": "出力価格",
     "cachePrice": "キャッシュ価格",
     "perRequestPrice": "リクエスト単価",
+    "credentialMultiplier": "上流 API キー倍率",
     "mode": "モード",
     "totalCost": "総コスト",
     "path": "パス",
@@ -99,6 +106,8 @@
       "cacheWrite5m": "キャッシュ書込(5m) {{tokens}} トークン / 100万トークン * {{price}}",
       "cacheWrite1h": "キャッシュ書込(1h) {{tokens}} トークン / 100万トークン * {{price}}",
       "output": "出力 {{tokens}} トークン / 100万トークン * {{price}}",
+      "credentialMultiplier": "上流 API キー {{multiplier}}",
+      "serviceTierMultiplier": "サービスティア {{multiplier}}",
       "perRequestUnit": "{{price}}/回"
     },
     "longContext": "長文脈課金",

--- a/web/src/locales/zh/requests.json
+++ b/web/src/locales/zh/requests.json
@@ -1,12 +1,16 @@
 {
   "table": {
     "headers": {
+      "expand": "展开",
       "time": "时间",
       "model": "模型",
       "apiKey": "下游密钥",
       "site": "站点",
       "status": "状态",
       "latency": "用时",
+      "firstByte": "首字",
+      "totalDuration": "总时长",
+      "reasoning": "推理强度",
       "input": "输入",
       "output": "输出",
       "cost": "花费"
@@ -21,6 +25,7 @@
     "cache": "缓存 {{tokens}}",
     "cacheWrite": "缓存写入 {{tokens}}",
     "cacheReadWrite": "缓存 {{read}}/{{write}}",
+    "resizeColumn": "调整{{column}}列宽",
     "empty": {
       "title": "没有请求日志",
       "description": "当前没有可展示的转发请求记录。"
@@ -71,6 +76,7 @@
     "failure": "失败",
     "statusCode": "状态码",
     "site": "站点",
+    "upstreamCredential": "上游 API Key",
     "group": "分组",
     "usage": "用量",
     "input": "输入",
@@ -83,6 +89,7 @@
     "outputPrice": "输出价格",
     "cachePrice": "缓存价格",
     "perRequestPrice": "按次价格",
+    "credentialMultiplier": "上游 API Key 倍率",
     "mode": "模式",
     "totalCost": "总花费",
     "path": "路径",
@@ -101,6 +108,8 @@
       "cacheWrite5m": "缓存写入(5m) {{tokens}} tokens / 1M tokens * {{price}}",
       "cacheWrite1h": "缓存写入(1h) {{tokens}} tokens / 1M tokens * {{price}}",
       "output": "输出 {{tokens}} tokens / 1M tokens * {{price}}",
+      "credentialMultiplier": "上游 API Key {{multiplier}}",
+      "serviceTierMultiplier": "服务等级 {{multiplier}}",
       "perRequestUnit": "{{price}}/次"
     },
     "longContext": "长上下文计价",


### PR DESCRIPTION
## 请求日志列表与详情增强

- 持久化自动刷新与桌面列宽偏好，支持列宽联动调整和键盘操作。
- 展示首字/总耗时及独立延迟分档、推理强度、站点 API Key 名称与计费倍率。
- 扩展请求日志 API 的首字延迟、推理强度和无密钥凭据投影，并兼容历史日志。

## 验证

- `go test ./...`
- 前端 Vitest：109 tests passed
- `pnpm lint`
- Docker 生产构建：通过

<img width="2580" height="1944" alt="image" src="https://github.com/user-attachments/assets/67669eb5-a3c5-4eb9-b7bb-46944ec3afc8" />
