### PR TITLE
fix: 修复 TokenPlan 周限额冷却时间计算错误

### DIFF
--- a/server/internal/gateway/codex.go
+++ b/server/internal/gateway/codex.go
@@ -15,6 +15,7 @@ import (
 	"xlyra/server/internal/adapter"
 	"xlyra/server/internal/config"
 	routeengine "xlyra/server/internal/router"
+	sitepkg "xlyra/server/internal/site"
 	"xlyra/server/internal/store"
 	"xlyra/server/internal/upstream"
 )
@@ -321,6 +322,9 @@ func subscriptionLimitResetAt(result gatewayAttemptResult, failure upstream.Fail
 	}
 	if failure.ResetAt.After(now) {
 		return failure.ResetAt, int64(math.Ceil(failure.ResetAt.Sub(now).Seconds()))
+	}
+	if resetAt, ok := sitepkg.CredentialQuotaProbeResetAt(result.credentialMeta, failure.LimitWindow, now); ok {
+		return resetAt, int64(math.Ceil(resetAt.Sub(now).Seconds()))
 	}
 	resetAt := subscriptionLimitCalendarResetAt(now, failure.LimitWindow, timeZone)
 	return resetAt, int64(math.Ceil(resetAt.Sub(now).Seconds()))

--- a/server/internal/gateway/execution.go
+++ b/server/internal/gateway/execution.go
@@ -75,6 +75,7 @@ type gatewayAttemptResult struct {
 	cacheDomain                string
 	credentialName             string
 	credentialMasked           string
+	credentialMeta             store.JSON
 	credentialPriority         float64
 	credentialCostMultiplier   float64
 	credentialAttempt          int
@@ -180,6 +181,7 @@ func (h Handler) forwardGatewayRequest(
 			cacheDomain:              store.SiteCredentialCacheDomain(selectedCredential.Credential),
 			credentialName:           store.SiteCredentialDisplayName(selectedCredential.Credential, selectedCredential.State),
 			credentialMasked:         selectedCredential.Credential.MaskedSecret,
+			credentialMeta:           selectedCredential.Credential.Meta,
 			credentialPriority:       store.SiteCredentialRoutingPriority(selectedCredential.Credential),
 			credentialCostMultiplier: store.SiteCredentialUpstreamCostMultiplier(selectedCredential.Credential),
 			credentialAttempt:        credentialIndex + 1,

--- a/server/internal/gateway/execution_forward_response_edges_test.go
+++ b/server/internal/gateway/execution_forward_response_edges_test.go
@@ -135,13 +135,14 @@ func TestForwardGatewayRequestReturnsPayloadEncodeFailureAfterCredentialSelectio
 		t.Fatalf("encrypt credential: %v", err)
 	}
 	db := gatewayOfflineGorm(t)
+	credentialMeta := store.JSON(`{"enabled":true,"quota_probe":{"status":"ok"}}`)
 	installGatewayCredentialQueries(t, db, siteID, siteModelID, store.SiteCredential{
 		ID:              credentialID,
 		SiteID:          siteID,
 		CredentialType:  "api_key",
 		EncryptedSecret: encrypted,
 		MaskedSecret:    masked,
-		Meta:            store.JSON(`{"enabled":true}`),
+		Meta:            credentialMeta,
 		CreatedAt:       time.Unix(10, 0),
 	})
 
@@ -179,6 +180,9 @@ func TestForwardGatewayRequestReturnsPayloadEncodeFailureAfterCredentialSelectio
 	}
 	if result.credentialID != credentialID || result.credentialMasked != masked || result.credentialAttempt != 1 || result.credentialTotal != 1 {
 		t.Fatalf("credential metadata = %#v", result)
+	}
+	if string(result.credentialMeta) != string(credentialMeta) {
+		t.Fatalf("credential quota metadata = %s, want %s", result.credentialMeta, credentialMeta)
 	}
 }
 

--- a/server/internal/gateway/resolver_cooldown_test.go
+++ b/server/internal/gateway/resolver_cooldown_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -589,6 +590,36 @@ func TestClassifyGatewayUpstreamErrorBuildsSubscriptionCooldown(t *testing.T) {
 	}
 	if got.cooldownMetadata["limit_window"] != "daily" || got.cooldownMetadata["upstream_code"] != "USAGE_LIMIT_EXCEEDED" || got.cooldownMetadata["upstream_reason"] != "DAILY_LIMIT_EXCEEDED" || got.cooldownMetadata["reset_at"] != wantReset.UTC().Format(time.RFC3339) {
 		t.Fatalf("metadata = %#v, want daily upstream details and reset", got.cooldownMetadata)
+	}
+}
+
+func TestClassifyGatewayUpstreamErrorUsesCredentialQuotaProbeReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 4, 3, 37, 0, time.UTC)
+	wantReset := time.Date(2026, 8, 21, 14, 29, 8, 997742000, time.UTC)
+	result := gatewayAttemptResult{
+		statusCode:         http.StatusTooManyRequests,
+		upstreamStatusCode: http.StatusTooManyRequests,
+		errorType:          "upstream_http_error",
+		errorMessage:       "upstream returned HTTP 429",
+		credentialMeta: store.JSON(`{"quota_probe":{"status":"ok","entries":[
+			{"label":"daily","remaining":100,"reset_at":"2026-08-21T00:00:00+08:00"},
+			{"label":"weekly","remaining":0,"reset_at":"2026-08-21T22:29:08.997742+08:00"},
+			{"label":"monthly","remaining":33.8,"reset_at":"2026-09-07T22:29:08.997742+08:00"}
+		],"fetched_at":"2026-08-20T00:00:14Z"}}`),
+	}
+	body := []byte(`{"code":"USAGE_LIMIT_EXCEEDED","message":"error: code=429 reason=\"WEEKLY_LIMIT_EXCEEDED\" message=\"weekly usage limit exceeded\" metadata=map[]"}`)
+	got := classifyGatewayUpstreamErrorWithTimeZone(resolverCooldownCandidate("openai"), result, body, now, config.LoadTimeZone("Asia/Shanghai"))
+	if got.cooldownDuration != wantReset.Sub(now) || got.retryAfterSeconds != int64(math.Ceil(wantReset.Sub(now).Seconds())) {
+		t.Fatalf("cooldown = %s retry=%d, want reset %s", got.cooldownDuration, got.retryAfterSeconds, wantReset)
+	}
+	if got.cooldownMetadata["reset_at"] != wantReset.Format(time.RFC3339) {
+		t.Fatalf("reset_at = %#v, want %s", got.cooldownMetadata["reset_at"], wantReset.Format(time.RFC3339))
+	}
+	calendarReset := subscriptionLimitCalendarResetAt(now, "weekly", config.LoadTimeZone("Asia/Shanghai"))
+	if wantReset.Equal(calendarReset) {
+		t.Fatalf("test setup must differ from calendar fallback %s", calendarReset)
 	}
 }
 

--- a/server/internal/site/quota_probe.go
+++ b/server/internal/site/quota_probe.go
@@ -192,15 +192,43 @@ func (s *Service) recoverSub2APISubscriptionCooldown(ctx context.Context, siteID
 		if json.Unmarshal(item.Metadata, &metadata) != nil {
 			continue
 		}
-		if !sub2APISubscriptionQuotaRecovered(result, anyString(metadata["limit_window"])) {
+		limitWindow := anyString(metadata["limit_window"])
+		entry, ok := sub2APISubscriptionQuotaEntry(result, limitWindow)
+		if !ok {
+			if sub2APISubscriptionQuotaRecovered(result, limitWindow) {
+				_, _ = repo.ClearActiveMatching(ctx, store.ClearActiveCooldownFilter{
+					SiteID:           siteID,
+					SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
+					Reasons:          []string{store.CooldownReasonUpstreamSubscriptionLimitExceeded},
+				})
+				return
+			}
 			continue
 		}
-		_, _ = repo.ClearActiveMatching(ctx, store.ClearActiveCooldownFilter{
-			SiteID:           siteID,
-			SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
-			Reasons:          []string{store.CooldownReasonUpstreamSubscriptionLimitExceeded},
-		})
-		return
+		if entry.Remaining != nil && *entry.Remaining > 0 {
+			_, _ = repo.ClearActiveMatching(ctx, store.ClearActiveCooldownFilter{
+				SiteID:           siteID,
+				SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
+				Reasons:          []string{store.CooldownReasonUpstreamSubscriptionLimitExceeded},
+			})
+			return
+		}
+		if entry.Remaining == nil {
+			continue
+		}
+		resetAt, ok := quotaProbeResetAt(result, limitWindow, time.Now())
+		if !ok {
+			continue
+		}
+		metadata["reset_at"] = resetAt.UTC().Format(time.RFC3339)
+		encodedMetadata, err := json.Marshal(metadata)
+		if err != nil {
+			continue
+		}
+		if item.ActiveUntil.Equal(resetAt) && string(item.Metadata) == string(encodedMetadata) {
+			continue
+		}
+		_ = repo.UpdateActiveUntil(ctx, item.ID, resetAt, store.JSON(encodedMetadata))
 	}
 }
 
@@ -232,6 +260,19 @@ func sub2APISubscriptionQuotaRecovered(result QuotaProbeResult, limitWindow stri
 		}
 	}
 	return foundWindow
+}
+
+func sub2APISubscriptionQuotaEntry(result QuotaProbeResult, limitWindow string) (QuotaProbeEntry, bool) {
+	limitWindow = strings.ToLower(strings.TrimSpace(limitWindow))
+	if limitWindow != "daily" && limitWindow != "weekly" && limitWindow != "monthly" {
+		return QuotaProbeEntry{}, false
+	}
+	for _, entry := range result.Entries {
+		if strings.EqualFold(strings.TrimSpace(entry.Label), limitWindow) {
+			return entry, true
+		}
+	}
+	return QuotaProbeEntry{}, false
 }
 
 func quotaProbeCredentialEligible(credentialType string) bool {
@@ -269,6 +310,52 @@ func preserveQuotaProbeResult(credentialMeta store.JSON, result QuotaProbeResult
 	result.Entries = previous.Entries
 	result.FetchedAt = previous.FetchedAt
 	return result
+}
+
+// CredentialQuotaProbeResetAt returns the future reset for a specific quota
+// window from the latest successful probe stored on a credential.
+func CredentialQuotaProbeResetAt(credentialMeta store.JSON, limitWindow string, now time.Time) (time.Time, bool) {
+	if len(credentialMeta) == 0 {
+		return time.Time{}, false
+	}
+	meta := map[string]json.RawMessage{}
+	if err := json.Unmarshal(credentialMeta, &meta); err != nil {
+		return time.Time{}, false
+	}
+	raw, ok := meta[QuotaProbeCredentialMetaKey]
+	if !ok {
+		return time.Time{}, false
+	}
+	var result QuotaProbeResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return time.Time{}, false
+	}
+	return quotaProbeResetAt(result, limitWindow, now)
+}
+
+func quotaProbeResetAt(result QuotaProbeResult, limitWindow string, now time.Time) (time.Time, bool) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if !strings.EqualFold(strings.TrimSpace(result.Status), "ok") || result.FetchedAt.IsZero() || result.FetchedAt.After(now) {
+		return time.Time{}, false
+	}
+	limitWindow = strings.ToLower(strings.TrimSpace(limitWindow))
+	switch limitWindow {
+	case "daily", "weekly", "monthly":
+	default:
+		return time.Time{}, false
+	}
+	for _, entry := range result.Entries {
+		if !strings.EqualFold(strings.TrimSpace(entry.Label), limitWindow) || entry.Remaining == nil || *entry.Remaining > 0 || entry.ResetAt == nil {
+			continue
+		}
+		resetAt, err := time.Parse(time.RFC3339, strings.TrimSpace(*entry.ResetAt))
+		if err == nil && resetAt.After(now) {
+			return resetAt, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func preserveQuotaSummaryValues(siteMeta map[string]any, summary map[string]any) {

--- a/server/internal/site/quota_probe_test.go
+++ b/server/internal/site/quota_probe_test.go
@@ -400,6 +400,41 @@ func TestPreserveQuotaProbeResultWithoutHistoryReturnsFailure(t *testing.T) {
 	}
 }
 
+func TestCredentialQuotaProbeResetAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 4, 3, 37, 0, time.UTC)
+	want := time.Date(2026, 8, 21, 14, 29, 8, 997742000, time.UTC)
+	valid := store.JSON(`{"quota_probe":{"status":"ok","entries":[{"label":"daily","remaining":100,"reset_at":"2026-08-21T00:00:00+08:00"},{"label":"weekly","remaining":0,"reset_at":"2026-08-21T22:29:08.997742+08:00"}],"fetched_at":"2026-08-20T00:00:14Z"}}`)
+	if got, ok := CredentialQuotaProbeResetAt(valid, "weekly", now); !ok || !got.Equal(want) {
+		t.Fatalf("CredentialQuotaProbeResetAt() = %s, %v, want %s, true", got, ok, want)
+	}
+
+	for _, test := range []struct {
+		name string
+		meta store.JSON
+	}{
+		{name: "failed probe", meta: store.JSON(`{"quota_probe":{"status":"error","entries":[{"label":"weekly","remaining":0,"reset_at":"2026-08-21T22:29:08.997742+08:00"}],"fetched_at":"2026-08-20T00:00:14Z"}}`)},
+		{name: "missing observation time", meta: store.JSON(`{"quota_probe":{"status":"ok","entries":[{"label":"weekly","remaining":0,"reset_at":"2026-08-21T22:29:08.997742+08:00"}]}}`)},
+		{name: "future observation", meta: store.JSON(`{"quota_probe":{"status":"ok","entries":[{"label":"weekly","remaining":0,"reset_at":"2026-08-21T22:29:08.997742+08:00"}],"fetched_at":"2026-08-20T05:00:00Z"}}`)},
+		{name: "past reset", meta: store.JSON(`{"quota_probe":{"status":"ok","entries":[{"label":"weekly","remaining":0,"reset_at":"2026-08-19T22:29:08.997742+08:00"}],"fetched_at":"2026-08-20T00:00:14Z"}}`)},
+		{name: "wrong window", meta: valid},
+		{name: "invalid metadata", meta: store.JSON(`{invalid`)},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			window := "weekly"
+			if test.name == "wrong window" {
+				window = "usage"
+			}
+			if got, ok := CredentialQuotaProbeResetAt(test.meta, window, now); ok || !got.IsZero() {
+				t.Fatalf("CredentialQuotaProbeResetAt() = %s, %v, want zero, false", got, ok)
+			}
+		})
+	}
+}
+
 func TestSub2APISubscriptionQuotaRecovered(t *testing.T) {
 	t.Parallel()
 
@@ -428,6 +463,111 @@ func TestSub2APISubscriptionQuotaRecovered(t *testing.T) {
 				t.Fatalf("sub2APISubscriptionQuotaRecovered() = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestSub2APISubscriptionQuotaEntry(t *testing.T) {
+	t.Parallel()
+
+	remaining := 0.0
+	result := QuotaProbeResult{Entries: []QuotaProbeEntry{{Label: "weekly", Remaining: &remaining}}}
+	entry, ok := sub2APISubscriptionQuotaEntry(result, "WEEKLY")
+	if !ok || entry.Label != "weekly" || entry.Remaining == nil || *entry.Remaining != 0 {
+		t.Fatalf("entry = %+v, %v, want weekly exhausted entry", entry, ok)
+	}
+	if _, ok := sub2APISubscriptionQuotaEntry(result, "usage"); ok {
+		t.Fatal("usage should not select a specific subscription window")
+	}
+}
+
+func TestRecoverSub2APISubscriptionCooldownUpdatesExhaustedReset(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Now().UTC()
+	credentialID := uuid.New()
+	cooldownID := uuid.New()
+	resetAt := observedAt.Add(2 * time.Hour)
+	updates := 0
+	service := siteServiceWithCallbacks(t, siteGormCallbacks{
+		query: func(tx *gorm.DB) {
+			items, ok := tx.Statement.Dest.(*[]store.RouteCooldown)
+			if !ok {
+				tx.AddError(gorm.ErrInvalidData)
+				return
+			}
+			*items = []store.RouteCooldown{{
+				ID:               cooldownID,
+				SiteID:           uuid.New(),
+				SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
+				Reason:           store.CooldownReasonUpstreamSubscriptionLimitExceeded,
+				ActiveUntil:      observedAt.Add(7 * 24 * time.Hour),
+				CreatedAt:        observedAt.Add(-time.Minute),
+				Metadata:         store.JSON(`{"limit_window":"weekly","reset_at":"2099-01-05T00:00:00Z"}`),
+			}}
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+		update: func(tx *gorm.DB) {
+			updates++
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+	})
+	remaining := 0.0
+	reset := resetAt.Format(time.RFC3339Nano)
+	service.recoverSub2APISubscriptionCooldown(context.Background(), uuid.New(), credentialID, QuotaProbeResult{
+		Status:    "ok",
+		FetchedAt: observedAt,
+		Entries:   []QuotaProbeEntry{{Label: "weekly", Remaining: &remaining, ResetAt: &reset}},
+	})
+	if updates != 1 {
+		t.Fatalf("cooldown updates = %d, want 1", updates)
+	}
+}
+
+func TestRecoverSub2APISubscriptionCooldownKeepsGenericUsageRecovery(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Now().UTC()
+	credentialID := uuid.New()
+	updates := 0
+	service := siteServiceWithCallbacks(t, siteGormCallbacks{
+		query: func(tx *gorm.DB) {
+			items, ok := tx.Statement.Dest.(*[]store.RouteCooldown)
+			if !ok {
+				tx.AddError(gorm.ErrInvalidData)
+				return
+			}
+			*items = []store.RouteCooldown{{
+				ID:               uuid.New(),
+				SiteID:           uuid.New(),
+				SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
+				Reason:           store.CooldownReasonUpstreamSubscriptionLimitExceeded,
+				ActiveUntil:      observedAt.Add(24 * time.Hour),
+				CreatedAt:        observedAt.Add(-time.Minute),
+				Metadata:         store.JSON(`{"limit_window":"usage"}`),
+			}}
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+		update: func(tx *gorm.DB) {
+			updates++
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+	})
+	positive := 1.0
+	service.recoverSub2APISubscriptionCooldown(context.Background(), uuid.New(), credentialID, QuotaProbeResult{
+		Status:    "ok",
+		FetchedAt: observedAt,
+		Entries: []QuotaProbeEntry{
+			{Label: "balance", Remaining: &positive},
+			{Label: "daily", Remaining: &positive},
+			{Label: "weekly", Remaining: &positive},
+		},
+	})
+	if updates != 1 {
+		t.Fatalf("generic usage cooldown updates = %d, want 1", updates)
 	}
 }
 

--- a/server/internal/store/route_cooldown_clear_matching_test.go
+++ b/server/internal/store/route_cooldown_clear_matching_test.go
@@ -58,6 +58,52 @@ func TestClearActiveMatchingBuildsScopedWhereOffline(t *testing.T) {
 	}
 }
 
+func TestUpdateActiveUntilBuildsScopedUpdateOffline(t *testing.T) {
+	t.Parallel()
+
+	cooldownID := uuid.New()
+	db := storeRepositoryOfflineGorm(t)
+	var captured string
+	var vars []any
+	var destination map[string]any
+	storeReplaceUpdateCallback(t, db, func(tx *gorm.DB) {
+		if updates, ok := tx.Statement.Dest.(map[string]any); ok {
+			destination = updates
+		}
+		tx.Statement.Build("WHERE")
+		captured = tx.Statement.SQL.String()
+		vars = tx.Statement.Vars
+		tx.Statement.RowsAffected = 1
+	})
+
+	metadata := JSON(`{"limit_window":"weekly","reset_at":"2026-08-21T14:29:08Z"}`)
+	err := NewRouteCooldownRepository(db).UpdateActiveUntil(context.Background(), cooldownID, time.Date(2026, 8, 21, 14, 29, 8, 0, time.UTC), metadata)
+	if err != nil {
+		t.Fatalf("UpdateActiveUntil returned error: %v", err)
+	}
+	lower := strings.ToLower(captured)
+	for _, want := range []string{"id =", "cleared_at is null"} {
+		if !strings.Contains(lower, want) {
+			t.Fatalf("generated SQL %q missing %q", captured, want)
+		}
+	}
+	if _, ok := destination["active_until"]; !ok {
+		t.Fatalf("update destination %#v missing active_until", destination)
+	}
+	if _, ok := destination["metadata"]; !ok {
+		t.Fatalf("update destination %#v missing metadata", destination)
+	}
+	foundID := false
+	for _, value := range vars {
+		if got, ok := value.(uuid.UUID); ok && got == cooldownID {
+			foundID = true
+		}
+	}
+	if !foundID {
+		t.Fatalf("bound vars %#v missing cooldown id %s", vars, cooldownID)
+	}
+}
+
 func TestCountRecentActivationsBuildsScopedWhereOffline(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/store/route_cooldown_clear_matching_test.go
+++ b/server/internal/store/route_cooldown_clear_matching_test.go
@@ -82,7 +82,7 @@ func TestUpdateActiveUntilBuildsScopedUpdateOffline(t *testing.T) {
 		t.Fatalf("UpdateActiveUntil returned error: %v", err)
 	}
 	lower := strings.ToLower(captured)
-	for _, want := range []string{"id =", "cleared_at is null"} {
+	for _, want := range []string{`"id" =`, `"cleared_at" is null`} {
 		if !strings.Contains(lower, want) {
 			t.Fatalf("generated SQL %q missing %q", captured, want)
 		}

--- a/server/internal/store/route_cooldown_repository.go
+++ b/server/internal/store/route_cooldown_repository.go
@@ -215,6 +215,27 @@ func (r RouteCooldownRepository) ClearActiveMatching(ctx context.Context, filter
 	return result.RowsAffected, nil
 }
 
+// UpdateActiveUntil updates an active cooldown after a fresh upstream quota
+// probe supplies a more accurate reset time. The metadata is updated together
+// so diagnostics and the UI do not retain the old fallback deadline.
+func (r RouteCooldownRepository) UpdateActiveUntil(ctx context.Context, cooldownID uuid.UUID, activeUntil time.Time, metadata JSON) error {
+	if cooldownID == uuid.Nil || activeUntil.IsZero() {
+		return nil
+	}
+	updates := map[string]any{"active_until": activeUntil}
+	if len(metadata) > 0 {
+		updates["metadata"] = metadata
+	}
+	result := r.db.WithContext(ctx).
+		Model(&RouteCooldown{}).
+		Where("id = ? AND cleared_at IS NULL", cooldownID).
+		Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update active route cooldown: %w", result.Error)
+	}
+	return nil
+}
+
 func (r RouteCooldownRepository) DeleteBySiteModel(ctx context.Context, siteID uuid.UUID, siteModelID uuid.UUID) error {
 	if err := r.db.WithContext(ctx).Where(&RouteCooldown{
 		SiteID:      siteID,

--- a/server/internal/store/route_cooldown_repository.go
+++ b/server/internal/store/route_cooldown_repository.go
@@ -228,7 +228,10 @@ func (r RouteCooldownRepository) UpdateActiveUntil(ctx context.Context, cooldown
 	}
 	result := r.db.WithContext(ctx).
 		Model(&RouteCooldown{}).
-		Where("id = ? AND cleared_at IS NULL", cooldownID).
+		Clauses(clause.Where{Exprs: []clause.Expression{
+			clause.Eq{Column: clause.Column{Name: "id"}, Value: cooldownID},
+			clause.Eq{Column: clause.Column{Name: "cleared_at"}, Value: nil},
+		}}).
 		Updates(updates)
 	if result.Error != nil {
 		return fmt.Errorf("update active route cooldown: %w", result.Error)


### PR DESCRIPTION
## 背景

TokenPlan 订阅额度耗尽时，xLyra 会将对应凭证进入订阅限额冷却。部分上游错误响应只说明周限额耗尽，并不携带准确的重置时间；但额度探测接口已经返回了订阅窗口的实际 `resets_at`。

实际案例中，上游周限额重置时间为周五 22:29 左右，旧逻辑却按本地自然周边界将冷却截止到周一 00:00，额外冷却约 49.5 小时。

## 根因

网关错误分类只能看到上游错误响应，缺少当前凭证最近一次成功额度探测的元数据。没有可用的 `Retry-After` 或错误体 `reset_at` 时，原逻辑直接回退到本地日/周/月日历边界，因此忽略了 TokenPlan 的实际重置时间。

## 改动

- 在网关凭证尝试结果中保留当前凭证的额度探测元数据。
- 订阅限额冷却时间按以下优先级选择：`Retry-After`、错误响应 `reset_at`、凭证额度探测中的对应窗口 `reset_at`、本地日/周/月边界回退。
- 额度探测读取 TokenPlan 的 daily/weekly/monthly 窗口时，仅接受成功探测、已耗尽且未来有效的重置时间。
- 后续额度探测发现已有订阅限额冷却时：额度恢复则清除冷却；额度仍耗尽则同步更新 `active_until` 和 metadata，避免旧的日历回退时间继续生效。
- 保留未指定具体窗口的通用 `usage` 冷却恢复行为。
- 增加网关、额度探测和存储层回归测试。

## 影响与兼容性

- 仅改变 `upstream_subscription_limit_exceeded` 凭证冷却的截止时间计算和后续校准。
- 上游已经提供有效 `Retry-After` 或 `reset_at` 时，原有优先级保持不变。
- 非订阅限额错误、其他站点类型、普通限流和通用 `usage` 回退行为不变。
- 不新增数据库迁移，不改变对外请求协议；已有冷却记录会在下一次成功额度探测时被校准。

## 验证

- [x] `cd server && go test ./internal/site ./internal/gateway ./internal/store -count=1`
- [x] `cd server && go vet ./internal/site ./internal/gateway ./internal/store`
- [x] `cd server && go build ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] GitHub Actions Backend / Frontend checks passed

> 本地 Windows 执行 `go test ./internal/...` 时，仓库既有的 `internal/config` 路径测试超时及 `internal/downloads` 文件名断言失败；本 PR 涉及的包已通过，Ubuntu GitHub Backend CI 也已全量通过。