### PR TITLE
fix: 修复 Grok Responses 跨协议参数兼容问题

### DIFF
--- a/server/internal/gateway/grok_responses_bridge.go
+++ b/server/internal/gateway/grok_responses_bridge.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,19 +17,29 @@ import (
 )
 
 type grokResponsesProtocolAdapter struct {
-	inner                   openAIResponsesProtocolAdapter
-	bridged                 map[string]struct{}
-	supportsReasoningEffort bool
+	inner            openAIResponsesProtocolAdapter
+	bridged          map[string]struct{}
+	reasoningEfforts map[string]struct{}
+	stopSequences    []string
 }
 
 func newGrokResponsesProtocolAdapter(request gatewayRequest, supportsReasoningEffort bool) *grokResponsesProtocolAdapter {
-	return &grokResponsesProtocolAdapter{
+	result := &grokResponsesProtocolAdapter{
 		inner: openAIResponsesProtocolAdapter{
 			includeUsage:       streamIncludeUsage(request.Payload),
 			downstreamProtocol: downstreamCanonicalProtocol(request.DownstreamPath),
 		},
-		supportsReasoningEffort: supportsReasoningEffort,
 	}
+	if supportsReasoningEffort {
+		result.reasoningEfforts = grokReasoningEffortSet([]string{"low", "medium", "high"})
+	}
+	return result
+}
+
+func newGrokResponsesProtocolAdapterWithReasoningEfforts(request gatewayRequest, efforts []string) *grokResponsesProtocolAdapter {
+	result := newGrokResponsesProtocolAdapter(request, len(efforts) > 0)
+	result.reasoningEfforts = grokReasoningEffortSet(efforts)
+	return result
 }
 
 func (a *grokResponsesProtocolAdapter) ProtocolName() string {
@@ -40,18 +51,463 @@ func (a *grokResponsesProtocolAdapter) UpstreamPath(baseURL string) string {
 }
 
 func (a *grokResponsesProtocolAdapter) BuildUpstreamPayload(request gatewayRequest, candidate routeengine.Candidate) (map[string]any, error) {
+	if params := a.incompatibleRequestParams(request); len(params) > 0 {
+		return nil, fmt.Errorf("Grok Responses cannot preserve request parameters: %s", strings.Join(params, ", "))
+	}
 	payload, err := a.inner.BuildUpstreamPayload(request, candidate)
 	if err != nil {
 		return nil, err
 	}
-	if request.DownstreamPath == gatewayEndpointResponses {
-		a.bridged = normalizeGrokResponsesPayload(payload)
-	}
-	if !a.supportsReasoningEffort {
+	a.stopSequences = grokRequestStopSequences(request)
+	normalizeGrokCanonicalPayload(payload, request, a.reasoningEfforts)
+	a.bridged = normalizeGrokResponsesPayload(payload)
+	delete(payload, "metadata")
+	delete(payload, "reasoning_effort")
+	if len(a.reasoningEfforts) == 0 {
 		delete(payload, "reasoning")
-		delete(payload, "reasoning_effort")
 	}
+	filterGrokResponsesRequestFields(payload)
 	return payload, nil
+}
+
+func (a *grokResponsesProtocolAdapter) incompatibleRequestParams(request gatewayRequest) []string {
+	params := grokIncompatibleRequestParams(request)
+	if len(a.reasoningEfforts) == 0 && grokRequestUsesReasoning(request) {
+		params = appendUniqueStrings(params, "reasoning")
+		sort.Strings(params)
+	}
+	return params
+}
+
+func normalizeGrokCanonicalPayload(payload map[string]any, request gatewayRequest, reasoningEfforts map[string]struct{}) {
+	normalizeGrokIdentity(payload)
+	canonical := request.Canonical
+	if canonical == nil {
+		return
+	}
+	normalizeGrokReasoningEffort(payload, canonical.Params, canonical.SourceProtocol, reasoningEfforts)
+	textFormat := canonical.TextFormat
+	if canonical.SourceProtocol == canonicalProtocolAnthropicMessages {
+		normalizeGrokAnthropicToolChoice(payload, canonical.Raw)
+		normalizeGrokAnthropicReasoning(payload, canonical.Params, reasoningEfforts)
+		if textFormat == nil {
+			if outputConfig, ok := canonical.Params["output_config"].(map[string]any); ok {
+				textFormat = outputConfig["format"]
+			}
+		}
+	}
+	normalizeGrokServiceTier(payload, canonical.SourceProtocol)
+	if textFormat != nil {
+		if _, exists := payload["text"]; !exists {
+			if text := grokResponsesTextFormat(textFormat); text != nil {
+				payload["text"] = text
+			}
+		}
+	}
+}
+
+func normalizeGrokReasoningEffort(payload map[string]any, params map[string]any, source canonicalProtocol, reasoningEfforts map[string]struct{}) {
+	if len(reasoningEfforts) == 0 {
+		return
+	}
+	effort := strings.ToLower(strings.TrimSpace(anyString(params["reasoning_effort"])))
+	if effort == "" {
+		if reasoning, ok := params["reasoning"].(map[string]any); ok {
+			effort = strings.ToLower(strings.TrimSpace(anyString(reasoning["effort"])))
+		}
+	}
+	if effort == "" {
+		return
+	}
+	effort = nearestGrokReasoningEffort(effort, reasoningEfforts)
+	if effort == "" {
+		return
+	}
+	if source == canonicalProtocolOpenAIResponses {
+		if existing, ok := payload["reasoning"].(map[string]any); ok {
+			preserved := clonePayload(existing)
+			preserved["effort"] = effort
+			payload["reasoning"] = preserved
+			return
+		}
+	}
+	payload["reasoning"] = map[string]any{"effort": effort, "summary": "detailed"}
+}
+
+func grokReasoningEffortSet(efforts []string) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, effort := range efforts {
+		effort = strings.ToLower(strings.TrimSpace(effort))
+		if effort != "" {
+			result[effort] = struct{}{}
+		}
+	}
+	return result
+}
+
+func nearestGrokReasoningEffort(requested string, supported map[string]struct{}) string {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	if _, ok := supported[requested]; ok {
+		return requested
+	}
+	levels := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	requestedIndex := len(levels) - 1
+	for index, level := range levels {
+		if level == requested {
+			requestedIndex = index
+			break
+		}
+	}
+	for index := requestedIndex; index >= 0; index-- {
+		if _, ok := supported[levels[index]]; ok {
+			return levels[index]
+		}
+	}
+	for index := requestedIndex + 1; index < len(levels); index++ {
+		if _, ok := supported[levels[index]]; ok {
+			return levels[index]
+		}
+	}
+	return ""
+}
+
+func normalizeGrokIdentity(payload map[string]any) {
+	if _, exists := payload["safety_identifier"]; !exists {
+		if user := strings.TrimSpace(anyString(payload["user"])); user != "" {
+			payload["safety_identifier"] = user
+		} else if metadata, ok := payload["metadata"].(map[string]any); ok {
+			if userID := strings.TrimSpace(anyString(metadata["user_id"])); userID != "" {
+				payload["safety_identifier"] = userID
+			}
+		}
+	}
+	delete(payload, "user")
+}
+
+func normalizeGrokServiceTier(payload map[string]any, source canonicalProtocol) {
+	tier := strings.ToLower(strings.TrimSpace(anyString(payload["service_tier"])))
+	if source == canonicalProtocolAnthropicMessages {
+		switch tier {
+		case "auto":
+			payload["service_tier"] = "priority"
+		case "standard_only":
+			payload["service_tier"] = "default"
+		}
+		return
+	}
+	switch tier {
+	case "auto", "standard":
+		payload["service_tier"] = "default"
+	case "fast":
+		payload["service_tier"] = "priority"
+	}
+}
+
+func normalizeGrokAnthropicToolChoice(payload map[string]any, raw map[string]any) {
+	choice, _ := raw["tool_choice"].(map[string]any)
+	if len(choice) == 0 {
+		return
+	}
+	choiceType := strings.ToLower(strings.TrimSpace(anyString(choice["type"])))
+	switch choiceType {
+	case "auto":
+		payload["tool_choice"] = "auto"
+	case "any":
+		payload["tool_choice"] = "required"
+	case "none":
+		payload["tool_choice"] = "none"
+	case "tool":
+		name := strings.TrimSpace(anyString(choice["name"]))
+		if name != "" {
+			payload["tool_choice"] = map[string]any{"type": "function", "name": name}
+		}
+	default:
+		return
+	}
+	if disabled, ok := choice["disable_parallel_tool_use"].(bool); ok && choiceType != "none" {
+		payload["parallel_tool_calls"] = !disabled
+	}
+}
+
+func normalizeGrokAnthropicReasoning(payload map[string]any, params map[string]any, reasoningEfforts map[string]struct{}) {
+	if len(reasoningEfforts) == 0 {
+		return
+	}
+	if outputConfig, ok := params["output_config"].(map[string]any); ok {
+		if effort := strings.ToLower(strings.TrimSpace(anyString(outputConfig["effort"]))); effort != "" {
+			effort = nearestGrokReasoningEffort(effort, reasoningEfforts)
+			if effort != "" {
+				payload["reasoning"] = map[string]any{"effort": effort, "summary": "detailed"}
+			}
+		}
+	}
+	thinking, ok := params["thinking"].(map[string]any)
+	if !ok {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(anyString(thinking["type"]))) {
+	case "disabled":
+		delete(payload, "reasoning")
+	case "enabled", "adaptive":
+		if _, exists := payload["reasoning"]; !exists {
+			if effort := nearestGrokReasoningEffort("high", reasoningEfforts); effort != "" {
+				payload["reasoning"] = map[string]any{"effort": effort, "summary": "detailed"}
+			}
+		}
+	}
+}
+
+func grokResponsesTextFormat(raw any) map[string]any {
+	format, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	typeName := strings.TrimSpace(anyString(format["type"]))
+	if typeName == "" {
+		return nil
+	}
+	result := map[string]any{"type": typeName}
+	for key, value := range format {
+		if key == "type" {
+			continue
+		}
+		if key == "json_schema" {
+			if nested, ok := value.(map[string]any); ok {
+				for nestedKey, nestedValue := range nested {
+					result[nestedKey] = nestedValue
+				}
+			}
+			continue
+		}
+		result[key] = value
+	}
+	if typeName == "json_schema" {
+		if strings.TrimSpace(anyString(result["name"])) == "" {
+			result["name"] = "response"
+		}
+		if _, ok := result["schema"]; !ok {
+			return nil
+		}
+	}
+	return map[string]any{"format": result}
+}
+
+var grokResponsesRequestFields = map[string]struct{}{
+	"background":             {},
+	"conversation":           {},
+	"include":                {},
+	"input":                  {},
+	"instructions":           {},
+	"max_output_tokens":      {},
+	"max_tool_calls":         {},
+	"model":                  {},
+	"parallel_tool_calls":    {},
+	"previous_response_id":   {},
+	"prompt":                 {},
+	"prompt_cache_retention": {},
+	"reasoning":              {},
+	"safety_identifier":      {},
+	"service_tier":           {},
+	"store":                  {},
+	"stream":                 {},
+	"stream_options":         {},
+	"temperature":            {},
+	"text":                   {},
+	"tool_choice":            {},
+	"tools":                  {},
+	"top_p":                  {},
+	"truncation":             {},
+}
+
+var grokCompatibleParamsByProtocol = map[canonicalProtocol]map[string]struct{}{
+	canonicalProtocolOpenAIResponses: {
+		"background": {}, "conversation": {}, "include": {}, "max_output_tokens": {}, "max_tool_calls": {},
+		"metadata": {}, "parallel_tool_calls": {}, "previous_response_id": {}, "prompt": {},
+		"prompt_cache_retention": {}, "reasoning": {}, "reasoning_effort": {}, "response_format": {}, "safety_identifier": {},
+		"service_tier": {}, "store": {}, "stream": {}, "stream_options": {}, "temperature": {}, "text": {},
+		"top_p": {}, "truncation": {}, "user": {},
+	},
+	canonicalProtocolOpenAIChat: {
+		"max_completion_tokens": {}, "max_tokens": {}, "parallel_tool_calls": {}, "reasoning_effort": {},
+		"response_format": {}, "service_tier": {}, "stop": {}, "store": {}, "stream": {},
+		"stream_options": {}, "temperature": {}, "top_p": {}, "user": {},
+	},
+	canonicalProtocolAnthropicMessages: {
+		"max_output_tokens": {}, "metadata": {}, "output_config": {}, "service_tier": {},
+		"stop_sequences": {}, "stream": {}, "temperature": {}, "thinking": {}, "top_p": {},
+	},
+}
+
+func filterGrokResponsesRequestFields(payload map[string]any) {
+	for key := range payload {
+		if _, ok := grokResponsesRequestFields[key]; !ok {
+			delete(payload, key)
+		}
+	}
+}
+
+func grokRequestUsesReasoning(request gatewayRequest) bool {
+	if request.Canonical == nil {
+		return false
+	}
+	params := request.Canonical.Params
+	if strings.TrimSpace(anyString(params["reasoning_effort"])) != "" {
+		return true
+	}
+	if reasoning, ok := params["reasoning"].(map[string]any); ok && len(reasoning) > 0 {
+		return true
+	}
+	if thinking, ok := params["thinking"].(map[string]any); ok {
+		typeName := strings.ToLower(strings.TrimSpace(anyString(thinking["type"])))
+		if typeName == "enabled" || typeName == "adaptive" {
+			return true
+		}
+	}
+	if outputConfig, ok := params["output_config"].(map[string]any); ok {
+		return strings.TrimSpace(anyString(outputConfig["effort"])) != ""
+	}
+	return false
+}
+
+func grokIncompatibleRequestParams(request gatewayRequest) []string {
+	if request.Canonical == nil {
+		return nil
+	}
+	canonical := request.Canonical
+	switch canonical.SourceProtocol {
+	case canonicalProtocolOpenAIResponses, canonicalProtocolOpenAIChat, canonicalProtocolAnthropicMessages:
+	default:
+		return nil
+	}
+	incompatible := make([]string, 0)
+	seen := map[string]struct{}{}
+	add := func(value string) {
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		incompatible = append(incompatible, value)
+	}
+	compatible := grokCompatibleParamsByProtocol[canonical.SourceProtocol]
+	for key, value := range canonical.Params {
+		if value == nil {
+			continue
+		}
+		if _, ok := compatible[key]; !ok {
+			add(key)
+		}
+	}
+	for _, message := range canonical.Messages {
+		if len(message.Thinking) > 0 {
+			add("thinking_history")
+		}
+		for _, part := range message.Content {
+			if part.CacheControl != nil {
+				add("cache_control")
+			}
+		}
+	}
+	if canonical.SourceProtocol == canonicalProtocolOpenAIResponses {
+		if input, ok := request.Payload["input"].([]any); ok {
+			for _, raw := range input {
+				item, _ := raw.(map[string]any)
+				if strings.EqualFold(strings.TrimSpace(anyString(item["type"])), "reasoning") {
+					add("reasoning_history")
+				}
+			}
+		}
+		if metadata, ok := request.Payload["metadata"].(map[string]any); ok {
+			for key := range metadata {
+				if key != "user_id" {
+					add("metadata." + key)
+				}
+			}
+		}
+		if include, ok := request.Payload["include"].([]any); ok {
+			for _, item := range include {
+				if strings.Contains(strings.ToLower(anyString(item)), "reasoning.encrypted_content") {
+					add("include.reasoning.encrypted_content")
+				}
+			}
+		}
+		if reasoning, ok := request.Payload["reasoning"].(map[string]any); ok {
+			for key := range reasoning {
+				if key != "effort" && key != "summary" {
+					add("reasoning." + key)
+				}
+			}
+		}
+	}
+	tier := strings.ToLower(strings.TrimSpace(anyString(canonical.Params["service_tier"])))
+	if tier != "" {
+		allowed := map[string]struct{}{"default": {}, "priority": {}}
+		if canonical.SourceProtocol == canonicalProtocolAnthropicMessages {
+			allowed["auto"] = struct{}{}
+			allowed["standard_only"] = struct{}{}
+		} else {
+			allowed["auto"] = struct{}{}
+			allowed["standard"] = struct{}{}
+			allowed["fast"] = struct{}{}
+		}
+		if _, ok := allowed[tier]; !ok {
+			add("service_tier")
+		}
+	}
+	if format := grokRequestTextFormat(canonical); format != nil {
+		typeName := strings.ToLower(strings.TrimSpace(anyString(format["type"])))
+		if typeName != "" && typeName != "text" && typeName != "json_object" && typeName != "json_schema" {
+			add("text.format.type")
+		}
+	}
+	sort.Strings(incompatible)
+	return incompatible
+}
+
+func grokRequestTextFormat(request *canonicalRequest) map[string]any {
+	if request == nil {
+		return nil
+	}
+	if format, ok := request.TextFormat.(map[string]any); ok {
+		return format
+	}
+	if outputConfig, ok := request.Params["output_config"].(map[string]any); ok {
+		format, _ := outputConfig["format"].(map[string]any)
+		return format
+	}
+	return nil
+}
+
+func grokRequestStopSequences(request gatewayRequest) []string {
+	if request.Canonical == nil {
+		return nil
+	}
+	values := make([]any, 0)
+	for _, key := range []string{"stop_sequences", "stop"} {
+		switch value := request.Canonical.Params[key].(type) {
+		case string:
+			values = append(values, value)
+		case []any:
+			values = append(values, value...)
+		case []string:
+			for _, item := range value {
+				values = append(values, item)
+			}
+		}
+	}
+	result := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		stop := anyString(value)
+		if stop == "" {
+			continue
+		}
+		if _, ok := seen[stop]; ok {
+			continue
+		}
+		seen[stop] = struct{}{}
+		result = append(result, stop)
+	}
+	return result
 }
 
 func (a *grokResponsesProtocolAdapter) TransformBufferedResponse(statusCode int, headers http.Header, body []byte) (gatewayBufferedResponse, error) {
@@ -62,6 +518,9 @@ func (a *grokResponsesProtocolAdapter) TransformBufferedResponse(statusCode int,
 	if len(a.bridged) > 0 && response.StatusCode >= 200 && response.StatusCode < 300 && a.inner.downstreamProtocol == canonicalProtocolOpenAIResponses {
 		response.Body = rewriteGrokBufferedResponsesBody(response.Body, a.bridged)
 	}
+	if len(a.stopSequences) > 0 && response.StatusCode >= 200 && response.StatusCode < 300 {
+		response.Body = applyGrokBufferedStopSequences(response.Body, a.inner.downstreamProtocol, a.stopSequences)
+	}
 	return response, nil
 }
 
@@ -69,7 +528,97 @@ func (a *grokResponsesProtocolAdapter) ProxyStream(ctx context.Context, w http.R
 	if len(a.bridged) > 0 && a.inner.downstreamProtocol == canonicalProtocolOpenAIResponses {
 		return proxyGrokResponsesStreamBridged(ctx, w, resp, startedAt, a.bridged)
 	}
+	if len(a.stopSequences) > 0 && a.inner.downstreamProtocol != canonicalProtocolOpenAIResponses {
+		target := a.inner.downstreamProtocol
+		if target == "" {
+			target = canonicalProtocolOpenAIChat
+		}
+		return proxyCanonicalStream(ctx, w, resp, startedAt, canonicalProtocolOpenAIResponses, target, canonicalStreamOptions{
+			IncludeUsage:  a.inner.includeUsage,
+			Candidate:     candidate,
+			StopSequences: a.stopSequences,
+		})
+	}
 	return a.inner.ProxyStream(ctx, w, resp, startedAt, candidate)
+}
+
+func applyGrokBufferedStopSequences(body []byte, protocol canonicalProtocol, stopSequences []string) []byte {
+	var payload map[string]any
+	if len(stopSequences) == 0 || json.Unmarshal(body, &payload) != nil {
+		return body
+	}
+	changed := false
+	switch protocol {
+	case canonicalProtocolAnthropicMessages:
+		content, _ := payload["content"].([]any)
+		for index, raw := range content {
+			block, _ := raw.(map[string]any)
+			if anyString(block["type"]) != "text" {
+				continue
+			}
+			text, stop, matched := truncateAtStopSequence(anyStringRaw(block["text"]), stopSequences)
+			if !matched {
+				continue
+			}
+			block["text"] = text
+			payload["content"] = content[:index+1]
+			payload["stop_reason"] = "stop_sequence"
+			payload["stop_sequence"] = stop
+			changed = true
+			break
+		}
+	case canonicalProtocolOpenAIChat, "":
+		choices, _ := payload["choices"].([]any)
+		for _, raw := range choices {
+			choice, _ := raw.(map[string]any)
+			message, _ := choice["message"].(map[string]any)
+			text, _, matched := truncateAtStopSequence(anyStringRaw(message["content"]), stopSequences)
+			if !matched {
+				continue
+			}
+			message["content"] = text
+			delete(message, "tool_calls")
+			choice["finish_reason"] = "stop"
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return encoded
+}
+
+func truncateAtStopSequence(text string, stopSequences []string) (string, string, bool) {
+	runes := []rune(text)
+	matchIndex := -1
+	matched := ""
+	for _, stop := range stopSequences {
+		sequence := []rune(stop)
+		if len(sequence) == 0 || len(sequence) > len(runes) {
+			continue
+		}
+		for index := 0; index+len(sequence) <= len(runes); index++ {
+			equal := true
+			for offset := range sequence {
+				if runes[index+offset] != sequence[offset] {
+					equal = false
+					break
+				}
+			}
+			if equal && (matchIndex < 0 || index < matchIndex) {
+				matchIndex = index
+				matched = stop
+			}
+		}
+	}
+	if matchIndex < 0 {
+		return text, "", false
+	}
+	return string(runes[:matchIndex]), matched, true
 }
 
 type grokImagesProtocolAdapter struct {

--- a/server/internal/gateway/grok_test.go
+++ b/server/internal/gateway/grok_test.go
@@ -1,7 +1,10 @@
 package gateway
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -65,6 +68,457 @@ func TestGrokResponsesProtocolUsesOfficialCLIHost(t *testing.T) {
 	protocol := newGrokResponsesProtocolAdapter(gatewayRequest{DownstreamPath: gatewayEndpointResponses}, false)
 	if got := protocol.UpstreamPath("https://untrusted.example"); got != adapter.GrokChatBaseURL+gatewayEndpointResponses {
 		t.Fatalf("responses path = %q", got)
+	}
+}
+
+func TestGrokResponsesProtocolStripsMetadataFromMessagesRequest(t *testing.T) {
+	payload := map[string]any{
+		"model":      "grok-4.5",
+		"max_tokens": 128,
+		"metadata":   map[string]any{"user_id": "user-1"},
+		"messages":   []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromAnthropicMessagesPayload returned error: %v", err)
+	}
+	request := gatewayRequest{
+		DownstreamPath: gatewayEndpointMessages,
+		Payload:        payload,
+		Canonical:      &canonical,
+	}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+		Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	if _, ok := upstream["metadata"]; ok {
+		t.Fatalf("metadata not stripped: %#v", upstream["metadata"])
+	}
+	if upstream["safety_identifier"] != "user-1" {
+		t.Fatalf("safety_identifier = %#v, want user-1", upstream["safety_identifier"])
+	}
+	if upstream["model"] != "grok-4.5" || upstream["max_output_tokens"] != 128 {
+		t.Fatalf("unexpected converted payload: %#v", upstream)
+	}
+}
+
+func TestGrokResponsesProtocolMapsOpenAIUserIdentity(t *testing.T) {
+	payload := map[string]any{
+		"model":            "grok-4.5",
+		"user":             "user-2",
+		"input":            "hello",
+		"reasoning_effort": "medium",
+	}
+	canonical, err := canonicalRequestFromOpenAIResponsesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromOpenAIResponsesPayload returned error: %v", err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointResponses, Payload: payload, Canonical: &canonical}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+		Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	if _, ok := upstream["user"]; ok {
+		t.Fatalf("user not converted: %#v", upstream["user"])
+	}
+	if upstream["safety_identifier"] != "user-2" {
+		t.Fatalf("safety_identifier = %#v, want user-2", upstream["safety_identifier"])
+	}
+	if _, ok := upstream["reasoning_effort"]; ok {
+		t.Fatalf("reasoning_effort scalar not converted: %#v", upstream["reasoning_effort"])
+	}
+	if reasoning, ok := upstream["reasoning"].(map[string]any); !ok || reasoning["effort"] != "medium" {
+		t.Fatalf("reasoning = %#v, want medium effort", upstream["reasoning"])
+	}
+}
+
+func TestGrokResponsesProtocolMapsOpenAIChatStructuredOutput(t *testing.T) {
+	payload := map[string]any{
+		"model":            "grok-4.5",
+		"reasoning_effort": "medium",
+		"messages": []any{map[string]any{
+			"role":    "user",
+			"content": "hello",
+		}},
+		"response_format": map[string]any{
+			"type": "json_schema",
+			"json_schema": map[string]any{
+				"name":   "answer",
+				"schema": map[string]any{"type": "object"},
+			},
+		},
+	}
+	canonical, err := canonicalRequestFromOpenAIChatPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromOpenAIChatPayload returned error: %v", err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointChatCompletions, Payload: payload, Canonical: &canonical}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+		Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	text, ok := upstream["text"].(map[string]any)
+	if !ok {
+		t.Fatalf("text = %#v", upstream["text"])
+	}
+	format, ok := text["format"].(map[string]any)
+	if !ok || format["type"] != "json_schema" || format["name"] != "answer" || format["schema"] == nil {
+		t.Fatalf("text.format = %#v", text["format"])
+	}
+	reasoning, ok := upstream["reasoning"].(map[string]any)
+	if !ok || reasoning["effort"] != "medium" {
+		t.Fatalf("reasoning = %#v, want medium effort", upstream["reasoning"])
+	}
+}
+
+func TestGrokResponsesProtocolMapsAnthropicToolChoice(t *testing.T) {
+	tests := []struct {
+		name            string
+		choice          map[string]any
+		wantChoice      any
+		wantParallel    any
+		wantParallelSet bool
+	}{
+		{name: "auto", choice: map[string]any{"type": "auto", "disable_parallel_tool_use": false}, wantChoice: "auto", wantParallel: true, wantParallelSet: true},
+		{name: "any", choice: map[string]any{"type": "any", "disable_parallel_tool_use": true}, wantChoice: "required", wantParallel: false, wantParallelSet: true},
+		{name: "none", choice: map[string]any{"type": "none"}, wantChoice: "none"},
+		{name: "tool", choice: map[string]any{"type": "tool", "name": "lookup", "disable_parallel_tool_use": true}, wantChoice: map[string]any{"type": "function", "name": "lookup"}, wantParallel: false, wantParallelSet: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]any{
+				"model":      "grok-4.5",
+				"max_tokens": 128,
+				"messages":   []any{map[string]any{"role": "user", "content": "hello"}},
+				"tools": []any{map[string]any{
+					"name":         "lookup",
+					"description":  "Lookup a value",
+					"input_schema": map[string]any{"type": "object"},
+				}},
+				"tool_choice": tc.choice,
+			}
+			canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+			if err != nil {
+				t.Fatalf("canonicalRequestFromAnthropicMessagesPayload returned error: %v", err)
+			}
+			request := gatewayRequest{DownstreamPath: gatewayEndpointMessages, Payload: payload, Canonical: &canonical}
+			upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+				Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+			})
+			if err != nil {
+				t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+			}
+			if got := upstream["tool_choice"]; !reflect.DeepEqual(got, tc.wantChoice) {
+				t.Fatalf("tool_choice = %#v, want %#v", got, tc.wantChoice)
+			}
+			parallel, exists := upstream["parallel_tool_calls"]
+			if exists != tc.wantParallelSet || !reflect.DeepEqual(parallel, tc.wantParallel) {
+				t.Fatalf("parallel_tool_calls = %#v, exists %v, want %#v, exists %v", parallel, exists, tc.wantParallel, tc.wantParallelSet)
+			}
+		})
+	}
+}
+
+func TestGrokResponsesProtocolPreservesAnthropicCapabilities(t *testing.T) {
+	payload := map[string]any{
+		"model":        "grok-4.5",
+		"max_tokens":   256,
+		"service_tier": "auto",
+		"thinking":     map[string]any{"type": "adaptive"},
+		"output_config": map[string]any{
+			"effort": "max",
+			"format": map[string]any{
+				"type":   "json_schema",
+				"schema": map[string]any{"type": "object", "properties": map[string]any{"answer": map[string]any{"type": "string"}}},
+			},
+		},
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "previous answer"},
+			}},
+			map[string]any{"role": "user", "content": "continue"},
+		},
+	}
+	canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromAnthropicMessagesPayload returned error: %v", err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointMessages, Payload: payload, Canonical: &canonical}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+		Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	if upstream["service_tier"] != "priority" {
+		t.Fatalf("service_tier = %#v, want priority", upstream["service_tier"])
+	}
+	reasoning, ok := upstream["reasoning"].(map[string]any)
+	if !ok || reasoning["effort"] != "high" || reasoning["summary"] != "detailed" {
+		t.Fatalf("reasoning = %#v, want clamped high effort", upstream["reasoning"])
+	}
+	text, ok := upstream["text"].(map[string]any)
+	if !ok {
+		t.Fatalf("text = %#v", upstream["text"])
+	}
+	format, ok := text["format"].(map[string]any)
+	if !ok || format["type"] != "json_schema" || format["name"] != "response" || format["schema"] == nil {
+		t.Fatalf("text.format = %#v", text["format"])
+	}
+}
+
+func TestGrokResponsesProtocolRejectsHistoricalThinkingWithoutRecasting(t *testing.T) {
+	payload := map[string]any{
+		"model":      "grok-4.5",
+		"max_tokens": 128,
+		"messages": []any{map[string]any{"role": "assistant", "content": []any{
+			map[string]any{"type": "thinking", "thinking": "private context", "signature": "sig_1"},
+			map[string]any{"type": "text", "text": "previous answer"},
+		}}, map[string]any{"role": "user", "content": "continue"}},
+	}
+	canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointMessages, Payload: payload, Canonical: &canonical}
+	params := grokIncompatibleRequestParams(request)
+	if !reflect.DeepEqual(params, []string{"thinking_history"}) {
+		t.Fatalf("incompatible parameters = %#v", params)
+	}
+	if _, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"}}); err == nil {
+		t.Fatal("expected historical thinking to make the Grok route incompatible")
+	}
+}
+
+func TestGrokResponsesProtocolPreservesDirectReasoningObject(t *testing.T) {
+	payload := map[string]any{
+		"model": "grok-4.5",
+		"input": "hello",
+		"reasoning": map[string]any{
+			"effort":  "high",
+			"summary": "auto",
+		},
+	}
+	canonical, err := canonicalRequestFromOpenAIResponsesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointResponses, Payload: payload, Canonical: &canonical}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasoning, _ := upstream["reasoning"].(map[string]any)
+	if reasoning["effort"] != "high" || reasoning["summary"] != "auto" {
+		t.Fatalf("reasoning = %#v", reasoning)
+	}
+}
+
+func TestGrokResponsesProtocolRejectsParametersWithoutEquivalent(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    string
+	}{
+		{name: "top k", payload: map[string]any{"top_k": 20}, want: "top_k"},
+		{name: "inference geo", payload: map[string]any{"inference_geo": "us"}, want: "inference_geo"},
+		{name: "flex tier", payload: map[string]any{"service_tier": "flex"}, want: "service_tier"},
+		{name: "arbitrary metadata", payload: map[string]any{"metadata": map[string]any{"trace": "abc"}}, want: "metadata.trace"},
+		{name: "reasoning context", payload: map[string]any{"reasoning": map[string]any{"effort": "high", "context": "opaque"}}, want: "reasoning.context"},
+		{name: "public API cache key", payload: map[string]any{"prompt_cache_key": "cache-1"}, want: "prompt_cache_key"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := map[string]any{"model": "grok-4.5", "input": "hello"}
+			for key, value := range tc.payload {
+				payload[key] = value
+			}
+			canonical, err := canonicalRequestFromOpenAIResponsesPayload(payload, "grok-4.5")
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := gatewayRequest{DownstreamPath: gatewayEndpointResponses, Payload: payload, Canonical: &canonical}
+			if got := grokIncompatibleRequestParams(request); !reflect.DeepEqual(got, []string{tc.want}) {
+				t.Fatalf("incompatible parameters = %#v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGrokResponsesCompatibilityDoesNotAffectImageRequests(t *testing.T) {
+	canonical := canonicalRequest{
+		SourceProtocol: canonicalProtocolOpenAIImages,
+		Params:         map[string]any{"size": "1024x1024", "quality": "hd"},
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointImagesGenerations, Canonical: &canonical}
+	if params := grokIncompatibleRequestParams(request); len(params) != 0 {
+		t.Fatalf("image parameters were classified as Responses incompatibilities: %#v", params)
+	}
+}
+
+func TestFilterGrokResponsesRequestFieldsUsesAllowlist(t *testing.T) {
+	payload := map[string]any{
+		"model":            "grok-4.5",
+		"input":            "hello",
+		"max_tool_calls":   3,
+		"metadata":         map[string]any{"user_id": "user-1"},
+		"prompt_cache_key": "unsupported",
+	}
+	filterGrokResponsesRequestFields(payload)
+	if _, ok := payload["metadata"]; ok {
+		t.Fatal("metadata remained after allowlist filtering")
+	}
+	if _, ok := payload["prompt_cache_key"]; ok {
+		t.Fatal("unknown request field remained after allowlist filtering")
+	}
+	if payload["max_tool_calls"] != 3 {
+		t.Fatalf("supported request field was removed: %#v", payload)
+	}
+}
+
+func TestGrokBufferedStopSequencesPreserveAnthropicSemantics(t *testing.T) {
+	adapter := &grokResponsesProtocolAdapter{
+		inner:         openAIResponsesProtocolAdapter{downstreamProtocol: canonicalProtocolAnthropicMessages},
+		stopSequences: []string{"<END>"},
+	}
+	body := []byte(`{"id":"resp_1","object":"response","created_at":1,"model":"grok-4.5","status":"completed","output":[{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"visible<END>hidden","annotations":[]}]}],"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}`)
+	response, err := adapter.TransformBufferedResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(response.Body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	content := payload["content"].([]any)
+	text := content[0].(map[string]any)["text"]
+	if text != "visible" || payload["stop_reason"] != "stop_sequence" || payload["stop_sequence"] != "<END>" {
+		t.Fatalf("truncated response = %#v", payload)
+	}
+}
+
+func TestGrokResponsesProtocolCompensatesStopSequencesOutsideUpstreamPayload(t *testing.T) {
+	payload := map[string]any{
+		"model":          "grok-4.5",
+		"max_tokens":     64,
+		"stop_sequences": []any{"<END>"},
+		"messages":       []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointMessages, Payload: payload, Canonical: &canonical}
+	protocol := newGrokResponsesProtocolAdapter(request, true)
+	upstream, err := protocol.BuildUpstreamPayload(request, routeengine.Candidate{Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := upstream["stop_sequences"]; ok {
+		t.Fatalf("unsupported stop_sequences reached Grok: %#v", upstream)
+	}
+	if !reflect.DeepEqual(protocol.stopSequences, []string{"<END>"}) {
+		t.Fatalf("compensated stop sequences = %#v", protocol.stopSequences)
+	}
+}
+
+func TestGrokStreamingStopSequenceMatchesAcrossDeltas(t *testing.T) {
+	filter := newCanonicalStopSequenceFilter([]string{"<END>"})
+	events := filter.Apply([]canonicalStreamEvent{
+		{Type: canonicalStreamEventTextDelta, Delta: "visible<EN"},
+		{Type: canonicalStreamEventTextDelta, Delta: "D>hidden"},
+		{Type: canonicalStreamEventCompleted},
+	})
+	var visible strings.Builder
+	for _, event := range events {
+		if event.Type == canonicalStreamEventTextDelta {
+			visible.WriteString(event.Delta)
+		}
+	}
+	if visible.String() != "visible" {
+		t.Fatalf("filtered events = %#v", events)
+	}
+	terminal := events[len(events)-1]
+	if terminal.Type != canonicalStreamEventCompleted || terminal.StopSequence != "<END>" {
+		t.Fatalf("terminal event = %#v", terminal)
+	}
+	recorder := httptest.NewRecorder()
+	capture := &streamCaptureState{}
+	encoder := newAnthropicMessagesStreamEncoder(canonicalStreamOptions{}, recorder, capture)
+	for _, event := range events {
+		if err := encoder.EncodeEvent(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stream := recorder.Body.String()
+	if !strings.Contains(stream, `"stop_reason":"stop_sequence"`) || !strings.Contains(stream, `"stop_sequence":"\u003cEND\u003e"`) {
+		t.Fatalf("Anthropic terminal stream = %s", stream)
+	}
+}
+
+func TestGrokResponsesProtocolMapsAnthropicStandardTier(t *testing.T) {
+	payload := map[string]any{
+		"model":        "grok-4.5",
+		"max_tokens":   64,
+		"service_tier": "standard_only",
+		"messages":     []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	canonical, err := canonicalRequestFromAnthropicMessagesPayload(payload, "grok-4.5")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromAnthropicMessagesPayload returned error: %v", err)
+	}
+	request := gatewayRequest{DownstreamPath: gatewayEndpointMessages, Payload: payload, Canonical: &canonical}
+	upstream, err := newGrokResponsesProtocolAdapter(request, true).BuildUpstreamPayload(request, routeengine.Candidate{
+		Model: routeengine.CandidateModel{UpstreamName: "grok-4.5"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	if upstream["service_tier"] != "default" {
+		t.Fatalf("service_tier = %#v, want default", upstream["service_tier"])
+	}
+}
+
+func TestNormalizeGrokServiceTierCoversOpenAIModes(t *testing.T) {
+	tests := map[string]string{
+		"auto":     "default",
+		"standard": "default",
+		"fast":     "priority",
+		"default":  "default",
+		"priority": "priority",
+	}
+	for input, want := range tests {
+		payload := map[string]any{"service_tier": input}
+		normalizeGrokServiceTier(payload, canonicalProtocolOpenAIResponses)
+		if payload["service_tier"] != want {
+			t.Fatalf("service_tier %q = %#v, want %q", input, payload["service_tier"], want)
+		}
+	}
+}
+
+func TestNearestGrokReasoningEffortUsesModelCapabilities(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		supported []string
+		want      string
+	}{
+		{name: "exact", requested: "xhigh", supported: []string{"low", "high", "xhigh"}, want: "xhigh"},
+		{name: "closest lower", requested: "max", supported: []string{"low", "medium", "high", "xhigh"}, want: "xhigh"},
+		{name: "closest higher", requested: "low", supported: []string{"medium", "high"}, want: "medium"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nearestGrokReasoningEffort(tc.requested, grokReasoningEffortSet(tc.supported)); got != tc.want {
+				t.Fatalf("nearestGrokReasoningEffort = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/server/internal/gateway/handler_chat.go
+++ b/server/internal/gateway/handler_chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -235,13 +236,27 @@ func (h Handler) serveEndpoint(
 	var lastFailure *gatewayAttemptResult
 	var retainedRateLimitFailure *gatewayAttemptResult
 	skippedImageUnsupported := false
+	var skippedGrokIncompatible []string
 	for {
 		lastFailure = nil
 		skippedImageUnsupported = false
+		skippedGrokIncompatible = nil
 		waitableRateLimit := true
 		for index, candidate := range attempts {
+			if isGrokSite(candidate.Site.SiteType) {
+				if incompatible := grokIncompatibleRequestParams(request); len(incompatible) > 0 {
+					skippedGrokIncompatible = appendUniqueStrings(skippedGrokIncompatible, incompatible...)
+					continue
+				}
+			}
 			if bridge != nil {
 				bridgeProtocol, bridgeResolveErr := resolver.Resolve(ctx, request, candidate)
+				if grokProtocol, ok := bridgeProtocol.(*grokResponsesProtocolAdapter); bridgeResolveErr == nil && ok {
+					if incompatible := grokProtocol.incompatibleRequestParams(request); len(incompatible) > 0 {
+						skippedGrokIncompatible = appendUniqueStrings(skippedGrokIncompatible, incompatible...)
+						continue
+					}
+				}
 				if bridgeResolveErr == nil && candidateRequiresImageBridge(candidate, bridgeProtocol) {
 					result := h.forwardBridgedResponses(ctx, w, requestID, index+1, apiKey.ID, plan.CanonicalModel.ID, candidate, request, reservation, resolver, bridge)
 					if result.success {
@@ -273,7 +288,6 @@ func (h Handler) serveEndpoint(
 				skippedImageUnsupported = true
 				continue
 			}
-
 			protocol, resolveErr := resolver.Resolve(ctx, attemptRequest, candidate)
 			if resolveErr != nil {
 				h.writeChatFailure(w, r, endpoint.DownstreamPath(), requestID, apiKey.ID, startedAt, chatFailure{
@@ -285,6 +299,12 @@ func (h Handler) serveEndpoint(
 					stage:          "protocol_resolve",
 				})
 				return
+			}
+			if grokProtocol, ok := protocol.(*grokResponsesProtocolAdapter); ok {
+				if incompatible := grokProtocol.incompatibleRequestParams(attemptRequest); len(incompatible) > 0 {
+					skippedGrokIncompatible = appendUniqueStrings(skippedGrokIncompatible, incompatible...)
+					continue
+				}
 			}
 
 			result := h.forwardGatewayRequest(ctx, w, requestID, index+1, apiKey.ID, plan.CanonicalModel.ID, candidate, attemptRequest, reservation, protocol)
@@ -333,7 +353,7 @@ func (h Handler) serveEndpoint(
 		}
 
 		if lastFailure == nil || !waitableRateLimit {
-			if (lastFailure != nil || skippedImageUnsupported) && engageSoftFallback() {
+			if (lastFailure != nil || skippedImageUnsupported || len(skippedGrokIncompatible) > 0) && engageSoftFallback() {
 				continue
 			}
 			break
@@ -353,6 +373,21 @@ func (h Handler) serveEndpoint(
 	}
 
 	lastFailure = preferredFinalGatewayFailure(lastFailure, retainedRateLimitFailure)
+	if lastFailure == nil && len(skippedGrokIncompatible) > 0 {
+		message := "no available upstream route candidate can preserve parameters: " + strings.Join(skippedGrokIncompatible, ", ")
+		if bridge != nil && bridge.FailAll("upstream_parameter_not_supported", message) {
+			return
+		}
+		h.writeChatFailure(w, r, endpoint.DownstreamPath(), requestID, apiKey.ID, startedAt, chatFailure{
+			status:         http.StatusUnprocessableEntity,
+			code:           "upstream_parameter_not_supported",
+			message:        message,
+			requestedModel: access.ModelKey,
+			stream:         request.Stream,
+			stage:          "route_plan",
+		})
+		return
+	}
 	if bridge != nil && bridge.FailAll("upstream_failed", "all upstream route candidates failed") {
 		return
 	}
@@ -368,7 +403,6 @@ func (h Handler) serveEndpoint(
 		})
 		return
 	}
-
 	if lastFailure != nil && len(lastFailure.body) > 0 && lastFailure.statusCode >= 400 {
 		writeUpstreamFailure(w, *lastFailure, requestID)
 		return

--- a/server/internal/gateway/protocol_canonical_stream.go
+++ b/server/internal/gateway/protocol_canonical_stream.go
@@ -39,6 +39,7 @@ type canonicalStreamEvent struct {
 	Delta                  string
 	Usage                  completionUsage
 	FinishReason           string
+	StopSequence           string
 	ErrorMessage           string
 	Annotation             any
 	Refusal                bool
@@ -62,6 +63,7 @@ type canonicalStreamOptions struct {
 	UpstreamLineInspect func([]byte, *streamCaptureState)
 	CustomTools         map[string]struct{}
 	ResponseTools       map[string]responsesToolIdentity
+	StopSequences       []string
 }
 
 type canonicalStreamDecoder interface {
@@ -156,12 +158,13 @@ func proxyCanonicalStream(ctx context.Context, w http.ResponseWriter, resp *http
 
 	decoder := source.NewDecoder()
 	encoder := target.NewEncoder(options, w, &capture)
+	stopFilter := newCanonicalStopSequenceFilter(options.StopSequences)
 	deferResponsesPreOutput := from == canonicalProtocolOpenAIResponses || from == canonicalProtocolCodexResponses
 	var preOutputEvents []canonicalStreamEvent
 	preOutputBytes := 0
 	responsesPreOutputCommitted := false
-	flushPreOutput := func() error {
-		for _, event := range preOutputEvents {
+	encodeRaw := func(events []canonicalStreamEvent) error {
+		for _, event := range events {
 			writeHeaders()
 			if encodeErr := encoder.EncodeEvent(event); encodeErr != nil {
 				if capture.endReason == "" {
@@ -169,6 +172,18 @@ func proxyCanonicalStream(ctx context.Context, w http.ResponseWriter, resp *http
 				}
 				return encodeErr
 			}
+		}
+		return nil
+	}
+	encodeFiltered := func(events []canonicalStreamEvent) error {
+		if stopFilter != nil {
+			events = stopFilter.Apply(events)
+		}
+		return encodeRaw(events)
+	}
+	flushPreOutput := func() error {
+		if err := encodeFiltered(preOutputEvents); err != nil {
+			return err
 		}
 		preOutputEvents = nil
 		preOutputBytes = 0
@@ -188,19 +203,10 @@ func proxyCanonicalStream(ctx context.Context, w http.ResponseWriter, resp *http
 		return nil
 	}
 	encodeEvents := func(events []canonicalStreamEvent) error {
-		for _, event := range events {
-			if flushErr := flushPreOutput(); flushErr != nil {
-				return flushErr
-			}
-			writeHeaders()
-			if encodeErr := encoder.EncodeEvent(event); encodeErr != nil {
-				if capture.endReason == "" {
-					capture.endReason = "downstream_stream_write_failed"
-				}
-				return encodeErr
-			}
+		if flushErr := flushPreOutput(); flushErr != nil {
+			return flushErr
 		}
-		return nil
+		return encodeFiltered(events)
 	}
 	reader := bufio.NewReader(resp.Body)
 	for {
@@ -286,13 +292,18 @@ func proxyCanonicalStream(ctx context.Context, w http.ResponseWriter, resp *http
 			}
 			if headersWritten && !capture.streamCompleted && !capture.sawDone && capture.endReason == "" {
 				if shouldSynthesizeEOFCompletion(from) {
-					if encodeErr := encoder.EncodeEvent(canonicalStreamEvent{Type: canonicalStreamEventCompleted}); encodeErr != nil {
+					if encodeErr := encodeEvents([]canonicalStreamEvent{{Type: canonicalStreamEventCompleted}}); encodeErr != nil {
 						capture.endReason = "downstream_stream_write_failed"
 						return capture, headersWritten, encodeErr
 					}
 				} else {
 					capture.endReason = "upstream_stream_incomplete"
 					return capture, headersWritten, nil
+				}
+			}
+			if stopFilter != nil {
+				if encodeErr := encodeRaw(stopFilter.Flush()); encodeErr != nil {
+					return capture, headersWritten, encodeErr
 				}
 			}
 			if capture.streamCompleted {
@@ -1823,9 +1834,13 @@ func (e *anthropicMessagesStreamEncoder) EncodeEvent(event canonicalStreamEvent)
 		}
 		return nil
 	case canonicalStreamEventCompleted:
-		return e.sendFinish("end_turn", true, "done")
+		stopReason := "end_turn"
+		if event.StopSequence != "" {
+			stopReason = "stop_sequence"
+		}
+		return e.sendFinish(stopReason, event.StopSequence, true, "done")
 	case canonicalStreamEventIncomplete:
-		return e.sendFinish("max_tokens", false, "response_incomplete")
+		return e.sendFinish("max_tokens", "", false, "response_incomplete")
 	case canonicalStreamEventError:
 		e.capture.endReason = "upstream_stream_error"
 		return fmt.Errorf("upstream stream failed: %s", nonEmptyString(event.ErrorMessage, "unknown error"))
@@ -2018,7 +2033,7 @@ func (e *anthropicMessagesStreamEncoder) sendToolCallDelta(event canonicalStream
 	})
 }
 
-func (e *anthropicMessagesStreamEncoder) sendFinish(stopReason string, completed bool, endReason string) error {
+func (e *anthropicMessagesStreamEncoder) sendFinish(stopReason string, stopSequence string, completed bool, endReason string) error {
 	if e.completed {
 		return nil
 	}
@@ -2052,7 +2067,7 @@ func (e *anthropicMessagesStreamEncoder) sendFinish(stopReason string, completed
 	}
 	if err := e.writeEvent("message_delta", map[string]any{
 		"type":  "message_delta",
-		"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nil},
+		"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": emptyToNil(stopSequence)},
 		"usage": map[string]any{"output_tokens": e.capture.usage.CompletionTokens},
 	}); err != nil {
 		return err

--- a/server/internal/gateway/protocol_openai_resolver.go
+++ b/server/internal/gateway/protocol_openai_resolver.go
@@ -70,7 +70,7 @@ func (r openAIProtocolResolver) Resolve(ctx context.Context, request gatewayRequ
 		return newAnthropicMessagesProtocolAdapter(downstreamCanonicalProtocol(request.DownstreamPath)), nil
 	}
 	if isGrokSite(candidate.Site.SiteType) {
-		return newGrokResponsesProtocolAdapter(request, r.grokModelSupportsReasoningEffort(ctx, candidate.Model.SiteModelID)), nil
+		return newGrokResponsesProtocolAdapterWithReasoningEfforts(request, r.grokModelReasoningEfforts(ctx, candidate.Model.SiteModelID)), nil
 	}
 	if isMiMoV25TTSModel(candidate.Model.UpstreamName) && request.DownstreamPath == gatewayEndpointChatCompletions {
 		return newOpenAIChatProtocolAdapter(request, candidate), nil
@@ -142,24 +142,42 @@ func (r openAIProtocolResolver) supportedEndpointTypes(ctx context.Context, site
 	return result, nil
 }
 
-func (r openAIProtocolResolver) grokModelSupportsReasoningEffort(ctx context.Context, siteModelID uuid.UUID) bool {
+func (r openAIProtocolResolver) grokModelReasoningEfforts(ctx context.Context, siteModelID uuid.UUID) []string {
 	if r.db == nil || siteModelID == uuid.Nil {
-		return false
+		return nil
 	}
 	model, err := store.NewSiteModelRepository(r.db.DB()).GetByID(ctx, siteModelID)
 	if err != nil || len(model.Capabilities) == 0 {
-		return false
+		return nil
 	}
 	capabilities := map[string]any{}
 	if err := json.Unmarshal(model.Capabilities, &capabilities); err != nil {
-		return false
+		return nil
 	}
 	raw, ok := capabilities["raw"].(map[string]any)
 	if !ok {
-		return false
+		return nil
 	}
 	supported, _ := raw["supports_reasoning_effort"].(bool)
-	return supported
+	if !supported {
+		return nil
+	}
+	result := make([]string, 0)
+	if efforts, ok := raw["reasoning_efforts"].([]any); ok {
+		for _, rawEffort := range efforts {
+			value := anyString(rawEffort)
+			if effort, ok := rawEffort.(map[string]any); ok {
+				value = firstNonEmptyGatewayString(anyString(effort["value"]), anyString(effort["id"]))
+			}
+			if value != "" {
+				result = append(result, value)
+			}
+		}
+	}
+	if len(result) == 0 {
+		return []string{"low", "medium", "high"}
+	}
+	return result
 }
 
 func (r openAIProtocolResolver) supportedEndpointTypesFromCapabilities(ctx context.Context, siteModelID uuid.UUID) ([]string, error) {

--- a/server/internal/gateway/protocol_stop_sequences.go
+++ b/server/internal/gateway/protocol_stop_sequences.go
@@ -1,0 +1,131 @@
+package gateway
+
+type canonicalStopSequenceFilter struct {
+	sequences      [][]rune
+	sequenceValues []string
+	maxLength      int
+	pending        []rune
+	template       canonicalStreamEvent
+	matched        string
+	stopped        bool
+}
+
+func newCanonicalStopSequenceFilter(values []string) *canonicalStopSequenceFilter {
+	filter := &canonicalStopSequenceFilter{}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		sequence := []rune(value)
+		if len(sequence) == 0 {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		filter.sequences = append(filter.sequences, sequence)
+		filter.sequenceValues = append(filter.sequenceValues, value)
+		if len(sequence) > filter.maxLength {
+			filter.maxLength = len(sequence)
+		}
+	}
+	if len(filter.sequences) == 0 {
+		return nil
+	}
+	return filter
+}
+
+func (f *canonicalStopSequenceFilter) Apply(events []canonicalStreamEvent) []canonicalStreamEvent {
+	if f == nil || len(events) == 0 {
+		return events
+	}
+	result := make([]canonicalStreamEvent, 0, len(events)+1)
+	for _, event := range events {
+		switch event.Type {
+		case canonicalStreamEventTextDelta:
+			if f.stopped || event.Delta == "" {
+				continue
+			}
+			if len(f.pending) == 0 {
+				f.template = event
+			}
+			f.pending = append(f.pending, []rune(event.Delta)...)
+			matchIndex, sequenceIndex := f.firstMatch()
+			if matchIndex >= 0 {
+				result = append(result, f.emitPrefix(matchIndex)...)
+				f.pending = nil
+				f.matched = f.sequenceValues[sequenceIndex]
+				f.stopped = true
+				continue
+			}
+			keep := f.maxLength - 1
+			if len(f.pending) > keep {
+				result = append(result, f.emitPrefix(len(f.pending)-keep)...)
+			}
+		case canonicalStreamEventCreated:
+			result = append(result, event)
+		case canonicalStreamEventUsage:
+			result = append(result, f.Flush()...)
+			result = append(result, event)
+		case canonicalStreamEventCompleted, canonicalStreamEventIncomplete, canonicalStreamEventError:
+			result = append(result, f.Flush()...)
+			if f.stopped {
+				event.Type = canonicalStreamEventCompleted
+				event.FinishReason = "stop_sequence"
+				event.StopSequence = f.matched
+				event.ErrorMessage = ""
+			}
+			result = append(result, event)
+		default:
+			if f.stopped {
+				continue
+			}
+			result = append(result, f.Flush()...)
+			result = append(result, event)
+		}
+	}
+	return result
+}
+
+func (f *canonicalStopSequenceFilter) Flush() []canonicalStreamEvent {
+	if f == nil || len(f.pending) == 0 || f.stopped {
+		return nil
+	}
+	return f.emitPrefix(len(f.pending))
+}
+
+func (f *canonicalStopSequenceFilter) emitPrefix(length int) []canonicalStreamEvent {
+	if length <= 0 || len(f.pending) == 0 {
+		return nil
+	}
+	if length > len(f.pending) {
+		length = len(f.pending)
+	}
+	event := f.template
+	event.Delta = string(f.pending[:length])
+	f.pending = append([]rune(nil), f.pending[length:]...)
+	if len(f.pending) == 0 {
+		f.template = canonicalStreamEvent{}
+	}
+	return []canonicalStreamEvent{event}
+}
+
+func (f *canonicalStopSequenceFilter) firstMatch() (int, int) {
+	for index := 0; index < len(f.pending); index++ {
+		for sequenceIndex, sequence := range f.sequences {
+			if index+len(sequence) > len(f.pending) {
+				continue
+			}
+			matched := true
+			for offset := range sequence {
+				if f.pending[index+offset] != sequence[offset] {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return index, sequenceIndex
+			}
+		}
+	}
+	return -1, -1
+}


### PR DESCRIPTION
## 变更内容

- 为 Grok CLI-proxy 的 Responses 请求增加字段白名单和协议级参数映射，避免将不支持的字段发送到上游。
- 保留直接 Responses 请求中的 reasoning 配置，并按站点模型能力读取可用推理强度。
- 对 `stop` 和 `stop_sequences` 在缓冲响应及 SSE 流中执行网关侧截断，保留 Chat 与 Anthropic 的停止语义。
- 对 `top_k`、`inference_geo`、历史 thinking/reasoning、无法映射的 metadata 和 service tier 等参数跳过不兼容的 Grok 候选，继续尝试其他路由。
- 将兼容判断限定在 Grok 文本接口，不影响图片及其他协议路由。

## 根因

Messages、Chat Completions 和 Responses 转换到 Grok Responses 时，部分下游字段会被直接透传给只接受有限请求结构的 CLI-proxy，导致上游返回 400；另一些字段在转换过程中被删除或改写，造成语义丢失。

## 影响

- 仅影响 `site_type=grok` 的 Chat Completions、Responses 和 Messages 请求。
- 可等价映射或由网关补偿的参数继续使用 Grok。
- 无法保真的参数会触发候选切换；全部候选均不兼容时返回本地 422，不再制造 Grok 上游 400。
- Grok 图片接口、非 Grok 站点和其他协议不受影响。

## 验证

- `go test ./...`
- `govulncheck ./...`
