### PR TITLE
修复 Responses 流式响应在业务输出前无法自动切换路由的问题

### DIFF
--- a/server/internal/gateway/cooldown.go
+++ b/server/internal/gateway/cooldown.go
@@ -381,7 +381,7 @@ func upstreamStreamFailure(result gatewayAttemptResult) bool {
 		return false
 	}
 	switch result.errorType {
-	case "upstream_stream_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_error", "upstream_stream_read_failed", "upstream_stream_empty":
+	case "upstream_stream_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_error", "upstream_stream_read_failed", "upstream_stream_empty", "upstream_stream_preoutput_too_large":
 		return true
 	default:
 		return false
@@ -393,7 +393,7 @@ func requestLogStreamFailure(item store.RequestLog) bool {
 		return false
 	}
 	switch item.ErrorType.String {
-	case "upstream_stream_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_error", "upstream_stream_read_failed", "upstream_stream_empty":
+	case "upstream_stream_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_error", "upstream_stream_read_failed", "upstream_stream_empty", "upstream_stream_preoutput_too_large":
 		return true
 	default:
 		return false

--- a/server/internal/gateway/cooldown_test.go
+++ b/server/internal/gateway/cooldown_test.go
@@ -124,6 +124,13 @@ func TestCooldownInputForFailureClassifiesStreamAndCredentialExhaustion(t *testi
 	if !ok || streamInput.Scope != "model" || streamInput.Reason != store.CooldownReasonUpstreamStreamUnstable || streamInput.Duration != transientCooldownBaseDuration {
 		t.Fatalf("stream failure input = %#v ok=%v, want transient model cooldown", streamInput, ok)
 	}
+	preOutputInput, ok := cooldownInputForFailure(candidate, gatewayAttemptResult{
+		statusCode: http.StatusBadGateway,
+		errorType:  "upstream_stream_preoutput_too_large",
+	})
+	if !ok || preOutputInput.Scope != "model" || preOutputInput.Reason != store.CooldownReasonUpstreamStreamUnstable {
+		t.Fatalf("pre-output stream failure input = %#v ok=%v, want transient model cooldown", preOutputInput, ok)
+	}
 
 	exhaustedInput, ok := cooldownInputForFailure(candidate, gatewayAttemptResult{
 		statusCode: http.StatusBadGateway,
@@ -237,6 +244,18 @@ func TestStreamFailureStreakRequiresThresholdAndBreaksOnSuccess(t *testing.T) {
 	}
 	if streamFailureStreakReached(broken, 3) {
 		t.Fatal("expected successful attempt to break stream failure streak")
+	}
+}
+
+func TestPreOutputLimitCountsTowardStreamFailureStreak(t *testing.T) {
+	t.Parallel()
+
+	item := streamFailureRequestLog()
+	item.StatusCode = http.StatusBadGateway
+	item.ErrorType = sql.NullString{String: "upstream_stream_preoutput_too_large", Valid: true}
+	item.Metadata = store.JSON([]byte(`{"stream_started":false}`))
+	if !requestLogStreamFailure(item) {
+		t.Fatal("pre-output resource limit must count as an upstream stream failure")
 	}
 }
 

--- a/server/internal/gateway/execution.go
+++ b/server/internal/gateway/execution.go
@@ -665,11 +665,18 @@ func (h Handler) handleStreamResponse(
 	result.streamEndReason = capture.endReason
 	result = applyStreamUsage(result, capture.usage)
 	result.latencyMS = time.Since(startedAt).Milliseconds()
+	if !responseStarted && capture.semanticFailure != nil {
+		return h.finishStreamSemanticFailure(ctx, requestID, apiKeyID, canonicalModelID, candidate, result, capture)
+	}
 
 	if proxyErr != nil {
 		var stateCommitErr *responsesWebSocketStateCommitError
 		var clientWriteErr *responsesWebSocketClientWriteError
-		if errors.As(proxyErr, &stateCommitErr) {
+		if errors.Is(proxyErr, errResponsesPreOutputTooLarge) {
+			result.statusCode = http.StatusBadGateway
+			result.errorType = "upstream_stream_preoutput_too_large"
+			result.errorMessage = proxyErr.Error()
+		} else if errors.As(proxyErr, &stateCommitErr) {
 			result.statusCode = http.StatusRequestEntityTooLarge
 			result.errorType = "websocket_state_too_large"
 			result.errorMessage = proxyErr.Error()
@@ -719,6 +726,29 @@ func (h Handler) handleStreamResponse(
 		result.errorType = streamErrorTypeFromEndReason(capture.endReason)
 		result.errorMessage = streamErrorMessageFromEndReason(capture.endReason)
 	}
+	result.requestLogID = h.recordAttempt(ctx, requestID, apiKeyID, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))
+	return result
+}
+
+func (h Handler) finishStreamSemanticFailure(
+	ctx context.Context,
+	requestID string,
+	apiKeyID uuid.UUID,
+	canonicalModelID uuid.UUID,
+	candidate routeengine.Candidate,
+	result gatewayAttemptResult,
+	capture streamCaptureState,
+) gatewayAttemptResult {
+	failure := capture.semanticFailure
+	classificationBody := semanticFailureClassificationBody(failure)
+	result.statusCode = http.StatusBadGateway
+	result.contentType = "application/json"
+	result.errorType = "upstream_response_failed"
+	result.errorMessage = failure.Error()
+	result.body = classificationBody
+	result.failureResponse = diagnosticFailureResponse(failure.Body)
+	result = classifyGatewayUpstreamErrorWithTimeZone(candidate, result, classificationBody, time.Now(), h.timeZone)
+	h.markOAuthConnectionUnavailableOnAuthFailure(ctx, candidate, result)
 	result.requestLogID = h.recordAttempt(ctx, requestID, apiKeyID, canonicalModelID, candidate, result, streamMetadataEnvelope(capture))
 	return result
 }

--- a/server/internal/gateway/execution_forward_response_edges_test.go
+++ b/server/internal/gateway/execution_forward_response_edges_test.go
@@ -232,6 +232,79 @@ func TestHandleStreamResponseUnstartedErrorKeepsFailureSemantics(t *testing.T) {
 	}
 }
 
+func TestHandleStreamResponseClassifiesUnstartedSemanticCredentialFailure(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"type":"response.failed","response":{"status":"failed","error":{"code":"invalid_api_key","message":"credential rejected"}}}`)
+	failure, ok := semanticFailureFromJSON(body)
+	if !ok {
+		t.Fatal("expected semantic failure")
+	}
+	result := Handler{logger: gatewayDiscardLogger()}.handleStreamResponse(
+		context.Background(),
+		httptest.NewRecorder(),
+		"req-forward",
+		uuid.New(),
+		uuid.New(),
+		routeengine.Candidate{Site: routeengine.CandidateSite{SiteType: "codex"}},
+		&testGatewayProtocol{
+			streamCapture: streamCaptureState{
+				endReason:       "upstream_stream_error",
+				errorDetail:     string(body),
+				semanticFailure: failure,
+			},
+		},
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+		gatewayAttemptResult{attempt: 1, downstreamPath: gatewayEndpointResponses, stream: true},
+		time.Now(),
+	)
+
+	if result.success || result.responseStarted {
+		t.Fatalf("semantic credential failure result = %#v", result)
+	}
+	if result.errorType != "upstream_credential_invalid" || result.cooldownScope != "credential" {
+		t.Fatalf("semantic credential classification = %#v", result)
+	}
+	if !strings.Contains(string(result.body), "invalid_api_key") || !strings.Contains(string(result.body), "credential rejected") || !shouldTryNextCredential(result) {
+		t.Fatalf("semantic credential body/retry = %q/%v", string(result.body), shouldTryNextCredential(result))
+	}
+}
+
+func TestHandleStreamResponseClassifiesPreOutputLimitAsRetryableStreamFailure(t *testing.T) {
+	t.Parallel()
+
+	result := Handler{logger: gatewayDiscardLogger()}.handleStreamResponse(
+		context.Background(),
+		httptest.NewRecorder(),
+		"req-forward",
+		uuid.New(),
+		uuid.New(),
+		routeengine.Candidate{},
+		&testGatewayProtocol{
+			streamCapture: streamCaptureState{endReason: "upstream_stream_preoutput_too_large"},
+			streamErr:     errResponsesPreOutputTooLarge,
+		},
+		&http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+		gatewayAttemptResult{attempt: 1, downstreamPath: gatewayEndpointResponses, stream: true},
+		time.Now(),
+	)
+
+	if result.success || result.responseStarted || result.statusCode != http.StatusBadGateway {
+		t.Fatalf("pre-output limit result = %#v", result)
+	}
+	if result.errorType != "upstream_stream_preoutput_too_large" || !upstreamStreamFailure(result) {
+		t.Fatalf("pre-output limit classification = %#v", result)
+	}
+}
+
 func TestHandleStreamResponseDownstreamCancelAfterHeadersUses499(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/gateway/protocol_canonical_stream_test.go
+++ b/server/internal/gateway/protocol_canonical_stream_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -409,13 +410,99 @@ func TestProxyResponsesStreamPassthroughCapturesIncompleteErrorAndAnnotations(t 
 		t.Fatalf("expected annotation and usage capture, got %+v", incompleteCapture)
 	}
 
-	_, errorCapture, started, err := proxyResponsesStreamPassthroughTest(t,
+	errorRec, errorCapture, started, err := proxyResponsesStreamPassthroughTest(t,
 		"data: {\"type\":\"response.error\",\"error\":{\"code\":\"bad_request\",\"message\":\"bad stream\"}}\n\n")
 	if err != nil {
 		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
 	}
-	if !started || errorCapture.streamCompleted || errorCapture.endReason != "upstream_stream_error" {
+	if started || errorCapture.streamCompleted || errorCapture.endReason != "upstream_stream_error" {
 		t.Fatalf("expected passthrough upstream_stream_error, started=%v capture=%+v", started, errorCapture)
+	}
+	if errorRec.Body.Len() != 0 {
+		t.Fatalf("pre-output error leaked downstream: %q", errorRec.Body.String())
+	}
+}
+
+func TestResponsesStreamPreOutputDispositionForLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want responsesPreOutputDisposition
+	}{
+		{name: "event field", line: "event: response.created\n", want: responsesPreOutputDefer},
+		{name: "created", line: "data: {\"type\":\"response.created\"}\n", want: responsesPreOutputDefer},
+		{name: "in progress", line: "data: {\"type\":\"response.in_progress\"}\n", want: responsesPreOutputDefer},
+		{name: "queued", line: "data: {\"type\":\"response.queued\"}\n", want: responsesPreOutputDefer},
+		{name: "keepalive", line: "data: {\"type\":\"keepalive\"}\n", want: responsesPreOutputDefer},
+		{name: "ping", line: "data: {\"type\":\"ping\"}\n", want: responsesPreOutputDefer},
+		{name: "empty message item", line: "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"content\":[]}}\n", want: responsesPreOutputDefer},
+		{name: "empty content part", line: "data: {\"type\":\"response.content_part.added\",\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n", want: responsesPreOutputDefer},
+		{name: "function item without arguments", line: "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"name\":\"lookup\",\"arguments\":\"\"}}\n", want: responsesPreOutputDefer},
+		{name: "empty image item", line: "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"ig_1\",\"type\":\"image_generation_call\",\"status\":\"in_progress\"}}\n", want: responsesPreOutputDefer},
+		{name: "image item with result", line: "data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"ig_1\",\"type\":\"image_generation_call\",\"status\":\"completed\",\"result\":\"aW1hZ2U=\"}}\n", want: responsesPreOutputCommit},
+		{name: "empty text delta", line: "data: {\"type\":\"response.output_text.delta\",\"delta\":\"\"}\n", want: responsesPreOutputDefer},
+		{name: "message item with text", line: "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello\"}]}}\n", want: responsesPreOutputCommit},
+		{name: "function item with arguments", line: "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"arguments\":\"{}\"}}\n", want: responsesPreOutputCommit},
+		{name: "unknown advanced event", line: "data: {\"type\":\"response.approval_request.created\",\"approval_id\":\"approval_1\"}\n", want: responsesPreOutputCommit},
+		{name: "failed", line: "data: {\"type\":\"response.failed\",\"error\":{\"code\":\"server_is_overloaded\"}}\n", want: responsesPreOutputFail},
+		{name: "error", line: "data: {\"type\":\"response.error\",\"error\":{\"code\":\"upstream_error\"}}\n", want: responsesPreOutputFail},
+		{name: "generic error", line: "data: {\"type\":\"error\",\"error\":{\"code\":\"upstream_error\"}}\n", want: responsesPreOutputFail},
+		{name: "business output", line: "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n", want: responsesPreOutputCommit},
+		{name: "completed", line: "data: {\"type\":\"response.completed\"}\n", want: responsesPreOutputCommit},
+		{name: "done", line: "data: [DONE]\n", want: responsesPreOutputCommit},
+		{name: "malformed data", line: "data: {invalid\n", want: responsesPreOutputCommit},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, _ := responsesStreamPreOutputDispositionForLine([]byte(test.line))
+			if got != test.want {
+				t.Fatalf("disposition = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestProxyResponsesStreamPassthroughDefersEmptyOutputContainersForFailover(t *testing.T) {
+	t.Parallel()
+
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t,
+		gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_empty_item"}}`)+
+			gatewaySSEEvent("response.output_item.added", `{"type":"response.output_item.added","item":{"id":"msg_empty","type":"message","status":"in_progress","content":[]}}`)+
+			gatewaySSEEvent("response.content_part.added", `{"type":"response.content_part.added","part":{"type":"output_text","text":""}}`)+
+			gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`),
+	)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if started || capture.endReason != "upstream_stream_error" || capture.semanticFailure == nil {
+		t.Fatalf("expected empty containers to preserve failover, started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("empty output containers leaked downstream: %q", rec.Body.String())
+	}
+}
+
+func TestProxyResponsesStreamPassthroughRejectsOversizedPreOutputWithoutStartingResponse(t *testing.T) {
+	t.Parallel()
+
+	instructions := strings.Repeat("x", 1<<20)
+	var body strings.Builder
+	for body.Len() <= responsesPreOutputMaxBytes {
+		body.WriteString(gatewaySSEEvent("response.created", `{"type":"response.created","response":{"instructions":"`+instructions+`"}}`))
+	}
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t, body.String())
+	if !errors.Is(err, errResponsesPreOutputTooLarge) {
+		t.Fatalf("error = %v, want pre-output size failure", err)
+	}
+	if started || capture.endReason != "upstream_stream_preoutput_too_large" {
+		t.Fatalf("oversized pre-output started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("oversized pre-output leaked downstream: %d bytes", rec.Body.Len())
 	}
 }
 
@@ -435,6 +522,44 @@ func TestProxyResponsesStreamPassthroughDefersPreOutputOverloadForFailover(t *te
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("pre-output overload leaked downstream: %q", rec.Body.String())
+	}
+}
+
+func TestProxyResponsesStreamPassthroughDefersLargePreOutputOverloadForFailover(t *testing.T) {
+	t.Parallel()
+
+	instructions := strings.Repeat("x", 70<<10)
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t,
+		gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded","instructions":"`+instructions+`"}}`)+
+			gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`),
+	)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if started || capture.endReason != "upstream_stream_error" || capture.firstByteLatency != 0 {
+		t.Fatalf("expected unstarted large upstream stream error, started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("large pre-output overload leaked downstream: %d bytes", rec.Body.Len())
+	}
+}
+
+func TestProxyResponsesStreamPassthroughCommitsLargeLifecycleEventOnBusinessOutput(t *testing.T) {
+	t.Parallel()
+
+	instructions := strings.Repeat("x", 70<<10)
+	body := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_started","instructions":"`+instructions+`"}}`) +
+		gatewaySSEEvent("response.output_text.delta", `{"type":"response.output_text.delta","item_id":"msg_started","delta":"hello"}`) +
+		gatewaySSEEvent("response.completed", `{"type":"response.completed","response":{"id":"resp_started","output":[]}}`)
+	rec, capture, started, err := proxyResponsesStreamPassthroughTest(t, body)
+	if err != nil {
+		t.Fatalf("proxyResponsesStreamPassthrough returned error: %v", err)
+	}
+	if !started || !capture.streamCompleted || capture.endReason != "done" {
+		t.Fatalf("expected completed large lifecycle stream, started=%v capture=%+v", started, capture)
+	}
+	if rec.Body.String() != body {
+		t.Fatalf("passthrough body length = %d, want %d", rec.Body.Len(), len(body))
 	}
 }
 
@@ -481,7 +606,8 @@ func TestProxyResponsesStreamPassthroughKeepsFailoverAvailableAfterDownstreamHea
 	defer cancel()
 
 	waitForStreamBody(t, recorder, ": xlyra-keepalive\n\n")
-	overloadedBody := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded"}}`) +
+	instructions := strings.Repeat("x", 70<<10)
+	overloadedBody := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded","instructions":"`+instructions+`"}}`) +
 		gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded"}}}`)
 	capture, started, err := proxyResponsesStreamPassthrough(ctx, session, gatewayStreamTestResponse(overloadedBody), time.Now())
 	if err != nil {

--- a/server/internal/gateway/protocol_responses_downstream.go
+++ b/server/internal/gateway/protocol_responses_downstream.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +16,20 @@ import (
 
 var synthesizedResponseCounter uint64
 
-const responsesPreOutputBufferLimit = 64 << 10
+const (
+	responsesPreOutputMaxBytes = 16 << 20
+	responsesPreOutputMaxLine  = 32 << 20
+)
+
+var errResponsesPreOutputTooLarge = errors.New("responses pre-output stream exceeded the buffering limit")
+
+type responsesPreOutputDisposition uint8
+
+const (
+	responsesPreOutputDefer responsesPreOutputDisposition = iota
+	responsesPreOutputCommit
+	responsesPreOutputFail
+)
 
 type chatChoice struct {
 	Index        int         `json:"index"`
@@ -90,13 +104,6 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 	}
 	writeLine := func(line []byte) error {
 		if !headersWritten {
-			if preOutput.Len()+len(line) > responsesPreOutputBufferLimit || responsesStreamPreOutputCommits(line) {
-				if err := commitPreOutput(); err != nil {
-					return err
-				}
-			}
-		}
-		if !headersWritten {
 			_, err := preOutput.Write(line)
 			return err
 		}
@@ -111,14 +118,43 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 			capture.endReason = "downstream_client_cancelled"
 			return capture, headersWritten, err
 		}
-		line, err := reader.ReadBytes('\n')
+		var line []byte
+		var err error
+		if headersWritten {
+			line, err = reader.ReadBytes('\n')
+		} else {
+			line, err = readResponsesPreOutputLine(reader)
+			if errors.Is(err, errResponsesPreOutputTooLarge) {
+				capture.endReason = "upstream_stream_preoutput_too_large"
+				return capture, false, err
+			}
+		}
 		if len(line) > 0 {
 			if normalizedLine, changed := normalizeResponsesStreamDataLine(line); changed {
 				line = normalizedLine
 			}
-			if !headersWritten && responsesStreamPreOutputOverloaded(line) {
-				inspectResponsesStreamLine(line, &capture)
-				return capture, false, nil
+			if !headersWritten {
+				disposition, failure := responsesStreamPreOutputDispositionForLine(line)
+				switch disposition {
+				case responsesPreOutputFail:
+					inspectResponsesStreamLine(line, &capture)
+					if capture.endReason == "" {
+						capture.endReason = "upstream_stream_error"
+						capture.errorDetail = truncatedStreamErrorDetail(string(failure.Body))
+					}
+					capture.semanticFailure = failure
+					return capture, false, nil
+				case responsesPreOutputCommit:
+					if commitErr := commitPreOutput(); commitErr != nil {
+						capture.endReason = "downstream_stream_write_failed"
+						return capture, headersWritten, commitErr
+					}
+				case responsesPreOutputDefer:
+					if preOutput.Len()+len(line) > responsesPreOutputMaxBytes {
+						capture.endReason = "upstream_stream_preoutput_too_large"
+						return capture, false, errResponsesPreOutputTooLarge
+					}
+				}
 			}
 			if writeErr := writeLine(line); writeErr != nil {
 				capture.endReason = "downstream_stream_write_failed"
@@ -156,35 +192,141 @@ func proxyResponsesStreamPassthrough(ctx context.Context, w http.ResponseWriter,
 	}
 }
 
-func responsesStreamPreOutputOverloaded(line []byte) bool {
-	data, done, ok := sseDataFromLine(line)
-	if !ok || done {
-		return false
+func readResponsesPreOutputLine(reader *bufio.Reader) ([]byte, error) {
+	line := make([]byte, 0, reader.Size())
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(line)+len(fragment) > responsesPreOutputMaxLine {
+			return nil, errResponsesPreOutputTooLarge
+		}
+		line = append(line, fragment...)
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return line, err
 	}
-	failure, ok := semanticFailureFromJSON([]byte(data))
-	return ok && strings.EqualFold(strings.TrimSpace(failure.Code), "server_is_overloaded")
 }
 
-func responsesStreamPreOutputCommits(line []byte) bool {
+func responsesStreamPreOutputDispositionForLine(line []byte) (responsesPreOutputDisposition, *upstreamSemanticFailure) {
 	data, done, ok := sseDataFromLine(line)
+	if !ok {
+		return responsesPreOutputDefer, nil
+	}
+	if done {
+		return responsesPreOutputCommit, nil
+	}
+	if strings.TrimSpace(data) == "" {
+		return responsesPreOutputDefer, nil
+	}
+	if failure, failed := semanticFailureFromJSON([]byte(data)); failed {
+		return responsesPreOutputFail, failure
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
+		return responsesPreOutputCommit, nil
+	}
+	eventType := strings.ToLower(strings.TrimSpace(anyString(event["type"])))
+	switch eventType {
+	case "response.created", "response.in_progress", "response.queued", "keepalive", "ping":
+		return responsesPreOutputDefer, nil
+	case "response.completed", "response.incomplete":
+		return responsesPreOutputCommit, nil
+	case "response.output_item.added", "response.output_item.done":
+		if responsesOutputItemStartsBusiness(event["item"]) {
+			return responsesPreOutputCommit, nil
+		}
+		return responsesPreOutputDefer, nil
+	case "response.content_part.added", "response.content_part.done":
+		if responsesContentPartStartsBusiness(event["part"]) || responsesContentPartStartsBusiness(event["content_part"]) {
+			return responsesPreOutputCommit, nil
+		}
+		return responsesPreOutputDefer, nil
+	case "response.image_generation_call.in_progress", "response.image_generation_call.generating", "response.mcp_call.in_progress", "response.tool_call.started":
+		return responsesPreOutputDefer, nil
+	case "response.output_text.delta", "response.output_text.done", "response.refusal.delta", "response.refusal.done",
+		"response.reasoning_summary_text.delta", "response.reasoning_text.delta", "response.reasoning_delta", "response.reasoning_summary.delta",
+		"response.reasoning.encrypted_content.delta", "response.reasoning.encrypted_content.done", "response.function_call_arguments.delta",
+		"response.function_call_arguments.done", "response.output_text.annotation.added":
+		if responsesEventHasBusinessOutput(event) {
+			return responsesPreOutputCommit, nil
+		}
+		return responsesPreOutputDefer, nil
+	default:
+		return responsesPreOutputCommit, nil
+	}
+}
+
+func responsesOutputItemStartsBusiness(value any) bool {
+	object, ok := value.(map[string]any)
 	if !ok {
 		return false
 	}
-	if done {
-		return true
-	}
-	if strings.TrimSpace(data) == "" {
-		return false
-	}
-	var event responsesStreamEvent
-	if err := json.Unmarshal([]byte(data), &event); err != nil {
-		return true
-	}
-	switch strings.ToLower(strings.TrimSpace(event.Type)) {
-	case "response.created", "response.in_progress", "response.queued", "keepalive", "ping":
+	switch strings.ToLower(strings.TrimSpace(anyString(object["type"]))) {
+	case "", "message":
+		content, _ := object["content"].([]any)
+		for _, item := range content {
+			if responsesContentPartStartsBusiness(item) {
+				return true
+			}
+		}
+		return responsesEventHasBusinessOutput(object)
+	case "function_call", "custom_tool_call":
+		for _, key := range []string{"arguments", "input"} {
+			if responsesBusinessValuePresent(object[key]) {
+				return true
+			}
+		}
 		return false
 	default:
-		return true
+		return responsesObjectHasNonStructuralPayload(object)
+	}
+}
+
+func responsesContentPartStartsBusiness(value any) bool {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(anyString(object["type"]))) {
+	case "", "output_text", "refusal", "text":
+		return responsesEventHasBusinessOutput(object)
+	default:
+		return responsesObjectHasNonStructuralPayload(object)
+	}
+}
+
+func responsesObjectHasNonStructuralPayload(object map[string]any) bool {
+	for key, value := range object {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "type", "id", "status", "role", "call_id", "name", "index", "output_index", "content_index", "item_id", "sequence_number":
+			continue
+		}
+		if responsesBusinessValuePresent(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func responsesEventHasBusinessOutput(object map[string]any) bool {
+	for _, key := range []string{"text", "refusal", "delta", "arguments", "result", "partial_image_b64", "stdout", "input", "output", "annotation", "patch", "command", "query", "encrypted_content"} {
+		if responsesBusinessValuePresent(object[key]) {
+			return true
+		}
+	}
+	return false
+}
+
+func responsesBusinessValuePresent(value any) bool {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return value != nil
 	}
 }
 

--- a/server/internal/gateway/recording_metadata.go
+++ b/server/internal/gateway/recording_metadata.go
@@ -229,7 +229,7 @@ func streamFailureScope(endReason string) any {
 		return nil
 	case "downstream_client_cancelled", "downstream_stream_write_failed":
 		return "downstream"
-	case "upstream_stream_error", "tool_call_arguments_invalid_json", "upstream_stream_read_failed", "upstream_stream_parse_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_empty", "upstream_stream_missing_body":
+	case "upstream_stream_error", "tool_call_arguments_invalid_json", "upstream_stream_read_failed", "upstream_stream_parse_failed", "upstream_stream_incomplete", "upstream_stream_eof", "upstream_stream_empty", "upstream_stream_missing_body", "upstream_stream_preoutput_too_large":
 		return "upstream"
 	default:
 		return nil

--- a/server/internal/gateway/recording_metadata_test.go
+++ b/server/internal/gateway/recording_metadata_test.go
@@ -417,6 +417,9 @@ func TestStreamFailureScopeClassifiesDownstreamAndUnknownReasons(t *testing.T) {
 	if got := streamFailureScope("upstream_stream_error"); got != "upstream" {
 		t.Fatalf("upstream stream error scope = %#v, want upstream", got)
 	}
+	if got := streamFailureScope("upstream_stream_preoutput_too_large"); got != "upstream" {
+		t.Fatalf("pre-output limit scope = %#v, want upstream", got)
+	}
 	if got := streamFailureScope("unexpected_reason"); got != nil {
 		t.Fatalf("unexpected stream end reason scope = %#v, want nil", got)
 	}

--- a/server/internal/gateway/semantic_failure.go
+++ b/server/internal/gateway/semantic_failure.go
@@ -71,3 +71,16 @@ func semanticFailureDetails(value any) (string, string) {
 		return "", ""
 	}
 }
+
+func semanticFailureClassificationBody(failure *upstreamSemanticFailure) []byte {
+	if failure == nil {
+		return nil
+	}
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"code":    failure.Code,
+			"message": failure.Message,
+		},
+	})
+	return body
+}

--- a/server/internal/gateway/semantic_failure_test.go
+++ b/server/internal/gateway/semantic_failure_test.go
@@ -34,6 +34,19 @@ func TestSemanticFailureFromJSONRecognizesTopLevelErrorEnvelope(t *testing.T) {
 	}
 }
 
+func TestSemanticFailureClassificationBodyFlattensNestedResponsesError(t *testing.T) {
+	t.Parallel()
+
+	failure, ok := semanticFailureFromJSON([]byte(`{"type":"response.failed","response":{"status":"failed","error":{"code":"invalid_api_key","message":"credential rejected"}}}`))
+	if !ok {
+		t.Fatal("expected semantic failure")
+	}
+	flattened, ok := semanticFailureFromJSON(semanticFailureClassificationBody(failure))
+	if !ok || flattened.Code != "invalid_api_key" || flattened.Message != "credential rejected" {
+		t.Fatalf("flattened failure = %#v, ok=%v", flattened, ok)
+	}
+}
+
 func TestSemanticFailureFromJSONIgnoresFailedOutputItem(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/gateway/soft_mapping_test.go
+++ b/server/internal/gateway/soft_mapping_test.go
@@ -75,6 +75,7 @@ type softMappingHarness struct {
 	requestLogs                 []store.RequestLog
 	semanticFailurePaths        map[string]bool
 	preOutputOverloadStreamPath map[string]bool
+	preOutputOversizeStreamPath map[string]bool
 
 	apiKey          store.APIKey
 	canonicalModels map[string]store.CanonicalModel
@@ -274,16 +275,36 @@ func softMappingUpstreamServer(t *testing.T, harness *softMappingHarness, failPr
 		if stream {
 			harness.mu.Lock()
 			overloaded := false
+			oversized := false
 			for prefix, enabled := range harness.preOutputOverloadStreamPath {
 				if enabled && strings.HasPrefix(r.URL.Path, prefix) {
 					overloaded = true
 					break
 				}
 			}
+			for prefix, enabled := range harness.preOutputOversizeStreamPath {
+				if enabled && strings.HasPrefix(r.URL.Path, prefix) {
+					oversized = true
+					break
+				}
+			}
 			harness.mu.Unlock()
 			w.Header().Set("Content-Type", "text/event-stream")
+			if oversized {
+				instructions := strings.Repeat("x", 1<<20)
+				written := 0
+				for written <= responsesPreOutputMaxBytes {
+					event := gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_oversized","instructions":"`+instructions+`"}}`)
+					if _, err := w.Write([]byte(event)); err != nil {
+						return
+					}
+					written += len(event)
+				}
+				return
+			}
 			if overloaded {
-				_, _ = w.Write([]byte(gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded","model":"`+model+`"}}`)))
+				instructions := strings.Repeat("x", 70<<10)
+				_, _ = w.Write([]byte(gatewaySSEEvent("response.created", `{"type":"response.created","response":{"id":"resp_overloaded","model":"`+model+`","instructions":"`+instructions+`"}}`)))
 				_, _ = w.Write([]byte(gatewaySSEEvent("response.failed", `{"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"try again later"}}}`)))
 				return
 			}
@@ -559,6 +580,31 @@ func TestSoftMappingFailsOverAfterPreOutputResponsesOverloadWithoutLeakingIt(t *
 	models := fixture.harness.upstreamModels()
 	if len(models) != 2 || models[0] != "orig-upstream-model" || models[1] != "fallback-upstream-model" {
 		t.Fatalf("upstream models = %v, want original overload then fallback success", models)
+	}
+}
+
+func TestSoftMappingFailsOverAfterOversizedResponsesPreOutput(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSoftMappingFixture(t, `[{"pattern":"orig-model","target":"fallback-model","mode":"soft"}]`, true, 0)
+	fixture.harness.mu.Lock()
+	fixture.harness.preOutputOversizeStreamPath = map[string]bool{"/orig": true}
+	for index := range fixture.harness.siteModels {
+		fixture.harness.siteModels[index].Capabilities = store.JSON(`{"supported_endpoint_types":["openai-response"]}`)
+	}
+	fixture.harness.mu.Unlock()
+	recorder := fixture.doResponsesStream(t, "orig-model")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200 after pre-output size failover", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "resp_oversized") {
+		t.Fatalf("oversized pre-output leaked downstream: %s", recorder.Body.String())
+	}
+	assertGatewayBodyContainsAll(t, recorder.Body.String(), "response.output_text.delta", "soft-ok")
+	models := fixture.harness.upstreamModels()
+	if len(models) != 2 || models[0] != "orig-upstream-model" || models[1] != "fallback-upstream-model" {
+		t.Fatalf("upstream models = %v, want oversized original then fallback success", models)
 	}
 }
 

--- a/server/internal/gateway/stream_runtime.go
+++ b/server/internal/gateway/stream_runtime.go
@@ -17,6 +17,7 @@ type streamCaptureState struct {
 	streamCompleted  bool
 	endReason        string
 	errorDetail      string
+	semanticFailure  *upstreamSemanticFailure
 	firstByteLatency int64
 	malformedLines   int
 	annotations      []any


### PR DESCRIPTION
## 改动说明

修复 Responses SSE 在真正业务输出前遇到上游错误时无法自动 failover 的问题。

### 根因

原逻辑使用前置缓存大小作为“响应已经开始”的判定条件。较大的 `response.created` 会因为超过 64 KiB 而提前提交给下游，使后续的 `response.failed` 无法继续尝试下一个路由候选。同时，空输出容器和具体语义错误也缺少统一的前置判定与分类传递。

### 修复内容

- 统一按事件是否携带真实业务内容判定响应是否开始。
- 生命周期事件、心跳、空消息、空工具调用及空图片占位不会关闭 failover。
- 前置缓存采用有界资源保护；累计缓存或单行超限时终止当前候选并保持下游未开始，继续尝试下一路由。
- 保留流式语义错误的 code 和 message，复用现有凭据轮换、限流分类与冷却逻辑。
- 将前置资源超限纳入现有连续流失败冷却门槛。
- 移除原有 64 KiB 阈值提交与旧的双线判断。

### 影响

当上游返回较大的生命周期事件后再报告容量、限流或凭据错误时，网关能够在没有真实业务输出的情况下自动尝试后续凭据或路由候选，不再把中间错误暴露给下游。

### 验证

- `go test ./...`
- `go test -race ./internal/gateway -run '<关键 failover 用例>' -count=3`
- `govulncheck ./...`
- `git diff --check`
- ORM/手写 SQL 静态扫描
