### PR TITLE
fix: fail over pre-output response overloads

### DIFF
--- a/server/internal/gateway/diagnostic_recording_edges_test.go
+++ b/server/internal/gateway/diagnostic_recording_edges_test.go
@@ -170,6 +170,43 @@ func TestHandleSiteModelTestStreamResponseMapsCancelledProxyError(t *testing.T) 
 	}
 }
 
+func TestHandleSiteModelTestStreamResponseKeepsUnstartedErrorSemantics(t *testing.T) {
+	t.Parallel()
+
+	result := (Handler{logger: gatewayDiscardLogger()}).handleSiteModelTestStreamResponse(
+		context.Background(),
+		"stream-error",
+		uuid.New(),
+		routeengine.Candidate{
+			Site:  routeengine.CandidateSite{ID: uuid.New(), SiteType: "openai"},
+			Model: routeengine.CandidateModel{SiteModelID: uuid.New()},
+		},
+		siteModelTestProtocolAdapter{
+			streamCapture: streamCaptureState{
+				endReason:   "upstream_stream_error",
+				errorDetail: `{"type":"response.failed","error":{"code":"server_is_overloaded"}}`,
+			},
+		},
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+		gatewayAttemptResult{stream: true, currency: "USD", downstreamPath: gatewayEndpointResponses},
+		time.Now(),
+	)
+
+	if result.success || result.responseStarted {
+		t.Fatalf("unstarted diagnostic error result = %#v", result)
+	}
+	if result.statusCode != http.StatusBadGateway || result.upstreamStatusCode != http.StatusOK {
+		t.Fatalf("status = %d upstream = %d, want 502/200", result.statusCode, result.upstreamStatusCode)
+	}
+	if result.errorType != "upstream_stream_error" || result.errorMessage != "upstream stream returned an error event" {
+		t.Fatalf("stream error = %q %q", result.errorType, result.errorMessage)
+	}
+}
+
 func TestDiscardResponseWriterWriteHeaderIsNoop(t *testing.T) {
 	t.Parallel()
 
@@ -184,7 +221,8 @@ func TestDiscardResponseWriterWriteHeaderIsNoop(t *testing.T) {
 }
 
 type siteModelTestProtocolAdapter struct {
-	proxyErr error
+	streamCapture streamCaptureState
+	proxyErr      error
 }
 
 func (a siteModelTestProtocolAdapter) ProtocolName() string {
@@ -204,5 +242,8 @@ func (a siteModelTestProtocolAdapter) TransformBufferedResponse(int, http.Header
 }
 
 func (a siteModelTestProtocolAdapter) ProxyStream(context.Context, http.ResponseWriter, *http.Response, time.Time, routeengine.Candidate) (streamCaptureState, bool, error) {
-	return streamCaptureState{endReason: "downstream_client_cancelled"}, false, a.proxyErr
+	if a.streamCapture.endReason == "" && a.proxyErr != nil {
+		a.streamCapture.endReason = "downstream_client_cancelled"
+	}
+	return a.streamCapture, false, a.proxyErr
 }

--- a/server/internal/gateway/execution.go
+++ b/server/internal/gateway/execution.go
@@ -700,6 +700,13 @@ func (h Handler) handleStreamResponse(
 	}
 
 	if !responseStarted {
+		if capture.endReason == "upstream_stream_error" {
+			result.statusCode = http.StatusBadGateway
+			result.errorType = "upstream_stream_error"
+			result.errorMessage = streamErrorMessageFromEndReason(capture.endReason)
+			result.requestLogID = h.recordAttempt(ctx, requestID, apiKeyID, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))
+			return result
+		}
 		result.errorType = "upstream_stream_empty"
 		result.errorMessage = "upstream stream returned without any data"
 		result.requestLogID = h.recordAttempt(ctx, requestID, apiKeyID, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))

--- a/server/internal/gateway/execution_forward_response_edges_test.go
+++ b/server/internal/gateway/execution_forward_response_edges_test.go
@@ -195,6 +195,43 @@ func TestHandleStreamResponseEmptySuccessfulUpstreamMarksSemanticFailure(t *test
 	}
 }
 
+func TestHandleStreamResponseUnstartedErrorKeepsFailureSemantics(t *testing.T) {
+	t.Parallel()
+
+	result := Handler{logger: gatewayDiscardLogger()}.handleStreamResponse(
+		context.Background(),
+		httptest.NewRecorder(),
+		"req-forward",
+		uuid.New(),
+		uuid.New(),
+		routeengine.Candidate{Site: routeengine.CandidateSite{Name: "unused-site"}},
+		&testGatewayProtocol{
+			streamCapture: streamCaptureState{
+				endReason:   "upstream_stream_error",
+				errorDetail: `{"type":"response.failed","error":{"code":"server_is_overloaded"}}`,
+			},
+			streamStarted: false,
+		},
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+		gatewayAttemptResult{attempt: 1, downstreamPath: gatewayEndpointResponses, stream: true},
+		time.Now(),
+	)
+
+	if result.success || result.responseStarted {
+		t.Fatalf("unstarted error result = %#v", result)
+	}
+	if result.statusCode != http.StatusBadGateway || result.upstreamStatusCode != http.StatusOK {
+		t.Fatalf("status = %d upstream = %d, want 502/200", result.statusCode, result.upstreamStatusCode)
+	}
+	if result.errorType != "upstream_stream_error" || result.errorMessage != "upstream stream returned an error event" {
+		t.Fatalf("stream error = %q %q", result.errorType, result.errorMessage)
+	}
+}
+
 func TestHandleStreamResponseDownstreamCancelAfterHeadersUses499(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/gateway/protocol_canonical_stream_test.go
+++ b/server/internal/gateway/protocol_canonical_stream_test.go
@@ -1,9 +1,11 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	routeengine "xlyra/server/internal/router"
 )
@@ -451,6 +453,60 @@ func TestProxyResponsesStreamPassthroughDoesNotDeferOverloadAfterOutput(t *testi
 		t.Fatalf("expected started upstream stream error, started=%v capture=%+v", started, capture)
 	}
 	assertGatewayBodyContainsAll(t, rec.Body.String(), "response.created", "response.output_text.delta", "server_is_overloaded")
+}
+
+func TestProxyResponsesStreamPassthroughCommitsLifecycleEventsBeforeDone(t *testing.T) {
+	t.Parallel()
+
+	body := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_empty"}}`) +
+		gatewaySSEEvent("response.in_progress", `{"type":"response.in_progress","response":{"id":"resp_empty"}}`) +
+		"data: [DONE]\n\n"
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t, body)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if !started || !capture.streamCompleted || capture.endReason != "done" {
+		t.Fatalf("expected completed lifecycle-only stream, started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.String() != body {
+		t.Fatalf("passthrough body = %q, want %q", rec.Body.String(), body)
+	}
+}
+
+func TestProxyResponsesStreamPassthroughKeepsFailoverAvailableAfterDownstreamHeartbeat(t *testing.T) {
+	recorder := newSynchronizedStreamRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	session := newDownstreamSSESessionWithIntervals(ctx, recorder, gatewayEndpointResponses, cancel, 10*time.Millisecond, time.Second)
+	defer session.Close()
+	defer cancel()
+
+	waitForStreamBody(t, recorder, ": xlyra-keepalive\n\n")
+	overloadedBody := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded"}}`) +
+		gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded"}}}`)
+	capture, started, err := proxyResponsesStreamPassthrough(ctx, session, gatewayStreamTestResponse(overloadedBody), time.Now())
+	if err != nil {
+		t.Fatalf("overloaded passthrough returned error: %v", err)
+	}
+	if started || capture.endReason != "upstream_stream_error" {
+		t.Fatalf("expected unstarted overload after heartbeat, started=%v capture=%+v", started, capture)
+	}
+
+	fallbackBody := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_fallback"}}`) +
+		gatewaySSEEvent("response.output_text.delta", `{"type":"response.output_text.delta","item_id":"msg_fallback","delta":"fallback-ok"}`) +
+		gatewaySSEEvent("response.completed", `{"type":"response.completed","response":{"id":"resp_fallback","output":[]}}`)
+	capture, started, err = proxyResponsesStreamPassthrough(ctx, session, gatewayStreamTestResponse(fallbackBody), time.Now())
+	if err != nil {
+		t.Fatalf("fallback passthrough returned error: %v", err)
+	}
+	if !started || !capture.streamCompleted || capture.endReason != "done" {
+		t.Fatalf("expected completed fallback after heartbeat, started=%v capture=%+v", started, capture)
+	}
+	session.FinishSSE()
+	_, body, _ := recorder.snapshot()
+	assertGatewayBodyContainsAll(t, body, "xlyra-keepalive", "resp_fallback", "fallback-ok", "response.completed")
+	if strings.Contains(body, "resp_overloaded") || strings.Contains(body, "server_is_overloaded") {
+		t.Fatalf("pre-output overload leaked after heartbeat: %q", body)
+	}
 }
 
 func TestProxyCanonicalStreamResponsesErrorEventFails(t *testing.T) {

--- a/server/internal/gateway/protocol_canonical_stream_test.go
+++ b/server/internal/gateway/protocol_canonical_stream_test.go
@@ -417,6 +417,42 @@ func TestProxyResponsesStreamPassthroughCapturesIncompleteErrorAndAnnotations(t 
 	}
 }
 
+func TestProxyResponsesStreamPassthroughDefersPreOutputOverloadForFailover(t *testing.T) {
+	t.Parallel()
+
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t,
+		gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded"}}`)+
+			gatewaySSEEvent("response.in_progress", `{"type":"response.in_progress","response":{"id":"resp_overloaded"}}`)+
+			gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`),
+	)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if started || capture.endReason != "upstream_stream_error" {
+		t.Fatalf("expected unstarted upstream stream error, started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("pre-output overload leaked downstream: %q", rec.Body.String())
+	}
+}
+
+func TestProxyResponsesStreamPassthroughDoesNotDeferOverloadAfterOutput(t *testing.T) {
+	t.Parallel()
+
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t,
+		gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_started"}}`)+
+			gatewaySSEEvent("response.output_text.delta", `{"type":"response.output_text.delta","item_id":"msg_started","delta":"hello"}`)+
+			gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_started","status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`),
+	)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if !started || capture.endReason != "upstream_stream_error" {
+		t.Fatalf("expected started upstream stream error, started=%v capture=%+v", started, capture)
+	}
+	assertGatewayBodyContainsAll(t, rec.Body.String(), "response.created", "response.output_text.delta", "server_is_overloaded")
+}
+
 func TestProxyCanonicalStreamResponsesErrorEventFails(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/gateway/protocol_responses_downstream.go
+++ b/server/internal/gateway/protocol_responses_downstream.go
@@ -15,6 +15,8 @@ import (
 
 var synthesizedResponseCounter uint64
 
+const responsesPreOutputBufferLimit = 64 << 10
+
 type chatChoice struct {
 	Index        int         `json:"index"`
 	Message      chatMessage `json:"message"`
@@ -56,6 +58,7 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 	flusher, _ := w.(http.Flusher)
 	reader := bufio.NewReader(resp.Body)
 	headersWritten := false
+	var preOutput bytes.Buffer
 	writeHeaders := func() {
 		if headersWritten {
 			return
@@ -63,6 +66,45 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 		copyStreamingHeaders(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
 		headersWritten = true
+	}
+	flush := func() {
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	commitPreOutput := func() error {
+		if headersWritten {
+			return nil
+		}
+		capture.firstByteLatency = firstNonZero(capture.firstByteLatency, time.Since(startedAt).Milliseconds())
+		writeHeaders()
+		if preOutput.Len() == 0 {
+			return nil
+		}
+		if _, writeErr := w.Write(preOutput.Bytes()); writeErr != nil {
+			return writeErr
+		}
+		preOutput.Reset()
+		flush()
+		return nil
+	}
+	writeLine := func(line []byte) error {
+		if !headersWritten {
+			if preOutput.Len()+len(line) > responsesPreOutputBufferLimit || responsesStreamPreOutputCommits(line) {
+				if err := commitPreOutput(); err != nil {
+					return err
+				}
+			}
+		}
+		if !headersWritten {
+			_, err := preOutput.Write(line)
+			return err
+		}
+		if _, err := w.Write(line); err != nil {
+			return err
+		}
+		flush()
+		return nil
 	}
 	for {
 		if err := ctx.Err(); err != nil {
@@ -74,16 +116,13 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 			if normalizedLine, changed := normalizeResponsesStreamDataLine(line); changed {
 				line = normalizedLine
 			}
-			if !headersWritten {
-				capture.firstByteLatency = time.Since(startedAt).Milliseconds()
-				writeHeaders()
+			if !headersWritten && responsesStreamPreOutputOverloaded(line) {
+				inspectResponsesStreamLine(line, &capture)
+				return capture, false, nil
 			}
-			if _, writeErr := w.Write(line); writeErr != nil {
+			if writeErr := writeLine(line); writeErr != nil {
 				capture.endReason = "downstream_stream_write_failed"
 				return capture, headersWritten, writeErr
-			}
-			if flusher != nil {
-				flusher.Flush()
 			}
 			inspectResponsesStreamLine(line, &capture)
 		}
@@ -114,6 +153,32 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 			capture.endReason = "upstream_stream_read_failed"
 		}
 		return capture, headersWritten, err
+	}
+}
+
+func responsesStreamPreOutputOverloaded(line []byte) bool {
+	data, done, ok := sseDataFromLine(line)
+	if !ok || done {
+		return false
+	}
+	failure, ok := semanticFailureFromJSON([]byte(data))
+	return ok && strings.EqualFold(strings.TrimSpace(failure.Code), "server_is_overloaded")
+}
+
+func responsesStreamPreOutputCommits(line []byte) bool {
+	data, done, ok := sseDataFromLine(line)
+	if !ok || done || strings.TrimSpace(data) == "" {
+		return false
+	}
+	var event responsesStreamEvent
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(event.Type)) {
+	case "response.created", "response.in_progress", "response.queued", "keepalive", "ping":
+		return false
+	default:
+		return true
 	}
 }
 

--- a/server/internal/gateway/protocol_responses_downstream.go
+++ b/server/internal/gateway/protocol_responses_downstream.go
@@ -167,7 +167,13 @@ func responsesStreamPreOutputOverloaded(line []byte) bool {
 
 func responsesStreamPreOutputCommits(line []byte) bool {
 	data, done, ok := sseDataFromLine(line)
-	if !ok || done || strings.TrimSpace(data) == "" {
+	if !ok {
+		return false
+	}
+	if done {
+		return true
+	}
+	if strings.TrimSpace(data) == "" {
 		return false
 	}
 	var event responsesStreamEvent

--- a/server/internal/gateway/site_model_diagnostic.go
+++ b/server/internal/gateway/site_model_diagnostic.go
@@ -611,6 +611,13 @@ func (h Handler) handleSiteModelTestStreamResponse(
 	}
 
 	if !responseStarted {
+		if capture.endReason == "upstream_stream_error" {
+			result.statusCode = http.StatusBadGateway
+			result.errorType = "upstream_stream_error"
+			result.errorMessage = streamErrorMessageFromEndReason(capture.endReason)
+			result.requestLogID = h.recordAttempt(ctx, requestID, uuid.Nil, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))
+			return result
+		}
 		result.errorType = "upstream_stream_empty"
 		result.errorMessage = "upstream stream returned without any data"
 		result.requestLogID = h.recordAttempt(ctx, requestID, uuid.Nil, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))

--- a/server/internal/gateway/soft_mapping_test.go
+++ b/server/internal/gateway/soft_mapping_test.go
@@ -70,10 +70,11 @@ type softMappingUpstreamCall struct {
 }
 
 type softMappingHarness struct {
-	mu                   sync.Mutex
-	upstreamCalls        []softMappingUpstreamCall
-	requestLogs          []store.RequestLog
-	semanticFailurePaths map[string]bool
+	mu                          sync.Mutex
+	upstreamCalls               []softMappingUpstreamCall
+	requestLogs                 []store.RequestLog
+	semanticFailurePaths        map[string]bool
+	preOutputOverloadStreamPath map[string]bool
 
 	apiKey          store.APIKey
 	canonicalModels map[string]store.CanonicalModel
@@ -159,6 +160,17 @@ func newSoftMappingHandler(t *testing.T, harness *softMappingHarness) Handler {
 			harness.mu.Unlock()
 			*dest = models
 			tx.Statement.RowsAffected = int64(len(models))
+		case *store.SiteModel:
+			harness.mu.Lock()
+			defer harness.mu.Unlock()
+			for _, model := range harness.siteModels {
+				if softMappingVarsContain(tx, model.ID.String()) {
+					*dest = model
+					tx.Statement.RowsAffected = 1
+					return
+				}
+			}
+			tx.AddError(gorm.ErrRecordNotFound)
 		case *[]store.Site:
 			sites := make([]store.Site, 0, len(harness.sites))
 			for _, site := range harness.sites {
@@ -240,6 +252,7 @@ func softMappingUpstreamServer(t *testing.T, harness *softMappingHarness, failPr
 		var payload map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&payload)
 		model, _ := payload["model"].(string)
+		stream, _ := payload["stream"].(bool)
 		harness.recordUpstream(softMappingUpstreamCall{Path: r.URL.Path, Model: model})
 		for prefix, status := range failPrefixes {
 			if strings.HasPrefix(r.URL.Path, prefix) {
@@ -258,6 +271,27 @@ func softMappingUpstreamServer(t *testing.T, harness *softMappingHarness, failPr
 			}
 		}
 		harness.mu.Unlock()
+		if stream {
+			harness.mu.Lock()
+			overloaded := false
+			for prefix, enabled := range harness.preOutputOverloadStreamPath {
+				if enabled && strings.HasPrefix(r.URL.Path, prefix) {
+					overloaded = true
+					break
+				}
+			}
+			harness.mu.Unlock()
+			w.Header().Set("Content-Type", "text/event-stream")
+			if overloaded {
+				_, _ = w.Write([]byte(gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded","model":"`+model+`"}}`)))
+				_, _ = w.Write([]byte(gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`)))
+				return
+			}
+			_, _ = w.Write([]byte(gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_ok","model":"`+model+`"}}`)))
+			_, _ = w.Write([]byte(gatewaySSEEvent("response.output_text.delta", `{"type":"response.output_text.delta","item_id":"msg_ok","delta":"soft-ok"}`)))
+			_, _ = w.Write([]byte(gatewaySSEEvent("response.completed", `{"type":"response.completed","response":{"id":"resp_ok","model":"`+model+`","output":[]}}`)))
+			return
+		}
 		if semanticFailure {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"error":{"code":"invalid_api_key","message":"semantic credential rejected"}}`))
@@ -344,6 +378,18 @@ func (f softMappingFixture) do(t *testing.T, model string) *httptest.ResponseRec
 	req = req.WithContext(auth.WithAPIKey(req.Context(), f.apiKey))
 	recorder := httptest.NewRecorder()
 	f.handler.ChatCompletions(recorder, req)
+	return recorder
+}
+
+func (f softMappingFixture) doResponsesStream(t *testing.T, model string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body := `{"model":"` + model + `","input":"hi","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, gatewayEndpointResponses, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithAPIKey(req.Context(), f.apiKey))
+	recorder := httptest.NewRecorder()
+	f.handler.Responses(recorder, req)
 	return recorder
 }
 
@@ -488,6 +534,31 @@ func TestSoftMappingFallsBackAfterBufferedSemanticFailureWithoutLeakingIt(t *tes
 	}
 	if successCount != 1 {
 		t.Fatalf("success logs = %d of %d, want exactly one", successCount, len(logs))
+	}
+}
+
+func TestSoftMappingFailsOverAfterPreOutputResponsesOverloadWithoutLeakingIt(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSoftMappingFixture(t, `[{"pattern":"orig-model","target":"fallback-model","mode":"soft"}]`, true, 0)
+	fixture.harness.mu.Lock()
+	fixture.harness.preOutputOverloadStreamPath = map[string]bool{"/orig": true}
+	for index := range fixture.harness.siteModels {
+		fixture.harness.siteModels[index].Capabilities = store.JSON(`{"supported_endpoint_types":["openai-response"]}`)
+	}
+	fixture.harness.mu.Unlock()
+	recorder := fixture.doResponsesStream(t, "orig-model")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200 after stream failover", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "server_is_overloaded") {
+		t.Fatalf("intermediate overload leaked downstream: %s", recorder.Body.String())
+	}
+	assertGatewayBodyContainsAll(t, recorder.Body.String(), "response.output_text.delta", "soft-ok")
+	models := fixture.harness.upstreamModels()
+	if len(models) != 2 || models[0] != "orig-upstream-model" || models[1] != "fallback-upstream-model" {
+		t.Fatalf("upstream models = %v, want original overload then fallback success", models)
 	}
 }
 


### PR DESCRIPTION
## Background

Responses 流式上游可能在 `response.created` / `response.in_progress` 后、实际输出前返回 `server_is_overloaded`。此前初始化事件会立即写入下游，导致无法切换候选路由，并可能泄露中间失败事件。

## Solution

- 缓冲 Responses 流的预输出生命周期事件，在实际输出前识别并丢弃 `server_is_overloaded` 失败，以便路由继续 failover。
- 保留已输出后的错误事件，避免在流已开始后切换上游。
- 将未开始的上游流错误记录为 HTTP 502 与 `upstream_stream_error`，不再误记为 `upstream_stream_empty`。

## Compatibility

- 仅影响 OpenAI Responses 直通流在首个业务输出前的处理；预输出缓冲上限为 64 KiB。

## Validation

- `go test ./...`
- `go build ./cmd/server`