### PR TITLE
feat: 新增模型体验记录跨浏览器持久化与断点续传

### DIFF
--- a/server/internal/app/router.go
+++ b/server/internal/app/router.go
@@ -27,6 +27,7 @@ import (
 	"xlyra/server/internal/newapi"
 	oauthsvc "xlyra/server/internal/oauth"
 	"xlyra/server/internal/observability"
+	"xlyra/server/internal/playground"
 	routeengine "xlyra/server/internal/router"
 	"xlyra/server/internal/settings"
 	"xlyra/server/internal/site"
@@ -71,6 +72,8 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 	downloadService := downloads.NewService()
 	gatewayHandler := gateway.NewHandlerWithTimeZone(logger.With("thread", "gateway"), authService, routerService, db, masterKey, appTimeZone, confFile)
 	playgroundGatewayHandler := gatewayHandler.WithRouteSiteHeader()
+	playgroundService := playground.NewService(logger.With("thread", "playground"), db, gatewayHandler, filepath.Join(config.ResolveWorkdir(), "playground"))
+	playgroundHandler := playground.NewHandler(playgroundService)
 	if db != nil {
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -131,6 +134,16 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 				protected.Use(adminHandler.AuditAdminMutation)
 				protected.Get("/auth/session", adminHandler.CurrentSession)
 				protected.Delete("/auth/session", adminHandler.DeleteSession)
+				protected.Route("/playground", func(playgroundRouter chi.Router) {
+					playgroundRouter.Get("/models", playgroundHandler.Models)
+					playgroundRouter.Get("/conversations", playgroundHandler.List)
+					playgroundRouter.Get("/conversations/{conversationID}", playgroundHandler.Get)
+					playgroundRouter.With(httpx.LimitRequestBody(64*1024*1024)).Post("/conversations/{conversationID}/turns", playgroundHandler.StartTurn)
+					playgroundRouter.Get("/conversations/{conversationID}/events", playgroundHandler.Events)
+					playgroundRouter.Delete("/conversations/{conversationID}", playgroundHandler.Delete)
+					playgroundRouter.Post("/runs/{runID}/cancel", playgroundHandler.Cancel)
+					playgroundRouter.Get("/assets/{assetID}", playgroundHandler.Asset)
+				})
 
 				protected.Get("/profile", adminHandler.GetProfile)
 				protected.Put("/profile/account", adminHandler.UpdateProfileAccount)
@@ -399,6 +412,10 @@ func routeAwareTimeout(timeout time.Duration) func(http.Handler) http.Handler {
 				return
 			}
 			if r.Method == http.MethodGet && r.URL.Path == "/api/v1/traffic-flow/stream" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/playground/conversations/") && strings.HasSuffix(r.URL.Path, "/events") {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/server/internal/playground/assets.go
+++ b/server/internal/playground/assets.go
@@ -1,0 +1,259 @@
+package playground
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+const maxAssetBytes = 25 * 1024 * 1024
+
+type AssetStore struct {
+	root   string
+	repo   store.PlaygroundRepository
+	client *http.Client
+}
+
+func NewAssetStore(root string, repo store.PlaygroundRepository) *AssetStore {
+	assetStore := &AssetStore{root: root, repo: repo}
+	transport := &http.Transport{DialContext: dialPublicAddress}
+	assetStore.client = &http.Client{
+		Timeout:   45 * time.Second,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many image redirects")
+			}
+			return validateRemoteURL(req.Context(), req.URL)
+		},
+	}
+	return assetStore
+}
+
+func dialPublicAddress(ctx context.Context, network string, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, address := range addresses {
+		ip := address.IP
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			continue
+		}
+		return (&net.Dialer{Timeout: 15 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+	return nil, fmt.Errorf("image URL has no public address")
+}
+
+func (s *AssetStore) SaveDataURL(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, purpose string, name string, value string) (store.PlaygroundAsset, error) {
+	comma := strings.IndexByte(value, ',')
+	if comma < 0 || !strings.HasPrefix(value, "data:") {
+		return store.PlaygroundAsset{}, fmt.Errorf("invalid data URL")
+	}
+	meta := value[5:comma]
+	if !strings.Contains(meta, ";base64") {
+		return store.PlaygroundAsset{}, fmt.Errorf("asset data URL must be base64 encoded")
+	}
+	mimeType := strings.TrimSpace(strings.Split(meta, ";")[0])
+	data, err := base64.StdEncoding.DecodeString(value[comma+1:])
+	if err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("decode asset data URL: %w", err)
+	}
+	return s.SaveBytes(ctx, conversationID, runID, purpose, name, mimeType, data)
+}
+
+func (s *AssetStore) SaveBytes(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, purpose string, name string, mimeType string, data []byte) (store.PlaygroundAsset, error) {
+	if len(data) == 0 || len(data) > maxAssetBytes {
+		return store.PlaygroundAsset{}, fmt.Errorf("asset size is invalid")
+	}
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		mimeType = http.DetectContentType(data)
+	}
+	id := uuid.New()
+	ext := extensionForMIME(mimeType)
+	relPath := filepath.ToSlash(filepath.Join("assets", conversationID.String(), purpose, id.String()+ext))
+	absPath := filepath.Join(s.root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o750); err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("create asset directory: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(absPath), ".asset-*")
+	if err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("create asset file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o640); err != nil {
+		_ = temp.Close()
+		return store.PlaygroundAsset{}, err
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return store.PlaygroundAsset{}, fmt.Errorf("write asset: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return store.PlaygroundAsset{}, fmt.Errorf("sync asset: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return store.PlaygroundAsset{}, err
+	}
+	if err := os.Rename(tempPath, absPath); err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("publish asset: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	item := store.PlaygroundAsset{
+		ID: id, ConversationID: conversationID, Purpose: purpose, Path: relPath,
+		OriginalName: name, MIMEType: mimeType, Size: int64(len(data)), SHA256: fmt.Sprintf("%x", digest),
+	}
+	if runID != uuid.Nil {
+		item.RunID = uuid.NullUUID{UUID: runID, Valid: true}
+	}
+	if err := s.repo.CreateAsset(ctx, &item); err != nil {
+		_ = os.Remove(absPath)
+		return store.PlaygroundAsset{}, err
+	}
+	return item, nil
+}
+
+func (s *AssetStore) SaveRemote(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, purpose string, value string) (store.PlaygroundAsset, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("parse image URL: %w", err)
+	}
+	if err := validateRemoteURL(ctx, parsed); err != nil {
+		return store.PlaygroundAsset{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return store.PlaygroundAsset{}, err
+	}
+	response, err := s.client.Do(request)
+	if err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("download image: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return store.PlaygroundAsset{}, fmt.Errorf("download image returned status %d", response.StatusCode)
+	}
+	limited := io.LimitReader(response.Body, maxAssetBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return store.PlaygroundAsset{}, fmt.Errorf("read downloaded image: %w", err)
+	}
+	if len(data) > maxAssetBytes {
+		return store.PlaygroundAsset{}, fmt.Errorf("downloaded image is too large")
+	}
+	mimeType := strings.TrimSpace(strings.Split(response.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+	if !strings.HasPrefix(mimeType, "image/") {
+		return store.PlaygroundAsset{}, fmt.Errorf("downloaded resource is not an image")
+	}
+	name := filepath.Base(parsed.Path)
+	return s.SaveBytes(ctx, conversationID, runID, purpose, name, mimeType, data)
+}
+
+func validateRemoteURL(ctx context.Context, parsed *url.URL) error {
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("image URL scheme is not allowed")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("image URL host is required")
+	}
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("resolve image URL host: %w", err)
+	}
+	for _, address := range addresses {
+		ip := address.IP
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			return fmt.Errorf("image URL resolves to a private address")
+		}
+	}
+	return nil
+}
+
+func extensionForMIME(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "image/avif":
+		return ".avif"
+	case "application/pdf":
+		return ".pdf"
+	case "text/plain":
+		return ".txt"
+	case "application/json":
+		return ".json"
+	default:
+		return ".png"
+	}
+}
+
+func (s *AssetStore) Read(ctx context.Context, id uuid.UUID) (store.PlaygroundAsset, []byte, error) {
+	item, err := s.repo.GetAsset(ctx, id)
+	if err != nil {
+		return store.PlaygroundAsset{}, nil, err
+	}
+	path := filepath.Join(s.root, filepath.FromSlash(item.Path))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return store.PlaygroundAsset{}, nil, err
+	}
+	return item, data, nil
+}
+
+func (s *AssetStore) Delete(ctx context.Context, asset store.PlaygroundAsset) error {
+	if err := s.repo.DeleteAsset(ctx, asset.ID); err != nil {
+		return err
+	}
+	path := filepath.Join(s.root, filepath.FromSlash(asset.Path))
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (s *AssetStore) DataURL(ctx context.Context, id uuid.UUID) (string, error) {
+	item, data, err := s.Read(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	var builder bytes.Buffer
+	builder.WriteString("data:")
+	builder.WriteString(item.MIMEType)
+	builder.WriteString(";base64,")
+	encoder := base64.NewEncoder(base64.StdEncoding, &builder)
+	if _, err := encoder.Write(data); err != nil {
+		return "", err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}

--- a/server/internal/playground/handler.go
+++ b/server/internal/playground/handler.go
@@ -1,0 +1,264 @@
+package playground
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"xlyra/server/internal/auth"
+	"xlyra/server/internal/httpx"
+	"xlyra/server/internal/store"
+)
+
+type Handler struct {
+	service *Service
+}
+
+func NewHandler(service *Service) Handler {
+	return Handler{service: service}
+}
+
+func (h Handler) List(w http.ResponseWriter, r *http.Request) {
+	adminID, ok := adminID(w, r)
+	if !ok {
+		return
+	}
+	items, err := h.service.List(r.Context(), adminID, r.URL.Query().Get("mode"))
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+func (h Handler) Get(w http.ResponseWriter, r *http.Request) {
+	adminID, id, ok := h.conversationIDs(w, r)
+	if !ok {
+		return
+	}
+	item, err := h.service.Get(r.Context(), adminID, id)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	httpx.JSON(w, http.StatusOK, item)
+}
+
+func (h Handler) StartTurn(w http.ResponseWriter, r *http.Request) {
+	adminID, id, ok := h.conversationIDs(w, r)
+	if !ok {
+		return
+	}
+	var input TurnRequest
+	if err := httpx.DecodeJSONBody(r, &input); err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_json", "request body must be valid JSON")
+		return
+	}
+	item, err := h.service.StartTurn(r.Context(), adminID, id, input)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	httpx.JSON(w, http.StatusAccepted, item)
+}
+
+func (h Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	adminID, id, ok := h.conversationIDs(w, r)
+	if !ok {
+		return
+	}
+	if err := h.service.Delete(r.Context(), adminID, id); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h Handler) Cancel(w http.ResponseWriter, r *http.Request) {
+	adminID, ok := adminID(w, r)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(chi.URLParam(r, "runID"))
+	if err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_run_id", "run id must be a UUID")
+		return
+	}
+	if err := h.service.Cancel(r.Context(), adminID, id); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	httpx.JSON(w, http.StatusAccepted, map[string]any{"status": "cancelling"})
+}
+
+func (h Handler) Events(w http.ResponseWriter, r *http.Request) {
+	adminID, id, ok := h.conversationIDs(w, r)
+	if !ok {
+		return
+	}
+	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httpx.Error(w, r, http.StatusInternalServerError, "streaming_unsupported", "streaming is not supported")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	lastActivity := time.Now()
+	var offset int64
+	for {
+		events, run, nextOffset, err := h.service.Events(r.Context(), adminID, id, offset, after)
+		if err != nil {
+			return
+		}
+		offset = nextOffset
+		for _, event := range events {
+			encoded, marshalErr := json.Marshal(event)
+			if marshalErr != nil {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "id: %d\nevent: rollout\ndata: %s\n\n", event.Ordinal, encoded); err != nil {
+				return
+			}
+			after = event.Ordinal
+			lastActivity = time.Now()
+		}
+		if len(events) > 0 {
+			flusher.Flush()
+		}
+		active := run.ID != uuid.Nil && (run.Status == "queued" || run.Status == "running")
+		if !active {
+			encoded, _ := json.Marshal(runView(run))
+			_, _ = fmt.Fprintf(w, "event: run_status\ndata: %s\n\n", encoded)
+			flusher.Flush()
+			return
+		}
+		if time.Since(lastActivity) >= 15*time.Second {
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+			lastActivity = time.Now()
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (h Handler) Asset(w http.ResponseWriter, r *http.Request) {
+	adminID, ok := adminID(w, r)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(chi.URLParam(r, "assetID"))
+	if err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_asset_id", "asset id must be a UUID")
+		return
+	}
+	asset, data, err := h.service.assets.Read(r.Context(), id)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	if _, err := h.service.repo.GetConversation(r.Context(), adminID, asset.ConversationID); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", asset.MIMEType)
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(data)), 10))
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	if len(asset.MIMEType) < 6 || asset.MIMEType[:6] != "image/" {
+		w.Header().Set("Content-Disposition", `attachment; filename="download"`)
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (h Handler) Models(w http.ResponseWriter, r *http.Request) {
+	if _, ok := adminID(w, r); !ok {
+		return
+	}
+	apiKeyID, err := uuid.Parse(r.URL.Query().Get("api_key_id"))
+	if err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_api_key_id", "api key id must be a UUID")
+		return
+	}
+	apiKey, err := store.NewAPIKeyRepository(h.service.db.DB()).GetByID(r.Context(), apiKeyID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	var body bytes.Buffer
+	capture := newCaptureWriter(func(data []byte) error {
+		_, writeErr := body.Write(data)
+		return writeErr
+	})
+	request, err := http.NewRequestWithContext(auth.WithAPIKey(r.Context(), apiKey), http.MethodGet, "/models", nil)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	h.service.gateway.Models(capture, request)
+	for key, values := range capture.Header() {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(capture.status)
+	_, _ = w.Write(body.Bytes())
+}
+
+func adminID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	id, ok := auth.AdminIDFromContext(r.Context())
+	if !ok {
+		httpx.Error(w, r, http.StatusUnauthorized, "unauthorized", "admin session is required")
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+func (h Handler) conversationIDs(w http.ResponseWriter, r *http.Request) (uuid.UUID, uuid.UUID, bool) {
+	adminID, ok := adminID(w, r)
+	if !ok {
+		return uuid.Nil, uuid.Nil, false
+	}
+	id, err := uuid.Parse(chi.URLParam(r, "conversationID"))
+	if err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_conversation_id", "conversation id must be a UUID")
+		return uuid.Nil, uuid.Nil, false
+	}
+	return adminID, id, true
+}
+
+func (h Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {
+	status := http.StatusBadRequest
+	code := "playground_error"
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		status = http.StatusNotFound
+		code = "not_found"
+	}
+	if errors.Is(err, context.Canceled) {
+		status = http.StatusRequestTimeout
+		code = "request_cancelled"
+	}
+	httpx.Error(w, r, status, code, err.Error())
+}

--- a/server/internal/playground/rollout.go
+++ b/server/internal/playground/rollout.go
@@ -1,0 +1,403 @@
+package playground
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+type RolloutStore struct {
+	root  string
+	repo  store.PlaygroundRepository
+	mu    sync.Mutex
+	locks map[uuid.UUID]*sync.Mutex
+}
+
+func NewRolloutStore(root string, repo store.PlaygroundRepository) *RolloutStore {
+	return &RolloutStore{root: root, repo: repo, locks: map[uuid.UUID]*sync.Mutex{}}
+}
+
+func (s *RolloutStore) Root() string {
+	return s.root
+}
+
+func (s *RolloutStore) NewPath(id uuid.UUID, now time.Time) string {
+	name := fmt.Sprintf("rollout-%s-%s.jsonl", now.UTC().Format("2006-01-02T15-04-05"), id.String())
+	return filepath.ToSlash(filepath.Join("sessions", now.UTC().Format("2006"), now.UTC().Format("01"), now.UTC().Format("02"), name))
+}
+
+func (s *RolloutStore) mutex(id uuid.UUID) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if value := s.locks[id]; value != nil {
+		return value
+	}
+	value := &sync.Mutex{}
+	s.locks[id] = value
+	return value
+}
+
+func (s *RolloutStore) Append(ctx context.Context, conversation store.PlaygroundConversation, eventType string, runID uuid.UUID, payload any, title string) (appendResult, error) {
+	lock := s.mutex(conversation.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	absPath := filepath.Join(s.root, filepath.FromSlash(conversation.RolloutPath))
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o750); err != nil {
+		return appendResult{}, fmt.Errorf("create rollout directory: %w", err)
+	}
+	fileLock, err := s.acquireFileLock(ctx, conversation.ID)
+	if err != nil {
+		return appendResult{}, err
+	}
+	defer s.releaseFileLock(fileLock)
+	if err := repairRolloutTail(absPath); err != nil {
+		return appendResult{}, err
+	}
+
+	encodedPayload, err := json.Marshal(payload)
+	if err != nil {
+		return appendResult{}, fmt.Errorf("encode rollout payload: %w", err)
+	}
+	lastOrdinal, err := lastRolloutOrdinal(absPath)
+	if err != nil {
+		return appendResult{}, err
+	}
+	if conversation.LastOrdinal > lastOrdinal {
+		lastOrdinal = conversation.LastOrdinal
+	}
+	ordinal := lastOrdinal + 1
+	event := Event{Timestamp: time.Now().UTC(), Ordinal: ordinal, Type: eventType, Payload: encodedPayload}
+	if runID != uuid.Nil {
+		event.RunID = runID.String()
+	}
+	line, err := json.Marshal(event)
+	if err != nil {
+		return appendResult{}, fmt.Errorf("encode rollout event: %w", err)
+	}
+	line = append(line, '\n')
+
+	file, err := os.OpenFile(absPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return appendResult{}, fmt.Errorf("open rollout: %w", err)
+	}
+	stat, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return appendResult{}, fmt.Errorf("inspect rollout: %w", err)
+	}
+	if _, err := file.Write(line); err != nil {
+		_ = file.Close()
+		return appendResult{}, fmt.Errorf("append rollout: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return appendResult{}, fmt.Errorf("sync rollout: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return appendResult{}, fmt.Errorf("close rollout: %w", err)
+	}
+	offset := stat.Size() + int64(len(line))
+	if err := s.repo.UpdateConversationCursor(ctx, conversation.ID, title, ordinal, offset, time.Now()); err != nil {
+		return appendResult{}, err
+	}
+	return appendResult{Ordinal: ordinal, Offset: offset}, nil
+}
+
+func repairRolloutTail(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0o640)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil || stat.Size() == 0 {
+		return err
+	}
+	last := make([]byte, 1)
+	if _, err := file.ReadAt(last, stat.Size()-1); err != nil {
+		return err
+	}
+	if last[0] == '\n' {
+		return nil
+	}
+	end := stat.Size()
+	for end > 0 {
+		start := end - 64*1024
+		if start < 0 {
+			start = 0
+		}
+		chunk := make([]byte, end-start)
+		if _, err := file.ReadAt(chunk, start); err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		if index := bytes.LastIndexByte(chunk, '\n'); index >= 0 {
+			return file.Truncate(start + int64(index) + 1)
+		}
+		end = start
+	}
+	return file.Truncate(0)
+}
+
+func lastRolloutOrdinal(path string) (int64, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if stat.Size() == 0 {
+		return 0, nil
+	}
+	end := stat.Size()
+	var collected []byte
+	for end > 0 {
+		start := end - 64*1024
+		if start < 0 {
+			start = 0
+		}
+		chunk := make([]byte, end-start)
+		if _, err := file.ReadAt(chunk, start); err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+		collected = append(chunk, collected...)
+		trimmed := bytes.TrimRight(collected, "\r\n")
+		if index := bytes.LastIndexByte(trimmed, '\n'); index >= 0 || start == 0 {
+			line := trimmed
+			if index >= 0 {
+				line = trimmed[index+1:]
+			}
+			var event Event
+			if err := json.Unmarshal(line, &event); err != nil {
+				return 0, fmt.Errorf("decode last rollout event: %w", err)
+			}
+			return event.Ordinal, nil
+		}
+		end = start
+	}
+	return 0, nil
+}
+
+func (s *RolloutStore) acquireFileLock(ctx context.Context, id uuid.UUID) (*os.File, error) {
+	dir := filepath.Join(s.root, "thread-writer-locks")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create writer lock directory: %w", err)
+	}
+	path := filepath.Join(dir, id.String()+".lock")
+	for {
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			return file, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("acquire rollout writer lock: %w", err)
+		}
+		if stat, statErr := os.Stat(path); statErr == nil && time.Since(stat.ModTime()) > 2*time.Minute {
+			_ = os.Remove(path)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func (s *RolloutStore) releaseFileLock(file *os.File) {
+	if file == nil {
+		return
+	}
+	path := file.Name()
+	_ = file.Close()
+	_ = os.Remove(path)
+}
+
+func (s *RolloutStore) Read(conversation store.PlaygroundConversation, after int64) ([]Event, error) {
+	events, _, err := s.ReadFrom(conversation, 0, after)
+	return events, err
+}
+
+func (s *RolloutStore) ReadFrom(conversation store.PlaygroundConversation, offset int64, after int64) ([]Event, int64, error) {
+	absPath := filepath.Join(s.root, filepath.FromSlash(conversation.RolloutPath))
+	file, err := os.Open(absPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, offset, nil
+	}
+	if err != nil {
+		return nil, offset, fmt.Errorf("open rollout: %w", err)
+	}
+	defer file.Close()
+	if offset > 0 {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return nil, offset, fmt.Errorf("seek rollout: %w", err)
+		}
+	}
+
+	reader := bufio.NewReaderSize(file, 64*1024)
+	events := make([]Event, 0)
+	nextOffset := offset
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			var event Event
+			if err := json.Unmarshal(line, &event); err != nil {
+				return nil, nextOffset, fmt.Errorf("decode rollout event: %w", err)
+			}
+			nextOffset += int64(len(line))
+			if event.Ordinal > after {
+				events = append(events, event)
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, nextOffset, fmt.Errorf("read rollout: %w", readErr)
+		}
+	}
+	return events, nextOffset, nil
+}
+
+func BuildView(conversation store.PlaygroundConversation, events []Event) (ConversationView, error) {
+	view := ConversationView{ID: conversation.ID.String(), Mode: conversation.Mode, Title: conversation.Title, LastOrdinal: conversation.LastOrdinal, UpdatedAt: conversation.UpdatedAt.UnixMilli()}
+	for _, event := range events {
+		if event.Ordinal > view.LastOrdinal {
+			view.LastOrdinal = event.Ordinal
+			view.UpdatedAt = event.Timestamp.UnixMilli()
+		}
+		switch event.Type {
+		case "conversation_snapshot", "branch_reset":
+			var payload snapshotPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return ConversationView{}, err
+			}
+			view.Chat = payload.Chat
+			view.Image = payload.Image
+		case "message_added":
+			if view.Chat == nil {
+				continue
+			}
+			var payload chatAppendPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return ConversationView{}, err
+			}
+			view.Chat.Title = payload.Title
+			view.Chat.Model = payload.Model
+			view.Chat.SystemPrompt = payload.SystemPrompt
+			view.Chat.UpdatedAt = payload.UpdatedAt
+			view.Chat.Messages = append(view.Chat.Messages, payload.Messages...)
+		case "image_entry_added":
+			if view.Image == nil {
+				continue
+			}
+			var payload imageAppendPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return ConversationView{}, err
+			}
+			view.Image.Title = payload.Title
+			view.Image.UpdatedAt = payload.UpdatedAt
+			view.Image.Entries = append(view.Image.Entries, payload.Entry)
+		case "assistant_delta":
+			if view.Chat == nil {
+				continue
+			}
+			var payload deltaPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return ConversationView{}, err
+			}
+			for index := range view.Chat.Messages {
+				if view.Chat.Messages[index].ID == payload.MessageID {
+					view.Chat.Messages[index].Content += payload.Content
+					view.Chat.Messages[index].Reasoning += payload.Reasoning
+				}
+			}
+		case "assistant_final":
+			if view.Chat == nil {
+				continue
+			}
+			var message ChatMessage
+			if err := json.Unmarshal(event.Payload, &message); err != nil {
+				return ConversationView{}, err
+			}
+			for index := range view.Chat.Messages {
+				if view.Chat.Messages[index].ID == message.ID {
+					view.Chat.Messages[index] = message
+				}
+			}
+		case "image_final":
+			if view.Image == nil {
+				continue
+			}
+			var entry ImageEntry
+			if err := json.Unmarshal(event.Payload, &entry); err != nil {
+				return ConversationView{}, err
+			}
+			for index := range view.Image.Entries {
+				if view.Image.Entries[index].ID == entry.ID {
+					view.Image.Entries[index] = entry
+				}
+			}
+		case "turn_failed", "turn_cancelled", "turn_interrupted":
+			var payload failurePayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return ConversationView{}, err
+			}
+			if view.Chat != nil {
+				for index := range view.Chat.Messages {
+					if view.Chat.Messages[index].ID == payload.MessageID {
+						view.Chat.Messages[index].Error = payload.Error
+						value := payload.ResponseDurationMS
+						view.Chat.Messages[index].ResponseDurationMS = &value
+					}
+				}
+			}
+			if view.Image != nil {
+				for index := range view.Image.Entries {
+					if view.Image.Entries[index].ID == payload.EntryID {
+						view.Image.Entries[index].Pending = false
+						view.Image.Entries[index].Error = payload.Error
+						value := payload.ResponseDurationMS
+						view.Image.Entries[index].ResponseDurationMS = &value
+					}
+				}
+			}
+		}
+	}
+	if view.Chat != nil {
+		view.Chat.ServerPersisted = true
+	}
+	if view.Image != nil {
+		view.Image.ServerPersisted = true
+	}
+	return view, nil
+}
+
+func (s *RolloutStore) Remove(conversation store.PlaygroundConversation) error {
+	absPath := filepath.Join(s.root, filepath.FromSlash(conversation.RolloutPath))
+	if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/server/internal/playground/rollout_test.go
+++ b/server/internal/playground/rollout_test.go
@@ -1,0 +1,207 @@
+package playground
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+func testEvent(t *testing.T, ordinal int64, eventType string, payload any) Event {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Event{Timestamp: time.Unix(ordinal, 0), Ordinal: ordinal, Type: eventType, Payload: encoded}
+}
+
+func TestBuildViewReplaysChatDeltasAndFinal(t *testing.T) {
+	id := uuid.New()
+	conversation := store.PlaygroundConversation{ID: id, Mode: ModeChat, Title: "hello", UpdatedAt: time.Unix(1, 0)}
+	started := ChatConversation{
+		ID: id.String(), Title: "hello", Messages: []ChatMessage{
+			{ID: "user", Role: "user", Content: "hello"},
+			{ID: "assistant", Role: "assistant"},
+		},
+	}
+	final := ChatMessage{ID: "assistant", Role: "assistant", Content: "hello world", Reasoning: "done", Model: "model"}
+	events := []Event{
+		testEvent(t, 1, "conversation_snapshot", snapshotPayload{Mode: ModeChat, Chat: &started}),
+		testEvent(t, 2, "assistant_delta", deltaPayload{MessageID: "assistant", Content: "hello ", Reasoning: "do"}),
+		testEvent(t, 3, "assistant_delta", deltaPayload{MessageID: "assistant", Content: "world", Reasoning: "ne"}),
+		testEvent(t, 4, "assistant_final", final),
+	}
+	view, err := BuildView(conversation, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.Chat == nil || len(view.Chat.Messages) != 2 {
+		t.Fatalf("unexpected chat view: %#v", view.Chat)
+	}
+	if got := view.Chat.Messages[1]; got.Content != "hello world" || got.Reasoning != "done" || got.Model != "model" {
+		t.Fatalf("unexpected assistant message: %#v", got)
+	}
+	if !view.Chat.ServerPersisted || view.LastOrdinal != 4 || view.UpdatedAt != time.Unix(4, 0).UnixMilli() {
+		t.Fatalf("unexpected view metadata: %#v", view)
+	}
+}
+
+func TestBuildViewAppendsNewChatTurnWithoutRepeatingHistory(t *testing.T) {
+	id := uuid.New()
+	conversation := store.PlaygroundConversation{ID: id, Mode: ModeChat, UpdatedAt: time.Unix(1, 0)}
+	chat := ChatConversation{ID: id.String(), Messages: []ChatMessage{{ID: "old", Role: "assistant", Content: "old"}}}
+	added := chatAppendPayload{
+		Title: "next", Model: "model", UpdatedAt: 5,
+		Messages: []ChatMessage{{ID: "user", Role: "user", Content: "next"}, {ID: "assistant", Role: "assistant"}},
+	}
+	events := []Event{
+		testEvent(t, 1, "conversation_snapshot", snapshotPayload{Mode: ModeChat, Chat: &chat}),
+		testEvent(t, 2, "message_added", added),
+		testEvent(t, 3, "assistant_delta", deltaPayload{MessageID: "assistant", Content: "answer"}),
+	}
+	view, err := BuildView(conversation, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(view.Chat.Messages) != 3 || view.Chat.Messages[2].Content != "answer" || view.Chat.Title != "next" {
+		t.Fatalf("unexpected appended chat: %#v", view.Chat)
+	}
+}
+
+func TestBuildViewAppliesInterruptedImageRun(t *testing.T) {
+	id := uuid.New()
+	conversation := store.PlaygroundConversation{ID: id, Mode: ModeImage, UpdatedAt: time.Unix(1, 0)}
+	image := ImageConversation{ID: id.String(), Entries: []ImageEntry{{ID: "entry", Prompt: "draw", Pending: true}}}
+	events := []Event{
+		testEvent(t, 1, "conversation_snapshot", snapshotPayload{Mode: ModeImage, Image: &image}),
+		testEvent(t, 2, "turn_interrupted", failurePayload{EntryID: "entry", Error: "server restarted", ResponseDurationMS: 25}),
+	}
+	view, err := BuildView(conversation, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := view.Image.Entries[0]
+	if entry.Pending || entry.Error != "server restarted" || entry.ResponseDurationMS == nil || *entry.ResponseDurationMS != 25 {
+		t.Fatalf("unexpected image entry: %#v", entry)
+	}
+}
+
+func TestSSEDecoderHandlesSplitEvents(t *testing.T) {
+	var values []string
+	decoder := sseDecoder{onData: func(value string) error {
+		values = append(values, value)
+		return nil
+	}}
+	for _, chunk := range []string{"event: message\nda", "ta: {\"a\":1}\n\n", "data: [DONE]\n\n", "data: second\r\n\r\n"} {
+		if err := decoder.Write([]byte(chunk)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(values) != 2 || values[0] != `{"a":1}` || values[1] != "second" {
+		t.Fatalf("unexpected SSE values: %#v", values)
+	}
+}
+
+func TestValidateRemoteURLRejectsPrivateAddresses(t *testing.T) {
+	parsed, err := url.Parse("http://127.0.0.1/image.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRemoteURL(t.Context(), parsed); err == nil {
+		t.Fatal("expected private address rejection")
+	}
+}
+
+func TestLastRolloutOrdinalReadsLargeFinalLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	events := []Event{
+		testEvent(t, 7, "assistant_delta", deltaPayload{MessageID: "assistant", Content: "first"}),
+		testEvent(t, 8, "assistant_final", ChatMessage{ID: "assistant", Content: string(bytes.Repeat([]byte("x"), 130*1024))}),
+	}
+	var data bytes.Buffer
+	for _, event := range events {
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data.Write(encoded)
+		data.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, data.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ordinal, err := lastRolloutOrdinal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 8 {
+		t.Fatalf("ordinal = %d, want 8", ordinal)
+	}
+}
+
+func TestRepairRolloutTailDropsIncompleteEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	complete, err := json.Marshal(testEvent(t, 3, "turn_started", map[string]any{"model": "model"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := append(append(complete, '\n'), []byte(`{"ordinal":4,"type":"assistant_delta"`)...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := repairRolloutTail(path); err != nil {
+		t.Fatal(err)
+	}
+	ordinal, err := lastRolloutOrdinal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 3 {
+		t.Fatalf("ordinal = %d, want 3", ordinal)
+	}
+}
+
+func TestReadFromContinuesAtLastCompleteOffset(t *testing.T) {
+	root := t.TempDir()
+	relative := filepath.Join("sessions", "rollout.jsonl")
+	path := filepath.Join(root, relative)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var data bytes.Buffer
+	for ordinal := int64(1); ordinal <= 2; ordinal++ {
+		encoded, err := json.Marshal(testEvent(t, ordinal, "assistant_delta", deltaPayload{MessageID: "assistant", Content: "x"}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		data.Write(encoded)
+		data.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, data.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rollout := NewRolloutStore(root, store.PlaygroundRepository{})
+	conversation := store.PlaygroundConversation{RolloutPath: relative}
+	events, offset, err := rollout.ReadFrom(conversation, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Ordinal != 2 || offset != int64(data.Len()) {
+		t.Fatalf("unexpected first read: events=%#v offset=%d", events, offset)
+	}
+	events, nextOffset, err := rollout.ReadFrom(conversation, offset, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 || nextOffset != offset {
+		t.Fatalf("unexpected continuation: events=%#v offset=%d", events, nextOffset)
+	}
+}

--- a/server/internal/playground/runner.go
+++ b/server/internal/playground/runner.go
@@ -1,0 +1,694 @@
+package playground
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/auth"
+	"xlyra/server/internal/gateway"
+	"xlyra/server/internal/store"
+)
+
+type captureWriter struct {
+	header http.Header
+	status int
+	mu     sync.Mutex
+	write  func([]byte) error
+}
+
+func newCaptureWriter(write func([]byte) error) *captureWriter {
+	return &captureWriter{header: make(http.Header), status: http.StatusOK, write: write}
+}
+
+func (w *captureWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *captureWriter) WriteHeader(status int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status = status
+}
+
+func (w *captureWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.write != nil {
+		if err := w.write(data); err != nil {
+			return 0, err
+		}
+	}
+	return len(data), nil
+}
+
+func (w *captureWriter) Flush() {}
+
+type sseDecoder struct {
+	buffer string
+	onData func(string) error
+}
+
+func (d *sseDecoder) Write(data []byte) error {
+	d.buffer += string(data)
+	for {
+		index, size := sseBoundary(d.buffer)
+		if index < 0 {
+			return nil
+		}
+		raw := d.buffer[:index]
+		d.buffer = d.buffer[index+size:]
+		lines := strings.FieldsFunc(raw, func(r rune) bool { return r == '\r' || r == '\n' })
+		values := make([]string, 0)
+		for _, line := range lines {
+			line = strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(line, "data:") {
+				values = append(values, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if len(values) > 0 {
+			value := strings.Join(values, "\n")
+			if value != "[DONE]" {
+				if err := d.onData(value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func sseBoundary(value string) (int, int) {
+	best := -1
+	size := 0
+	for _, boundary := range []string{"\r\n\r\n", "\n\n", "\r\r"} {
+		if index := strings.Index(value, boundary); index >= 0 && (best < 0 || index < best) {
+			best = index
+			size = len(boundary)
+		}
+	}
+	return best, size
+}
+
+type chatRunState struct {
+	content       string
+	reasoning     string
+	pendingText   string
+	pendingReason string
+	usage         *Usage
+	siteName      string
+	failure       string
+	lastFlush     time.Time
+}
+
+const messagesMaxTokens = 16384
+
+func (s *Service) execute(run store.PlaygroundRun, apiKey store.APIKey, conversation store.PlaygroundConversation, payload RunPayload, ready chan<- struct{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	s.mu.Lock()
+	s.cancels[run.ID] = cancel
+	s.finishes[run.ID] = done
+	s.mu.Unlock()
+	close(ready)
+	defer func() {
+		cancel()
+		s.mu.Lock()
+		delete(s.cancels, run.ID)
+		delete(s.finishes, run.ID)
+		s.mu.Unlock()
+		close(done)
+	}()
+	if current, err := s.repo.GetRun(context.Background(), run.ID); err == nil && current.CancelRequested {
+		cancel()
+	}
+	now := time.Now()
+	_ = s.patchRun(ctx, run.ConversationID, run.ID, map[string]any{"status": "running", "started_at": now, "updated_at": now})
+	if payload.Mode == ModeImage {
+		s.executeImage(ctx, run, apiKey, &conversation, payload)
+		return
+	}
+	s.executeChat(ctx, run, apiKey, &conversation, payload)
+}
+
+func (s *Service) executeChat(ctx context.Context, run store.PlaygroundRun, apiKey store.APIKey, conversation *store.PlaygroundConversation, payload RunPayload) {
+	startedAt := time.Now()
+	state := &chatRunState{lastFlush: startedAt}
+	body, err := s.chatGatewayBody(ctx, payload)
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, err, false)
+		return
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, err, false)
+		return
+	}
+	decoder := &sseDecoder{onData: func(value string) error {
+		if err := s.consumeChatEvent(payload.Protocol, value, state); err != nil {
+			return err
+		}
+		if len(state.pendingText)+len(state.pendingReason) >= 4096 || time.Since(state.lastFlush) >= 300*time.Millisecond {
+			return s.flushChatDelta(ctx, run, conversation, payload, state)
+		}
+		return nil
+	}}
+	writer := newCaptureWriter(decoder.Write)
+	request, err := http.NewRequestWithContext(auth.WithAPIKey(ctx, apiKey), http.MethodPost, gatewayPath(payload.Protocol), bytes.NewReader(encoded))
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, err, false)
+		return
+	}
+	request.Header.Set("Content-Type", "application/json")
+	s.serveGateway(writer, request, payload.Protocol, false)
+	state.siteName = routeSiteName(writer.Header())
+	if err := s.flushChatDelta(context.Background(), run, conversation, payload, state); err != nil && state.failure == "" {
+		state.failure = err.Error()
+	}
+	if ctx.Err() != nil {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, context.Canceled, true)
+		return
+	}
+	if writer.status < 200 || writer.status >= 300 {
+		if state.failure == "" {
+			state.failure = fmt.Sprintf("gateway returned status %d", writer.status)
+		}
+	}
+	if state.failure != "" {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, errors.New(state.failure), false)
+		return
+	}
+	duration := time.Since(startedAt).Milliseconds()
+	message := ChatMessage{ID: payload.MessageID, Role: "assistant", Content: state.content, Reasoning: state.reasoning, Usage: state.usage, Model: payload.Model, SiteName: state.siteName, ResponseDurationMS: &duration, CreatedAt: startedAt.UnixMilli()}
+	result, err := s.append(context.Background(), conversation, "assistant_final", run.ID, message, conversation.Title)
+	if err == nil {
+		result, err = s.append(context.Background(), conversation, "turn_completed", run.ID, map[string]any{"response_duration_ms": duration}, conversation.Title)
+	}
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, state, startedAt, err, false)
+		return
+	}
+	now := time.Now()
+	_ = s.patchRun(context.Background(), run.ConversationID, run.ID, map[string]any{"status": "completed", "completed_at": now, "updated_at": now})
+	_ = s.repo.UpdateTurnIndex(context.Background(), run.ID, "completed", result.Ordinal, result.Offset)
+}
+
+func (s *Service) flushChatDelta(ctx context.Context, run store.PlaygroundRun, conversation *store.PlaygroundConversation, payload RunPayload, state *chatRunState) error {
+	if state.pendingText == "" && state.pendingReason == "" {
+		return nil
+	}
+	delta := deltaPayload{MessageID: payload.MessageID, Content: state.pendingText, Reasoning: state.pendingReason}
+	if _, err := s.append(ctx, conversation, "assistant_delta", run.ID, delta, conversation.Title); err != nil {
+		return err
+	}
+	state.pendingText = ""
+	state.pendingReason = ""
+	state.lastFlush = time.Now()
+	return nil
+}
+
+func (s *Service) consumeChatEvent(protocol string, value string, state *chatRunState) error {
+	var event map[string]any
+	if err := json.Unmarshal([]byte(value), &event); err != nil {
+		return nil
+	}
+	if protocol == "responses" {
+		eventType, _ := event["type"].(string)
+		switch eventType {
+		case "response.output_text.delta":
+			state.addContent(stringValue(event["delta"]))
+		case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
+			state.addReasoning(stringValue(event["delta"]))
+		case "response.completed", "response.incomplete":
+			if response, ok := event["response"].(map[string]any); ok {
+				state.usage = responsesUsage(response["usage"])
+			}
+		case "response.failed", "error":
+			state.failure = nestedError(event)
+		}
+		return nil
+	}
+	if protocol == "messages" {
+		eventType, _ := event["type"].(string)
+		switch eventType {
+		case "content_block_delta":
+			if delta, ok := event["delta"].(map[string]any); ok {
+				switch stringValue(delta["type"]) {
+				case "text_delta":
+					state.addContent(stringValue(delta["text"]))
+				case "thinking_delta":
+					state.addReasoning(stringValue(delta["thinking"]))
+				}
+			}
+		case "message_start":
+			if message, ok := event["message"].(map[string]any); ok {
+				state.usage = anthropicUsage(message["usage"], state.usage)
+			}
+		case "message_delta":
+			state.usage = anthropicUsage(event["usage"], state.usage)
+		case "error":
+			state.failure = nestedError(event)
+		}
+		return nil
+	}
+	if errorValue, ok := event["error"].(map[string]any); ok {
+		state.failure = stringValue(errorValue["message"])
+	}
+	if choices, ok := event["choices"].([]any); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]any); ok {
+			if delta, ok := choice["delta"].(map[string]any); ok {
+				state.addContent(stringValue(delta["content"]))
+				state.addReasoning(stringValue(delta["reasoning_content"]))
+			}
+		}
+	}
+	if usage, ok := event["usage"].(map[string]any); ok {
+		state.usage = openAIUsage(usage)
+	}
+	return nil
+}
+
+func (s *chatRunState) addContent(value string) {
+	s.content += value
+	s.pendingText += value
+}
+
+func (s *chatRunState) addReasoning(value string) {
+	s.reasoning += value
+	s.pendingReason += value
+}
+
+func (s *Service) finishFailedRun(run store.PlaygroundRun, conversation *store.PlaygroundConversation, payload RunPayload, state *chatRunState, startedAt time.Time, failure error, cancelled bool) {
+	duration := time.Since(startedAt).Milliseconds()
+	status := "failed"
+	eventType := "turn_failed"
+	message := failure.Error()
+	if cancelled {
+		status = "cancelled"
+		eventType = "turn_cancelled"
+		message = "request cancelled"
+	} else if state != nil && (state.content != "" || state.reasoning != "") {
+		status = "partial"
+	}
+	if state != nil && (state.content != "" || state.reasoning != "") {
+		final := ChatMessage{ID: payload.MessageID, Role: "assistant", Content: state.content, Reasoning: state.reasoning, Usage: state.usage, Model: payload.Model, SiteName: state.siteName, ResponseDurationMS: &duration, CreatedAt: startedAt.UnixMilli()}
+		_, _ = s.append(context.Background(), conversation, "assistant_final", run.ID, final, conversation.Title)
+	}
+	result, _ := s.append(context.Background(), conversation, eventType, run.ID, failurePayload{MessageID: payload.MessageID, EntryID: payload.EntryID, Error: message, ResponseDurationMS: duration}, conversation.Title)
+	now := time.Now()
+	_ = s.patchRun(context.Background(), run.ConversationID, run.ID, map[string]any{"status": status, "error": message, "completed_at": now, "updated_at": now})
+	_ = s.repo.UpdateTurnIndex(context.Background(), run.ID, status, result.Ordinal, result.Offset)
+}
+
+func (s *Service) chatGatewayBody(ctx context.Context, payload RunPayload) (map[string]any, error) {
+	if payload.Chat == nil {
+		return nil, fmt.Errorf("chat payload is missing")
+	}
+	messages := make([]map[string]any, 0, len(payload.Chat.Messages)+1)
+	if strings.TrimSpace(payload.Chat.SystemPrompt) != "" && payload.Protocol != "responses" && payload.Protocol != "messages" {
+		messages = append(messages, map[string]any{"role": "system", "content": payload.Chat.SystemPrompt})
+	}
+	for _, message := range payload.Chat.Messages {
+		if message.ID == payload.MessageID || message.Error != "" {
+			continue
+		}
+		content, err := s.gatewayMessageContent(ctx, payload.Protocol, message)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, map[string]any{"role": message.Role, "content": content})
+	}
+	if payload.Protocol == "responses" {
+		input := make([]map[string]any, 0, len(messages))
+		for _, message := range messages {
+			if message["role"] == "system" {
+				continue
+			}
+			input = append(input, map[string]any{"type": "message", "role": message["role"], "content": message["content"]})
+		}
+		body := map[string]any{"model": payload.Model, "input": input, "stream": true}
+		if strings.TrimSpace(payload.Chat.SystemPrompt) != "" {
+			body["instructions"] = strings.TrimSpace(payload.Chat.SystemPrompt)
+		}
+		if payload.ReasoningEffort != "" {
+			body["reasoning"] = map[string]any{"effort": payload.ReasoningEffort, "summary": "auto"}
+		}
+		return body, nil
+	}
+	if payload.Protocol == "messages" {
+		body := map[string]any{"model": payload.Model, "max_tokens": messagesMaxTokens, "messages": messages, "stream": true}
+		if strings.TrimSpace(payload.Chat.SystemPrompt) != "" {
+			body["system"] = strings.TrimSpace(payload.Chat.SystemPrompt)
+		}
+		return body, nil
+	}
+	body := map[string]any{"model": payload.Model, "messages": messages, "stream": true, "stream_options": map[string]any{"include_usage": true}}
+	if payload.ReasoningEffort != "" {
+		body["reasoning_effort"] = payload.ReasoningEffort
+	}
+	return body, nil
+}
+
+func (s *Service) gatewayMessageContent(ctx context.Context, protocol string, message ChatMessage) (any, error) {
+	if len(message.Attachments) == 0 {
+		return message.Content, nil
+	}
+	parts := make([]map[string]any, 0, len(message.Attachments)+1)
+	if message.Content != "" {
+		partType := "text"
+		if protocol == "responses" {
+			if message.Role == "assistant" {
+				partType = "output_text"
+			} else {
+				partType = "input_text"
+			}
+		}
+		parts = append(parts, map[string]any{"type": partType, "text": message.Content})
+	}
+	for _, attachment := range message.Attachments {
+		id, err := uuid.Parse(attachment.AssetID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid attachment asset")
+		}
+		dataURL, err := s.assets.DataURL(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if protocol == "responses" {
+			if strings.HasPrefix(attachment.MIMEType, "image/") {
+				parts = append(parts, map[string]any{"type": "input_image", "image_url": dataURL})
+			} else {
+				parts = append(parts, map[string]any{"type": "input_file", "filename": attachment.Name, "file_data": dataURL})
+			}
+			continue
+		}
+		if protocol == "messages" {
+			comma := strings.IndexByte(dataURL, ',')
+			data := dataURL
+			if comma >= 0 {
+				data = dataURL[comma+1:]
+			}
+			if strings.HasPrefix(attachment.MIMEType, "image/") {
+				parts = append(parts, map[string]any{"type": "image", "source": map[string]any{"type": "base64", "media_type": attachment.MIMEType, "data": data}})
+			} else {
+				parts = append(parts, map[string]any{"type": "document", "title": attachment.Name, "source": map[string]any{"type": "base64", "media_type": attachment.MIMEType, "data": data}})
+			}
+			continue
+		}
+		if strings.HasPrefix(attachment.MIMEType, "image/") {
+			parts = append(parts, map[string]any{"type": "image_url", "image_url": map[string]any{"url": dataURL}})
+		} else {
+			parts = append(parts, map[string]any{"type": "file", "file": map[string]any{"filename": attachment.Name, "file_data": dataURL}})
+		}
+	}
+	return parts, nil
+}
+
+func gatewayPath(protocol string) string {
+	switch protocol {
+	case "responses":
+		return "/responses"
+	case "messages":
+		return "/messages"
+	default:
+		return "/chat/completions"
+	}
+}
+
+func (s *Service) serveGateway(writer http.ResponseWriter, request *http.Request, protocol string, image bool) {
+	if image {
+		if strings.Contains(request.URL.Path, "edits") {
+			s.gateway.ImagesEdits(writer, request)
+		} else {
+			s.gateway.ImagesGenerations(writer, request)
+		}
+		return
+	}
+	switch protocol {
+	case "responses":
+		s.gateway.Responses(writer, request)
+	case "messages":
+		s.gateway.Messages(writer, request)
+	default:
+		s.gateway.ChatCompletions(writer, request)
+	}
+}
+
+func (s *Service) executeImage(ctx context.Context, run store.PlaygroundRun, apiKey store.APIKey, conversation *store.PlaygroundConversation, payload RunPayload) {
+	startedAt := time.Now()
+	body, contentType, path, err := s.imageGatewayBody(ctx, payload)
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, err, false)
+		return
+	}
+	var response bytes.Buffer
+	writer := newCaptureWriter(func(data []byte) error {
+		if response.Len()+len(data) > maxAssetBytes*2 {
+			return fmt.Errorf("image response is too large")
+		}
+		_, err := response.Write(data)
+		return err
+	})
+	request, err := http.NewRequestWithContext(auth.WithAPIKey(ctx, apiKey), http.MethodPost, path, body)
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, err, false)
+		return
+	}
+	request.Header.Set("Content-Type", contentType)
+	s.serveGateway(writer, request, "", true)
+	if ctx.Err() != nil {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, context.Canceled, true)
+		return
+	}
+	if writer.status < 200 || writer.status >= 300 {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, gatewayJSONError(response.Bytes(), writer.status), false)
+		return
+	}
+	var upstream struct {
+		Data []struct {
+			Base64 string `json:"b64_json"`
+			URL    string `json:"url"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response.Bytes(), &upstream); err != nil {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, fmt.Errorf("decode image response: %w", err), false)
+		return
+	}
+	results := make([]ImageResult, 0, len(upstream.Data))
+	saved := make([]store.PlaygroundAsset, 0, len(upstream.Data))
+	for _, item := range upstream.Data {
+		var asset store.PlaygroundAsset
+		if item.Base64 != "" {
+			data, decodeErr := base64.StdEncoding.DecodeString(item.Base64)
+			if decodeErr != nil {
+				err = decodeErr
+				break
+			}
+			asset, err = s.assets.SaveBytes(context.Background(), conversation.ID, run.ID, "generated-images", "generated.png", "image/png", data)
+		} else if item.URL != "" {
+			asset, err = s.assets.SaveRemote(context.Background(), conversation.ID, run.ID, "generated-images", item.URL)
+		} else {
+			err = fmt.Errorf("image response item has no image data")
+		}
+		if err != nil {
+			break
+		}
+		saved = append(saved, asset)
+		results = append(results, ImageResult{ID: uuid.NewString(), Src: assetURL(asset.ID), AssetID: asset.ID.String()})
+	}
+	if err != nil || len(results) == 0 {
+		if err == nil {
+			err = fmt.Errorf("image response did not contain images")
+		}
+		s.discardAssets(saved)
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, err, false)
+		return
+	}
+	duration := time.Since(startedAt).Milliseconds()
+	entry := payload.Image.Entries[len(payload.Image.Entries)-1]
+	entry.Images = results
+	entry.SiteName = routeSiteName(writer.Header())
+	entry.Pending = false
+	entry.ResponseDurationMS = &duration
+	result, err := s.append(context.Background(), conversation, "image_final", run.ID, entry, conversation.Title)
+	if err == nil {
+		result, err = s.append(context.Background(), conversation, "turn_completed", run.ID, map[string]any{"response_duration_ms": duration}, conversation.Title)
+	}
+	if err != nil {
+		s.finishFailedRun(run, conversation, payload, nil, startedAt, err, false)
+		return
+	}
+	now := time.Now()
+	_ = s.patchRun(context.Background(), run.ConversationID, run.ID, map[string]any{"status": "completed", "completed_at": now, "updated_at": now})
+	_ = s.repo.UpdateTurnIndex(context.Background(), run.ID, "completed", result.Ordinal, result.Offset)
+}
+
+func (s *Service) discardAssets(assets []store.PlaygroundAsset) {
+	for _, asset := range assets {
+		_ = s.assets.Delete(context.Background(), asset)
+	}
+}
+
+func (s *Service) imageGatewayBody(ctx context.Context, payload RunPayload) (io.Reader, string, string, error) {
+	if payload.Image == nil || len(payload.Image.Entries) == 0 {
+		return nil, "", "", fmt.Errorf("image payload is missing")
+	}
+	entry := payload.Image.Entries[len(payload.Image.Entries)-1]
+	if entry.Mode != "edit" || len(entry.SourceAssetIDs) == 0 {
+		body := map[string]any{"model": payload.Model, "prompt": entry.Prompt, "n": 1, "response_format": "b64_json"}
+		if entry.Size != "" && entry.Size != "auto" {
+			body["size"] = entry.Size
+		}
+		encoded, err := json.Marshal(body)
+		return bytes.NewReader(encoded), "application/json", "/images/generations", err
+	}
+	var buffer bytes.Buffer
+	writer := multipart.NewWriter(&buffer)
+	for key, value := range map[string]string{"model": payload.Model, "prompt": entry.Prompt, "n": "1"} {
+		if err := writer.WriteField(key, value); err != nil {
+			return nil, "", "", err
+		}
+	}
+	if entry.Size != "" && entry.Size != "auto" {
+		if err := writer.WriteField("size", entry.Size); err != nil {
+			return nil, "", "", err
+		}
+	}
+	for index, value := range entry.SourceAssetIDs {
+		id, err := uuid.Parse(value)
+		if err != nil {
+			return nil, "", "", err
+		}
+		asset, data, err := s.assets.Read(ctx, id)
+		if err != nil {
+			return nil, "", "", err
+		}
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="image"; filename="source-%d%s"`, index+1, extensionForMIME(asset.MIMEType)))
+		header.Set("Content-Type", asset.MIMEType)
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			return nil, "", "", err
+		}
+		if _, err := part.Write(data); err != nil {
+			return nil, "", "", err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, "", "", err
+	}
+	return bytes.NewReader(buffer.Bytes()), writer.FormDataContentType(), "/images/edits", nil
+}
+
+func routeSiteName(headers http.Header) string {
+	value := strings.TrimSpace(headers.Get(gateway.RouteSiteHeader))
+	if decoded, err := url.PathUnescape(value); err == nil {
+		return decoded
+	}
+	return value
+}
+
+func gatewayJSONError(data []byte, status int) error {
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(data, &payload) == nil && payload.Error.Message != "" {
+		return errors.New(payload.Error.Message)
+	}
+	return fmt.Errorf("gateway returned status %d", status)
+}
+
+func stringValue(value any) string {
+	result, _ := value.(string)
+	return result
+}
+
+func int64Value(value any) int64 {
+	switch number := value.(type) {
+	case float64:
+		return int64(number)
+	case int64:
+		return number
+	case json.Number:
+		result, _ := number.Int64()
+		return result
+	default:
+		return 0
+	}
+}
+
+func openAIUsage(value map[string]any) *Usage {
+	prompt := int64Value(value["prompt_tokens"])
+	completion := int64Value(value["completion_tokens"])
+	total := int64Value(value["total_tokens"])
+	if total == 0 {
+		total = prompt + completion
+	}
+	return &Usage{PromptTokens: prompt, CompletionTokens: completion, TotalTokens: total}
+}
+
+func responsesUsage(value any) *Usage {
+	usage, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	prompt := int64Value(usage["input_tokens"])
+	completion := int64Value(usage["output_tokens"])
+	total := int64Value(usage["total_tokens"])
+	if total == 0 {
+		total = prompt + completion
+	}
+	return &Usage{PromptTokens: prompt, CompletionTokens: completion, TotalTokens: total}
+}
+
+func anthropicUsage(value any, current *Usage) *Usage {
+	usage, ok := value.(map[string]any)
+	if !ok {
+		return current
+	}
+	result := Usage{}
+	if current != nil {
+		result = *current
+	}
+	if input := int64Value(usage["input_tokens"]); input > 0 {
+		result.PromptTokens = input
+	}
+	if output := int64Value(usage["output_tokens"]); output > 0 {
+		result.CompletionTokens = output
+	}
+	result.TotalTokens = result.PromptTokens + result.CompletionTokens
+	return &result
+}
+
+func nestedError(event map[string]any) string {
+	if value, ok := event["error"].(map[string]any); ok {
+		if message := stringValue(value["message"]); message != "" {
+			return message
+		}
+	}
+	if response, ok := event["response"].(map[string]any); ok {
+		if value, ok := response["error"].(map[string]any); ok {
+			if message := stringValue(value["message"]); message != "" {
+				return message
+			}
+		}
+	}
+	if message := stringValue(event["message"]); message != "" {
+		return message
+	}
+	return "response failed"
+}

--- a/server/internal/playground/service.go
+++ b/server/internal/playground/service.go
@@ -1,0 +1,620 @@
+package playground
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"xlyra/server/internal/gateway"
+	"xlyra/server/internal/store"
+)
+
+type Service struct {
+	logger   *slog.Logger
+	db       *store.Store
+	repo     store.PlaygroundRepository
+	rollout  *RolloutStore
+	assets   *AssetStore
+	gateway  gateway.Handler
+	mu       sync.Mutex
+	cancels  map[uuid.UUID]context.CancelFunc
+	finishes map[uuid.UUID]chan struct{}
+	turns    map[uuid.UUID]*sync.Mutex
+	runs     map[uuid.UUID]store.PlaygroundRun
+}
+
+func NewService(logger *slog.Logger, db *store.Store, gatewayHandler gateway.Handler, root string) *Service {
+	if db == nil {
+		return nil
+	}
+	repo := store.NewPlaygroundRepository(db.DB())
+	service := &Service{
+		logger: logger, db: db, repo: repo, gateway: gatewayHandler.WithRouteSiteHeader(),
+		rollout: NewRolloutStore(root, repo), assets: NewAssetStore(root, repo),
+		cancels:  map[uuid.UUID]context.CancelFunc{},
+		finishes: map[uuid.UUID]chan struct{}{},
+		turns:    map[uuid.UUID]*sync.Mutex{},
+		runs:     map[uuid.UUID]store.PlaygroundRun{},
+	}
+	service.recoverActiveRuns()
+	return service
+}
+
+func (s *Service) turnLock(conversationID uuid.UUID) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if lock, ok := s.turns[conversationID]; ok {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	s.turns[conversationID] = lock
+	return lock
+}
+
+func (s *Service) rememberRun(run store.PlaygroundRun) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.runs[run.ConversationID]
+	if !exists || current.ID == run.ID || current.CreatedAt.Before(run.CreatedAt) {
+		s.runs[run.ConversationID] = run
+	}
+}
+
+func (s *Service) forgetConversation(conversationID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.runs, conversationID)
+	delete(s.turns, conversationID)
+}
+
+func (s *Service) latestRun(ctx context.Context, conversationID uuid.UUID) (store.PlaygroundRun, error) {
+	s.mu.Lock()
+	cached, ok := s.runs[conversationID]
+	s.mu.Unlock()
+	if ok {
+		return cached, nil
+	}
+	run, err := s.repo.LatestRun(ctx, conversationID)
+	if err != nil {
+		return store.PlaygroundRun{}, err
+	}
+	s.rememberRun(run)
+	return run, nil
+}
+
+func applyRunUpdates(run *store.PlaygroundRun, updates map[string]any) {
+	for key, value := range updates {
+		switch key {
+		case "status":
+			if text, ok := value.(string); ok {
+				run.Status = text
+			}
+		case "error":
+			if text, ok := value.(string); ok {
+				run.Error = text
+			}
+		case "cancel_requested":
+			if flag, ok := value.(bool); ok {
+				run.CancelRequested = flag
+			}
+		case "started_at":
+			if moment, ok := value.(time.Time); ok {
+				run.StartedAt = &moment
+			}
+		case "completed_at":
+			if moment, ok := value.(time.Time); ok {
+				run.CompletedAt = &moment
+			}
+		case "updated_at":
+			if moment, ok := value.(time.Time); ok {
+				run.UpdatedAt = moment
+			}
+		}
+	}
+}
+
+func (s *Service) patchRun(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, updates map[string]any) error {
+	if err := s.repo.UpdateRun(ctx, runID, updates); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	if cached, ok := s.runs[conversationID]; ok && cached.ID == runID {
+		applyRunUpdates(&cached, updates)
+		s.runs[conversationID] = cached
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Service) waitRunFinished(runID uuid.UUID, timeout time.Duration) {
+	s.mu.Lock()
+	done := s.finishes[runID]
+	s.mu.Unlock()
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+}
+
+func (s *Service) recoverActiveRuns() {
+	ctx := context.Background()
+	runs, err := s.repo.ListActiveRuns(ctx)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("failed to list active playground runs", "error", err)
+		}
+		return
+	}
+	for _, run := range runs {
+		conversation, getErr := s.repo.GetConversationByID(ctx, run.ConversationID)
+		if getErr != nil {
+			continue
+		}
+		var metadata runMetadata
+		if json.Unmarshal(run.Params, &metadata) != nil {
+			continue
+		}
+		result, _ := s.append(ctx, &conversation, "turn_interrupted", run.ID, failurePayload{MessageID: metadata.MessageID, EntryID: metadata.EntryID, Error: "server restarted while the run was active"}, conversation.Title)
+		now := time.Now()
+		_ = s.patchRun(ctx, run.ConversationID, run.ID, map[string]any{"status": "interrupted", "error": "server restarted while the run was active", "completed_at": now, "updated_at": now})
+		_ = s.repo.UpdateTurnIndex(ctx, run.ID, "interrupted", result.Ordinal, result.Offset)
+	}
+}
+
+func (s *Service) List(ctx context.Context, adminID uuid.UUID, mode string) ([]ConversationView, error) {
+	items, err := s.repo.ListConversations(ctx, adminID, mode, 50)
+	if err != nil {
+		return nil, err
+	}
+	views := make([]ConversationView, 0, len(items))
+	for _, item := range items {
+		view, err := s.view(ctx, item)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (s *Service) Get(ctx context.Context, adminID uuid.UUID, id uuid.UUID) (ConversationView, error) {
+	item, err := s.repo.GetConversation(ctx, adminID, id)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	return s.view(ctx, item)
+}
+
+func (s *Service) view(ctx context.Context, item store.PlaygroundConversation) (ConversationView, error) {
+	events, err := s.rollout.Read(item, 0)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	view, err := BuildView(item, events)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	run, err := s.latestRun(ctx, item.ID)
+	if err == nil {
+		value := runView(run)
+		view.Run = &value
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return ConversationView{}, err
+	}
+	return view, nil
+}
+
+func (s *Service) Events(ctx context.Context, adminID uuid.UUID, id uuid.UUID, offset int64, after int64) ([]Event, store.PlaygroundRun, int64, error) {
+	item, err := s.repo.GetConversation(ctx, adminID, id)
+	if err != nil {
+		return nil, store.PlaygroundRun{}, offset, err
+	}
+	events, nextOffset, err := s.rollout.ReadFrom(item, offset, after)
+	if err != nil {
+		return nil, store.PlaygroundRun{}, offset, err
+	}
+	run, runErr := s.latestRun(ctx, id)
+	if errors.Is(runErr, gorm.ErrRecordNotFound) {
+		return events, store.PlaygroundRun{}, nextOffset, nil
+	}
+	return events, run, nextOffset, runErr
+}
+
+func (s *Service) StartTurn(ctx context.Context, adminID uuid.UUID, conversationID uuid.UUID, input TurnRequest) (ConversationView, error) {
+	if input.Mode != ModeChat && input.Mode != ModeImage {
+		return ConversationView{}, fmt.Errorf("unsupported playground mode")
+	}
+	apiKeyID, err := uuid.Parse(input.APIKeyID)
+	if err != nil {
+		return ConversationView{}, fmt.Errorf("invalid api key id")
+	}
+	apiKey, err := store.NewAPIKeyRepository(s.db.DB()).GetByID(ctx, apiKeyID)
+	if err != nil {
+		return ConversationView{}, fmt.Errorf("api key not found")
+	}
+	if apiKey.Status != "active" {
+		return ConversationView{}, fmt.Errorf("api key is not active")
+	}
+	input.Model = strings.TrimSpace(input.Model)
+	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
+	if input.Model == "" || input.IdempotencyKey == "" {
+		return ConversationView{}, fmt.Errorf("model and idempotency key are required")
+	}
+
+	lock := s.turnLock(conversationID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	conversation, created, err := s.ensureConversation(ctx, adminID, conversationID, input)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	if existing, err := s.repo.GetRunByIdempotency(ctx, conversationID, input.IdempotencyKey); err == nil {
+		s.rememberRun(existing)
+		view, viewErr := s.view(ctx, conversation)
+		if viewErr == nil {
+			value := runView(existing)
+			view.Run = &value
+		}
+		return view, viewErr
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return ConversationView{}, err
+	}
+	if latest, err := s.latestRun(ctx, conversationID); err == nil && (latest.Status == "queued" || latest.Status == "running") {
+		return ConversationView{}, fmt.Errorf("conversation already has an active run")
+	} else if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return ConversationView{}, err
+	}
+
+	runID := uuid.New()
+	payload, title, err := s.normalizeTurn(ctx, conversation, runID, input)
+	if err != nil {
+		if created {
+			_ = s.repo.DeleteConversation(ctx, adminID, conversationID)
+			_ = os.RemoveAll(filepath.Join(s.rollout.Root(), "assets", conversationID.String()))
+			s.forgetConversation(conversationID)
+		}
+		return ConversationView{}, err
+	}
+	historyEventType, historyEventPayload, err := s.turnHistoryEvent(ctx, conversation, created, payload)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	metadata := runMetadata{MessageID: payload.MessageID, EntryID: payload.EntryID, ReasoningEffort: payload.ReasoningEffort}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	now := time.Now()
+	run := store.PlaygroundRun{
+		ID: runID, ConversationID: conversationID, APIKeyID: apiKeyID, IdempotencyKey: input.IdempotencyKey,
+		Mode: input.Mode, Protocol: input.Protocol, Model: input.Model, Status: "queued", Params: store.JSON(encoded),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	inserted, err := s.repo.CreateRun(ctx, &run)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	if !inserted {
+		existing, getErr := s.repo.GetRunByIdempotency(ctx, conversationID, input.IdempotencyKey)
+		if getErr != nil {
+			return ConversationView{}, getErr
+		}
+		s.rememberRun(existing)
+		view, viewErr := s.view(ctx, conversation)
+		if viewErr == nil {
+			value := runView(existing)
+			view.Run = &value
+		}
+		return view, viewErr
+	}
+	s.rememberRun(run)
+
+	if created {
+		result, appendErr := s.append(ctx, &conversation, "session_meta", uuid.Nil, map[string]any{"mode": input.Mode, "created_at": now.UTC()}, title)
+		if appendErr != nil {
+			s.finishFailedRun(run, &conversation, payload, nil, now, appendErr, false)
+			return ConversationView{}, appendErr
+		}
+		_ = result
+	}
+	start, err := s.append(ctx, &conversation, historyEventType, runID, historyEventPayload, title)
+	if err != nil {
+		s.finishFailedRun(run, &conversation, payload, nil, now, err, false)
+		return ConversationView{}, err
+	}
+	if _, err := s.append(ctx, &conversation, "turn_started", runID, map[string]any{"model": input.Model, "protocol": input.Protocol}, title); err != nil {
+		s.finishFailedRun(run, &conversation, payload, nil, now, err, false)
+		return ConversationView{}, err
+	}
+	index := store.PlaygroundTurnIndex{ID: uuid.New(), ConversationID: conversationID, RunID: runID, StartOrdinal: start.Ordinal, StartByte: start.Offset, Status: "running"}
+	if err := s.repo.CreateTurnIndex(ctx, &index); err != nil {
+		s.finishFailedRun(run, &conversation, payload, nil, now, err, false)
+		return ConversationView{}, err
+	}
+
+	ready := make(chan struct{})
+	go s.execute(run, apiKey, conversation, payload, ready)
+	<-ready
+	view, err := s.view(ctx, conversation)
+	if err != nil {
+		return ConversationView{}, err
+	}
+	value := runView(run)
+	view.Run = &value
+	return view, nil
+}
+
+func (s *Service) turnHistoryEvent(ctx context.Context, conversation store.PlaygroundConversation, created bool, payload RunPayload) (string, any, error) {
+	snapshot := snapshotPayload{Mode: payload.Mode, Chat: payload.Chat, Image: payload.Image}
+	if created {
+		return "conversation_snapshot", snapshot, nil
+	}
+	previous, err := s.view(ctx, conversation)
+	if err != nil {
+		return "", nil, err
+	}
+	if payload.Chat != nil && previous.Chat != nil {
+		incoming := payload.Chat.Messages
+		existing := previous.Chat.Messages
+		if payload.Chat.SystemPrompt == previous.Chat.SystemPrompt && len(incoming) == len(existing)+2 && reflect.DeepEqual(existing, incoming[:len(existing)]) {
+			return "message_added", chatAppendPayload{
+				Title: payload.Chat.Title, Model: payload.Chat.Model, SystemPrompt: payload.Chat.SystemPrompt,
+				UpdatedAt: payload.Chat.UpdatedAt, Messages: incoming[len(existing):],
+			}, nil
+		}
+	}
+	if payload.Image != nil && previous.Image != nil {
+		incoming := payload.Image.Entries
+		existing := previous.Image.Entries
+		if len(incoming) == len(existing)+1 && reflect.DeepEqual(existing, incoming[:len(existing)]) {
+			return "image_entry_added", imageAppendPayload{Title: payload.Image.Title, UpdatedAt: payload.Image.UpdatedAt, Entry: incoming[len(incoming)-1]}, nil
+		}
+	}
+	return "branch_reset", snapshot, nil
+}
+
+func (s *Service) ensureConversation(ctx context.Context, adminID uuid.UUID, id uuid.UUID, input TurnRequest) (store.PlaygroundConversation, bool, error) {
+	item, err := s.repo.GetConversation(ctx, adminID, id)
+	if err == nil {
+		if item.Mode != input.Mode {
+			return store.PlaygroundConversation{}, false, fmt.Errorf("conversation mode does not match")
+		}
+		return item, false, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return store.PlaygroundConversation{}, false, err
+	}
+	now := time.Now()
+	title := ""
+	if input.Chat != nil {
+		title = input.Chat.Title
+	}
+	if input.Image != nil {
+		title = input.Image.Title
+	}
+	item = store.PlaygroundConversation{ID: id, AdminID: adminID, Mode: input.Mode, Title: title, RolloutPath: s.rollout.NewPath(id, now), CreatedAt: now, UpdatedAt: now}
+	if input.LegacyImport {
+		item.LegacyClientID = id.String()
+	}
+	if err := s.repo.CreateConversation(ctx, &item); err != nil {
+		return store.PlaygroundConversation{}, false, err
+	}
+	return item, true, nil
+}
+
+func (s *Service) normalizeTurn(ctx context.Context, conversation store.PlaygroundConversation, runID uuid.UUID, input TurnRequest) (RunPayload, string, error) {
+	payload := RunPayload{Mode: input.Mode, Model: input.Model, Protocol: input.Protocol, ReasoningEffort: input.ReasoningEffort}
+	if input.Mode == ModeChat {
+		if input.Chat == nil || len(input.Chat.Messages) == 0 {
+			return RunPayload{}, "", fmt.Errorf("chat conversation is required")
+		}
+		chat := *input.Chat
+		chat.ID = conversation.ID.String()
+		chat.ServerPersisted = true
+		for messageIndex := range chat.Messages {
+			for attachmentIndex := range chat.Messages[messageIndex].Attachments {
+				attachment, err := s.normalizeAttachment(ctx, conversation.ID, runID, chat.Messages[messageIndex].Attachments[attachmentIndex])
+				if err != nil {
+					return RunPayload{}, "", err
+				}
+				chat.Messages[messageIndex].Attachments[attachmentIndex] = attachment
+			}
+		}
+		messageID := uuid.NewString()
+		chat.Messages = append(chat.Messages, ChatMessage{ID: messageID, Role: "assistant", Model: input.Model, CreatedAt: time.Now().UnixMilli()})
+		chat.Model = input.Model
+		chat.UpdatedAt = time.Now().UnixMilli()
+		payload.Chat = &chat
+		payload.MessageID = messageID
+		return payload, chat.Title, nil
+	}
+	if input.Image == nil || len(input.Image.Entries) == 0 {
+		return RunPayload{}, "", fmt.Errorf("image conversation is required")
+	}
+	image := *input.Image
+	image.ID = conversation.ID.String()
+	image.ServerPersisted = true
+	for entryIndex := range image.Entries {
+		entry := &image.Entries[entryIndex]
+		if err := s.normalizeImageEntry(ctx, conversation.ID, runID, entry); err != nil {
+			return RunPayload{}, "", err
+		}
+	}
+	entry := &image.Entries[len(image.Entries)-1]
+	entry.Pending = true
+	entry.Error = ""
+	entry.Images = nil
+	image.UpdatedAt = time.Now().UnixMilli()
+	payload.Image = &image
+	payload.EntryID = entry.ID
+	return payload, image.Title, nil
+}
+
+func (s *Service) normalizeAttachment(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, attachment Attachment) (Attachment, error) {
+	if attachment.AssetID != "" {
+		id, err := uuid.Parse(attachment.AssetID)
+		if err != nil {
+			return Attachment{}, fmt.Errorf("invalid attachment asset id")
+		}
+		asset, err := s.repo.GetAsset(ctx, id)
+		if err != nil || asset.ConversationID != conversationID {
+			return Attachment{}, fmt.Errorf("attachment asset not found")
+		}
+		attachment.DataURL = ""
+		attachment.Src = assetURL(id)
+		return attachment, nil
+	}
+	if attachment.DataURL == "" {
+		return Attachment{}, fmt.Errorf("attachment data is unavailable")
+	}
+	asset, err := s.assets.SaveDataURL(ctx, conversationID, runID, "attachments", attachment.Name, attachment.DataURL)
+	if err != nil {
+		return Attachment{}, err
+	}
+	attachment.AssetID = asset.ID.String()
+	attachment.DataURL = ""
+	attachment.Src = assetURL(asset.ID)
+	attachment.Size = asset.Size
+	attachment.MIMEType = asset.MIMEType
+	return attachment, nil
+}
+
+func (s *Service) normalizeImageEntry(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, entry *ImageEntry) error {
+	entry.SourceAssetIDs = nil
+	for _, source := range entry.SourceImages {
+		asset, err := s.normalizeImageSource(ctx, conversationID, runID, "input-images", source)
+		if err != nil {
+			return err
+		}
+		entry.SourceAssetIDs = append(entry.SourceAssetIDs, asset.ID.String())
+	}
+	entry.SourceImages = nil
+	if len(entry.SourceAssetIDs) > 0 {
+		entry.SourceImages = make([]string, 0, len(entry.SourceAssetIDs))
+		for _, value := range entry.SourceAssetIDs {
+			id, _ := uuid.Parse(value)
+			entry.SourceImages = append(entry.SourceImages, assetURL(id))
+		}
+	}
+	for index := range entry.Images {
+		image := &entry.Images[index]
+		if image.AssetID != "" {
+			id, err := uuid.Parse(image.AssetID)
+			if err != nil {
+				return fmt.Errorf("invalid image asset id")
+			}
+			asset, err := s.repo.GetAsset(ctx, id)
+			if err != nil || asset.ConversationID != conversationID {
+				return fmt.Errorf("image asset not found")
+			}
+			image.Src = assetURL(id)
+			continue
+		}
+		asset, err := s.normalizeImageSource(ctx, conversationID, runID, "generated-images", image.Src)
+		if err != nil {
+			return err
+		}
+		image.AssetID = asset.ID.String()
+		image.Src = assetURL(asset.ID)
+	}
+	return nil
+}
+
+func (s *Service) normalizeImageSource(ctx context.Context, conversationID uuid.UUID, runID uuid.UUID, purpose string, source string) (store.PlaygroundAsset, error) {
+	if id, ok := assetIDFromURL(source); ok {
+		asset, err := s.repo.GetAsset(ctx, id)
+		if err != nil || asset.ConversationID != conversationID {
+			return store.PlaygroundAsset{}, fmt.Errorf("image asset not found")
+		}
+		return asset, nil
+	}
+	if strings.HasPrefix(source, "data:") {
+		return s.assets.SaveDataURL(ctx, conversationID, runID, purpose, "image", source)
+	}
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		return s.assets.SaveRemote(ctx, conversationID, runID, purpose, source)
+	}
+	return store.PlaygroundAsset{}, fmt.Errorf("image source is unavailable")
+}
+
+func assetURL(id uuid.UUID) string {
+	return "/api/v1/playground/assets/" + id.String()
+}
+
+func assetIDFromURL(value string) (uuid.UUID, bool) {
+	const prefix = "/api/v1/playground/assets/"
+	index := strings.Index(value, prefix)
+	if index < 0 {
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(strings.TrimSpace(value[index+len(prefix):]))
+	return id, err == nil
+}
+
+func (s *Service) append(ctx context.Context, conversation *store.PlaygroundConversation, eventType string, runID uuid.UUID, payload any, title string) (appendResult, error) {
+	result, err := s.rollout.Append(ctx, *conversation, eventType, runID, payload, title)
+	if err == nil {
+		conversation.LastOrdinal = result.Ordinal
+		conversation.LastByteOffset = result.Offset
+		conversation.Title = title
+		conversation.UpdatedAt = time.Now()
+	}
+	return result, err
+}
+
+func (s *Service) Cancel(ctx context.Context, adminID uuid.UUID, runID uuid.UUID) error {
+	run, err := s.repo.GetRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.repo.GetConversation(ctx, adminID, run.ConversationID); err != nil {
+		return err
+	}
+	if err := s.patchRun(ctx, run.ConversationID, runID, map[string]any{"cancel_requested": true, "updated_at": time.Now()}); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	cancel := s.cancels[runID]
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+func (s *Service) Delete(ctx context.Context, adminID uuid.UUID, id uuid.UUID) error {
+	conversation, err := s.repo.GetConversation(ctx, adminID, id)
+	if err != nil {
+		return err
+	}
+	lock := s.turnLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+	if run, err := s.latestRun(ctx, id); err == nil && (run.Status == "queued" || run.Status == "running") {
+		_ = s.Cancel(ctx, adminID, run.ID)
+		s.waitRunFinished(run.ID, 30*time.Second)
+	}
+	assetDir := filepath.Join(s.rollout.Root(), "assets", id.String())
+	if err := s.repo.DeleteConversation(ctx, adminID, id); err != nil {
+		return err
+	}
+	s.forgetConversation(id)
+	_ = s.rollout.Remove(conversation)
+	_ = os.RemoveAll(assetDir)
+	return nil
+}

--- a/server/internal/playground/types.go
+++ b/server/internal/playground/types.go
@@ -1,0 +1,194 @@
+package playground
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+const (
+	ModeChat  = "chat"
+	ModeImage = "image"
+)
+
+type Attachment struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MIMEType string `json:"mimeType"`
+	Size     int64  `json:"size"`
+	DataURL  string `json:"dataURL,omitempty"`
+	AssetID  string `json:"assetId,omitempty"`
+	Src      string `json:"src,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens     int64 `json:"prompt_tokens,omitempty"`
+	CompletionTokens int64 `json:"completion_tokens,omitempty"`
+	TotalTokens      int64 `json:"total_tokens,omitempty"`
+}
+
+type ChatMessage struct {
+	ID                 string       `json:"id"`
+	Role               string       `json:"role"`
+	Content            string       `json:"content"`
+	Reasoning          string       `json:"reasoning,omitempty"`
+	Error              string       `json:"error,omitempty"`
+	Usage              *Usage       `json:"usage,omitempty"`
+	Model              string       `json:"model,omitempty"`
+	SiteName           string       `json:"siteName,omitempty"`
+	ResponseDurationMS *int64       `json:"responseDurationMs,omitempty"`
+	Attachments        []Attachment `json:"attachments,omitempty"`
+	CreatedAt          int64        `json:"createdAt"`
+}
+
+type ChatConversation struct {
+	ID              string        `json:"id"`
+	Title           string        `json:"title"`
+	Model           string        `json:"model"`
+	SystemPrompt    string        `json:"systemPrompt"`
+	Messages        []ChatMessage `json:"messages"`
+	CreatedAt       int64         `json:"createdAt"`
+	UpdatedAt       int64         `json:"updatedAt"`
+	ServerPersisted bool          `json:"serverPersisted"`
+}
+
+type ImageResult struct {
+	ID      string `json:"id"`
+	Src     string `json:"src"`
+	AssetID string `json:"assetId,omitempty"`
+}
+
+type ImageEntry struct {
+	ID                 string        `json:"id"`
+	Mode               string        `json:"mode"`
+	Model              string        `json:"model"`
+	Prompt             string        `json:"prompt"`
+	Size               string        `json:"size,omitempty"`
+	SourceImages       []string      `json:"sourceImages,omitempty"`
+	SourceAssetIDs     []string      `json:"sourceAssetIds,omitempty"`
+	Images             []ImageResult `json:"images"`
+	SiteName           string        `json:"siteName,omitempty"`
+	ResponseDurationMS *int64        `json:"responseDurationMs,omitempty"`
+	Pending            bool          `json:"pending,omitempty"`
+	Error              string        `json:"error,omitempty"`
+	CreatedAt          int64         `json:"createdAt"`
+}
+
+type ImageConversation struct {
+	ID              string       `json:"id"`
+	Title           string       `json:"title"`
+	Entries         []ImageEntry `json:"entries"`
+	CreatedAt       int64        `json:"createdAt"`
+	UpdatedAt       int64        `json:"updatedAt"`
+	ServerPersisted bool         `json:"serverPersisted"`
+}
+
+type TurnRequest struct {
+	Mode            string             `json:"mode"`
+	APIKeyID        string             `json:"api_key_id"`
+	Model           string             `json:"model"`
+	Protocol        string             `json:"protocol,omitempty"`
+	ReasoningEffort string             `json:"reasoning_effort,omitempty"`
+	IdempotencyKey  string             `json:"idempotency_key"`
+	LegacyImport    bool               `json:"legacy_import,omitempty"`
+	Chat            *ChatConversation  `json:"chat,omitempty"`
+	Image           *ImageConversation `json:"image,omitempty"`
+}
+
+type RunPayload struct {
+	Mode            string             `json:"mode"`
+	Model           string             `json:"model"`
+	Protocol        string             `json:"protocol,omitempty"`
+	ReasoningEffort string             `json:"reasoning_effort,omitempty"`
+	Chat            *ChatConversation  `json:"chat,omitempty"`
+	Image           *ImageConversation `json:"image,omitempty"`
+	MessageID       string             `json:"message_id,omitempty"`
+	EntryID         string             `json:"entry_id,omitempty"`
+}
+
+type runMetadata struct {
+	MessageID       string `json:"message_id,omitempty"`
+	EntryID         string `json:"entry_id,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+}
+
+type RunView struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Error       string `json:"error,omitempty"`
+	CreatedAt   int64  `json:"created_at"`
+	CompletedAt *int64 `json:"completed_at,omitempty"`
+}
+
+func runView(item store.PlaygroundRun) RunView {
+	view := RunView{ID: item.ID.String(), Status: item.Status, Error: item.Error, CreatedAt: item.CreatedAt.UnixMilli()}
+	if item.CompletedAt != nil {
+		value := item.CompletedAt.UnixMilli()
+		view.CompletedAt = &value
+	}
+	return view
+}
+
+type ConversationView struct {
+	ID          string             `json:"id"`
+	Mode        string             `json:"mode"`
+	Title       string             `json:"title"`
+	Chat        *ChatConversation  `json:"chat,omitempty"`
+	Image       *ImageConversation `json:"image,omitempty"`
+	Run         *RunView           `json:"run,omitempty"`
+	LastOrdinal int64              `json:"last_ordinal"`
+	UpdatedAt   int64              `json:"updated_at"`
+}
+
+type Event struct {
+	Timestamp time.Time       `json:"timestamp"`
+	Ordinal   int64           `json:"ordinal"`
+	Type      string          `json:"type"`
+	RunID     string          `json:"run_id,omitempty"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type appendResult struct {
+	Ordinal int64
+	Offset  int64
+}
+
+type snapshotPayload struct {
+	Mode  string             `json:"mode"`
+	Chat  *ChatConversation  `json:"chat,omitempty"`
+	Image *ImageConversation `json:"image,omitempty"`
+}
+
+type chatAppendPayload struct {
+	Title        string        `json:"title"`
+	Model        string        `json:"model"`
+	SystemPrompt string        `json:"system_prompt"`
+	UpdatedAt    int64         `json:"updated_at"`
+	Messages     []ChatMessage `json:"messages"`
+}
+
+type imageAppendPayload struct {
+	Title     string     `json:"title"`
+	UpdatedAt int64      `json:"updated_at"`
+	Entry     ImageEntry `json:"entry"`
+}
+
+type deltaPayload struct {
+	MessageID string `json:"message_id"`
+	Content   string `json:"content,omitempty"`
+	Reasoning string `json:"reasoning,omitempty"`
+}
+
+type failurePayload struct {
+	MessageID          string `json:"message_id,omitempty"`
+	EntryID            string `json:"entry_id,omitempty"`
+	Error              string `json:"error"`
+	ResponseDurationMS int64  `json:"response_duration_ms"`
+}
+
+func parseUUID(value string) (uuid.UUID, error) {
+	return uuid.Parse(value)
+}

--- a/server/internal/store/bootstrap.go
+++ b/server/internal/store/bootstrap.go
@@ -148,6 +148,36 @@ func ensureSchemaUpgrades(ctx context.Context, db *gorm.DB) error {
 			return fmt.Errorf("ensure request_usage_hourly_summaries table: %w", err)
 		}
 	}
+	for _, model := range []any{
+		&PlaygroundConversation{},
+		&PlaygroundRun{},
+		&PlaygroundTurnIndex{},
+		&PlaygroundAsset{},
+	} {
+		if migrator.HasTable(model) {
+			continue
+		}
+		if err := migrator.CreateTable(model); err != nil {
+			return fmt.Errorf("ensure playground persistence table: %w", err)
+		}
+	}
+	for _, index := range []struct {
+		model any
+		name  string
+	}{
+		{&PlaygroundConversation{}, "playground_conversations_admin_updated_idx"},
+		{&PlaygroundRun{}, "playground_runs_conversation_idempotency_idx"},
+		{&PlaygroundRun{}, "playground_runs_conversation_created_idx"},
+		{&PlaygroundRun{}, "idx_playground_runs_status"},
+		{&PlaygroundTurnIndex{}, "idx_playground_turn_indexes_conversation_id"},
+		{&PlaygroundTurnIndex{}, "idx_playground_turn_indexes_run_id"},
+		{&PlaygroundAsset{}, "idx_playground_assets_conversation_id"},
+		{&PlaygroundAsset{}, "idx_playground_assets_run_id"},
+	} {
+		if err := ensureSchemaIndex(migrator, index.model, index.name); err != nil {
+			return err
+		}
+	}
 	if err := ensureSchemaIndex(migrator, &RequestUsageDailySummary{}, "request_usage_daily_summaries_bucket_idx"); err != nil {
 		return err
 	}

--- a/server/internal/store/playground_repository.go
+++ b/server/internal/store/playground_repository.go
@@ -1,0 +1,254 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type PlaygroundConversation struct {
+	ID             uuid.UUID `gorm:"type:uuid;primaryKey"`
+	AdminID        uuid.UUID `gorm:"type:uuid;not null;index:playground_conversations_admin_updated_idx,priority:1"`
+	Mode           string    `gorm:"size:16;not null;index:playground_conversations_admin_updated_idx,priority:2"`
+	Title          string
+	RolloutPath    string `gorm:"not null"`
+	LegacyClientID string `gorm:"size:128"`
+	LastOrdinal    int64
+	LastByteOffset int64
+	CreatedAt      time.Time
+	UpdatedAt      time.Time `gorm:"index:playground_conversations_admin_updated_idx,priority:3"`
+}
+
+func (PlaygroundConversation) TableName() string { return "playground_conversations" }
+
+type PlaygroundRun struct {
+	ID              uuid.UUID `gorm:"type:uuid;primaryKey"`
+	ConversationID  uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:playground_runs_conversation_idempotency_idx,priority:1;index:playground_runs_conversation_created_idx,priority:1"`
+	APIKeyID        uuid.UUID `gorm:"type:uuid;not null"`
+	IdempotencyKey  string    `gorm:"size:128;not null;uniqueIndex:playground_runs_conversation_idempotency_idx,priority:2"`
+	Mode            string    `gorm:"size:16;not null"`
+	Protocol        string    `gorm:"size:32"`
+	Model           string
+	Status          string `gorm:"size:24;not null;index"`
+	Params          JSON   `gorm:"type:jsonb;not null"`
+	CancelRequested bool
+	Error           string
+	StartedAt       *time.Time
+	CompletedAt     *time.Time
+	CreatedAt       time.Time `gorm:"index:playground_runs_conversation_created_idx,priority:2"`
+	UpdatedAt       time.Time
+}
+
+func (PlaygroundRun) TableName() string { return "playground_runs" }
+
+type PlaygroundTurnIndex struct {
+	ID             uuid.UUID `gorm:"type:uuid;primaryKey"`
+	ConversationID uuid.UUID `gorm:"type:uuid;not null;index"`
+	RunID          uuid.UUID `gorm:"type:uuid;not null;uniqueIndex"`
+	StartOrdinal   int64
+	EndOrdinal     int64
+	StartByte      int64
+	EndByte        int64
+	Status         string `gorm:"size:24;not null"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func (PlaygroundTurnIndex) TableName() string { return "playground_turn_indexes" }
+
+type PlaygroundAsset struct {
+	ID             uuid.UUID     `gorm:"type:uuid;primaryKey"`
+	ConversationID uuid.UUID     `gorm:"type:uuid;not null;index"`
+	RunID          uuid.NullUUID `gorm:"type:uuid;index"`
+	Purpose        string        `gorm:"size:32;not null"`
+	Path           string        `gorm:"not null"`
+	OriginalName   string
+	MIMEType       string
+	Size           int64
+	SHA256         string `gorm:"size:64"`
+	CreatedAt      time.Time
+}
+
+func (PlaygroundAsset) TableName() string { return "playground_assets" }
+
+type PlaygroundRepository struct {
+	db *gorm.DB
+}
+
+func NewPlaygroundRepository(db *gorm.DB) PlaygroundRepository {
+	return PlaygroundRepository{db: db}
+}
+
+func (r PlaygroundRepository) CreateConversation(ctx context.Context, item *PlaygroundConversation) error {
+	if err := r.db.WithContext(ctx).Create(item).Error; err != nil {
+		return fmt.Errorf("create playground conversation: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) GetConversation(ctx context.Context, adminID uuid.UUID, id uuid.UUID) (PlaygroundConversation, error) {
+	var item PlaygroundConversation
+	if err := r.db.WithContext(ctx).Where(&PlaygroundConversation{ID: id, AdminID: adminID}).First(&item).Error; err != nil {
+		return PlaygroundConversation{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) GetConversationByID(ctx context.Context, id uuid.UUID) (PlaygroundConversation, error) {
+	var item PlaygroundConversation
+	if err := r.db.WithContext(ctx).Where(&PlaygroundConversation{ID: id}).First(&item).Error; err != nil {
+		return PlaygroundConversation{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) ListConversations(ctx context.Context, adminID uuid.UUID, mode string, limit int) ([]PlaygroundConversation, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	query := r.db.WithContext(ctx).Where(&PlaygroundConversation{AdminID: adminID})
+	if mode != "" {
+		query = query.Where(&PlaygroundConversation{Mode: mode})
+	}
+	var items []PlaygroundConversation
+	if err := query.Clauses(clause.OrderBy{Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "updated_at"}, Desc: true}}}).Limit(limit).Find(&items).Error; err != nil {
+		return nil, fmt.Errorf("list playground conversations: %w", err)
+	}
+	return items, nil
+}
+
+func (r PlaygroundRepository) UpdateConversationCursor(ctx context.Context, id uuid.UUID, title string, ordinal int64, offset int64, updatedAt time.Time) error {
+	updates := map[string]any{
+		"title":            title,
+		"last_ordinal":     ordinal,
+		"last_byte_offset": offset,
+		"updated_at":       updatedAt,
+	}
+	if err := r.db.WithContext(ctx).Model(&PlaygroundConversation{ID: id}).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update playground conversation cursor: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) DeleteConversation(ctx context.Context, adminID uuid.UUID, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where(&PlaygroundAsset{ConversationID: id}).Delete(&PlaygroundAsset{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where(&PlaygroundTurnIndex{ConversationID: id}).Delete(&PlaygroundTurnIndex{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where(&PlaygroundRun{ConversationID: id}).Delete(&PlaygroundRun{}).Error; err != nil {
+			return err
+		}
+		result := tx.Where(&PlaygroundConversation{ID: id, AdminID: adminID}).Delete(&PlaygroundConversation{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+}
+
+func (r PlaygroundRepository) CreateRun(ctx context.Context, item *PlaygroundRun) (bool, error) {
+	result := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "conversation_id"}, {Name: "idempotency_key"}},
+		DoNothing: true,
+	}).Create(item)
+	if result.Error != nil {
+		return false, fmt.Errorf("create playground run: %w", result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
+func (r PlaygroundRepository) GetRunByIdempotency(ctx context.Context, conversationID uuid.UUID, key string) (PlaygroundRun, error) {
+	var item PlaygroundRun
+	if err := r.db.WithContext(ctx).Where(&PlaygroundRun{ConversationID: conversationID, IdempotencyKey: key}).First(&item).Error; err != nil {
+		return PlaygroundRun{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) GetRun(ctx context.Context, id uuid.UUID) (PlaygroundRun, error) {
+	var item PlaygroundRun
+	if err := r.db.WithContext(ctx).Where(&PlaygroundRun{ID: id}).First(&item).Error; err != nil {
+		return PlaygroundRun{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) LatestRun(ctx context.Context, conversationID uuid.UUID) (PlaygroundRun, error) {
+	var item PlaygroundRun
+	if err := r.db.WithContext(ctx).Where(&PlaygroundRun{ConversationID: conversationID}).Clauses(clause.OrderBy{Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "created_at"}, Desc: true}}}).First(&item).Error; err != nil {
+		return PlaygroundRun{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) UpdateRun(ctx context.Context, id uuid.UUID, updates map[string]any) error {
+	if err := r.db.WithContext(ctx).Model(&PlaygroundRun{ID: id}).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update playground run: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) InterruptActiveRuns(ctx context.Context, now time.Time) error {
+	statuses := []any{"queued", "running"}
+	updates := map[string]any{"status": "interrupted", "error": "server restarted while the run was active", "completed_at": now, "updated_at": now}
+	if err := r.db.WithContext(ctx).Model(&PlaygroundRun{}).Clauses(clause.Where{Exprs: []clause.Expression{clause.IN{Column: clause.Column{Name: "status"}, Values: statuses}}}).Updates(updates).Error; err != nil {
+		return fmt.Errorf("interrupt active playground runs: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) ListActiveRuns(ctx context.Context) ([]PlaygroundRun, error) {
+	statuses := []any{"queued", "running"}
+	var items []PlaygroundRun
+	if err := r.db.WithContext(ctx).Clauses(clause.Where{Exprs: []clause.Expression{clause.IN{Column: clause.Column{Name: "status"}, Values: statuses}}}).Find(&items).Error; err != nil {
+		return nil, fmt.Errorf("list active playground runs: %w", err)
+	}
+	return items, nil
+}
+
+func (r PlaygroundRepository) CreateTurnIndex(ctx context.Context, item *PlaygroundTurnIndex) error {
+	if err := r.db.WithContext(ctx).Create(item).Error; err != nil {
+		return fmt.Errorf("create playground turn index: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) UpdateTurnIndex(ctx context.Context, runID uuid.UUID, status string, endOrdinal int64, endByte int64) error {
+	updates := map[string]any{"status": status, "end_ordinal": endOrdinal, "end_byte": endByte, "updated_at": time.Now()}
+	if err := r.db.WithContext(ctx).Model(&PlaygroundTurnIndex{}).Where(&PlaygroundTurnIndex{RunID: runID}).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update playground turn index: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) CreateAsset(ctx context.Context, item *PlaygroundAsset) error {
+	if err := r.db.WithContext(ctx).Create(item).Error; err != nil {
+		return fmt.Errorf("create playground asset: %w", err)
+	}
+	return nil
+}
+
+func (r PlaygroundRepository) GetAsset(ctx context.Context, id uuid.UUID) (PlaygroundAsset, error) {
+	var item PlaygroundAsset
+	if err := r.db.WithContext(ctx).Where(&PlaygroundAsset{ID: id}).First(&item).Error; err != nil {
+		return PlaygroundAsset{}, err
+	}
+	return item, nil
+}
+
+func (r PlaygroundRepository) DeleteAsset(ctx context.Context, id uuid.UUID) error {
+	if err := r.db.WithContext(ctx).Where(&PlaygroundAsset{ID: id}).Delete(&PlaygroundAsset{}).Error; err != nil {
+		return fmt.Errorf("delete playground asset: %w", err)
+	}
+	return nil
+}

--- a/web/src/features/playground/api/playground.test.ts
+++ b/web/src/features/playground/api/playground.test.ts
@@ -1,248 +1,122 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  generateImage,
-  listGatewayModels,
-  streamChatCompletion,
-  streamMessages,
-  streamResponses,
+  followServerConversation,
+  listPlaygroundModels,
+  type PlaygroundRolloutEvent,
 } from '@/features/playground/api/playground'
+import type { PlaygroundRun } from '@/features/playground/lib/types'
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('listGatewayModels', () => {
-  it('bypasses the browser cache when the authorization key changes', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('listPlaygroundModels', () => {
+  it('requests models through the admin endpoint with the API key id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: [] }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await listGatewayModels('sk-test')
+    await listPlaygroundModels('key-id-1')
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/playground/v1/models', {
-      method: 'GET',
-      headers: { Authorization: 'Bearer sk-test' },
-      cache: 'no-store',
-    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/playground/models?api_key_id=key-id-1',
+      expect.objectContaining({ credentials: 'include' }),
+    )
   })
 
   it('sorts models alphabetically without case sensitivity', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({
-        data: [
-          { id: 'zeta-model' },
-          { id: 'Beta-model' },
-          { id: 'alpha-model' },
-        ],
-      }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    ))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: [
+        { id: 'zeta-model' },
+        { id: 'Beta-model' },
+        { id: 'alpha-model' },
+      ],
+    })))
 
-    const models = await listGatewayModels('sk-test')
+    const models = await listPlaygroundModels('key-id-1')
 
     expect(models.map((model) => model.id)).toEqual(['alpha-model', 'Beta-model', 'zeta-model'])
   })
 
   it('preserves the mapped target for model aliases', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({
-        data: [{
-          id: 'codex-pro',
-          metadata: { mapped_model: ' gpt-5.6-sol ' },
-        }],
-      }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    ))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: [{
+        id: 'codex-pro',
+        metadata: { mapped_model: ' gpt-5.6-sol ' },
+      }],
+    })))
 
-    const models = await listGatewayModels('sk-test')
+    const models = await listPlaygroundModels('key-id-1')
 
     expect(models[0].mappedModel).toBe('gpt-5.6-sol')
   })
 
-  it('reports a clear error when the development server returns the SPA document', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response('<!doctype html><html></html>', {
-        status: 200,
-        headers: { 'Content-Type': 'text/html' },
-      }),
-    ))
+  it('normalizes supported endpoint types', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: [{
+        id: 'gpt-5.6-sol',
+        metadata: { supported_endpoint_types: [' Chat ', 'RESPONSES', 42, ''] },
+      }],
+    })))
 
-    await expect(listGatewayModels('sk-test')).rejects.toThrow(
-      'Playground API returned text/html instead of JSON',
-    )
+    const models = await listPlaygroundModels('key-id-1')
+
+    expect(models[0].endpointTypes).toEqual(['chat', 'responses'])
   })
 })
 
-describe('gateway route metadata', () => {
-  it('reports the routed site for streaming chat responses', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response('data: [DONE]\n\n', {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/event-stream',
-          'X-Xlyra-Route-Site': 'tokenfree',
-        },
-      }),
-    ))
-    const onRouteSite = vi.fn()
-
-    await streamChatCompletion({
-      apiKey: 'sk-test',
-      model: 'gpt-5.6-sol',
-      messages: [{ role: 'user', content: 'hello' }],
-      onContent: vi.fn(),
-      onReasoning: vi.fn(),
-      onUsage: vi.fn(),
-      onRouteSite,
+describe('followServerConversation', () => {
+  function sseResponse(body: string): Response {
+    return new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
     })
-
-    expect(onRouteSite).toHaveBeenCalledWith('tokenfree')
-  })
-
-  it('parses CRLF-delimited streaming chat events', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response(
-        'data: {"choices":[{"delta":{"content":"hello"}}]}\r\n\r\n' +
-          'data: {"choices":[{"delta":{"content":" world"}}]}\r\n\r\n' +
-          'data: [DONE]\r\n\r\n',
-        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
-      ),
-    ))
-    const onContent = vi.fn()
-
-    await streamChatCompletion({
-      apiKey: 'sk-test',
-      model: 'gpt-test',
-      messages: [{ role: 'user', content: 'hello' }],
-      onContent,
-      onReasoning: vi.fn(),
-      onUsage: vi.fn(),
-      onRouteSite: vi.fn(),
-    })
-
-    expect(onContent.mock.calls.flat()).toEqual(['hello', ' world'])
-  })
-
-  it('rejects an error event after partial streaming content', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response(
-        'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n' +
-          'data: {"error":{"message":"upstream interrupted"}}\n\n',
-        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
-      ),
-    ))
-
-    await expect(streamChatCompletion({
-      apiKey: 'sk-test',
-      model: 'gpt-test',
-      messages: [{ role: 'user', content: 'hello' }],
-      onContent: vi.fn(),
-      onReasoning: vi.fn(),
-      onUsage: vi.fn(),
-      onRouteSite: vi.fn(),
-    })).rejects.toThrow('upstream interrupted')
-  })
-
-  it('returns the routed site with generated images', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [{ b64_json: 'aW1hZ2U=' }] }), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Xlyra-Route-Site': '%E5%9B%BE%E7%89%87%E7%AB%99%E7%82%B9',
-        },
-      }),
-    ))
-
-    const result = await generateImage({
-      apiKey: 'sk-test',
-      model: 'gpt-image-1',
-      prompt: 'a lighthouse',
-    })
-
-    expect(result.siteName).toBe('图片站点')
-    expect(result.images).toHaveLength(1)
-  })
-})
-
-describe('chat attachments', () => {
-  const attachment = {
-    id: 'attachment-1',
-    name: 'report.pdf',
-    mimeType: 'application/pdf',
-    size: 4,
-    dataURL: 'data:application/pdf;base64,cGRm',
   }
 
-  function streamInput() {
-    return {
-      apiKey: 'sk-test',
-      model: 'test-model',
-      messages: [{ role: 'user' as const, content: 'summarize', attachments: [attachment] }],
-      onContent: vi.fn(),
-      onReasoning: vi.fn(),
-      onUsage: vi.fn(),
-      onRouteSite: vi.fn(),
+  it('dispatches rollout events and terminal run status', async () => {
+    const event: PlaygroundRolloutEvent = {
+      timestamp: '2026-08-24T00:00:00Z',
+      ordinal: 7,
+      type: 'assistant_delta',
+      payload: { message_id: 'm1', content: 'hello' },
     }
-  }
+    const run: PlaygroundRun = { id: 'run-1', status: 'completed', created_at: 1 }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(
+      `id: 7\nevent: rollout\ndata: ${JSON.stringify(event)}\n\n` +
+      `event: run_status\ndata: ${JSON.stringify(run)}\n\n`,
+    )))
 
-  it('sends files using the Chat Completions file content part', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('data: [DONE]\n\n', {
-      status: 200,
-      headers: { 'Content-Type': 'text/event-stream' },
-    }))
-    vi.stubGlobal('fetch', fetchMock)
+    const events: PlaygroundRolloutEvent[] = []
+    const runs: PlaygroundRun[] = []
+    await followServerConversation('conv-1', 0, new AbortController().signal, (item) => events.push(item), (item) => runs.push(item))
 
-    await streamChatCompletion(streamInput())
-
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
-    expect(body.messages[0].content).toEqual([
-      { type: 'text', text: 'summarize' },
-      { type: 'file', file: { filename: 'report.pdf', file_data: attachment.dataURL } },
-    ])
+    expect(events).toHaveLength(1)
+    expect(events[0].ordinal).toBe(7)
+    expect(runs).toHaveLength(1)
+    expect(runs[0].status).toBe('completed')
   })
 
-  it('sends files using the Responses input_file content part', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('data: {"type":"response.completed"}\n\n', {
-      status: 200,
-      headers: { 'Content-Type': 'text/event-stream' },
-    }))
-    vi.stubGlobal('fetch', fetchMock)
+  it('parses CRLF-delimited events and skips keepalive comments', async () => {
+    const event: PlaygroundRolloutEvent = {
+      timestamp: '2026-08-24T00:00:00Z',
+      ordinal: 3,
+      type: 'turn_completed',
+      payload: { response_duration_ms: 12 },
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(
+      `: keepalive\r\n\r\nevent: rollout\r\ndata: ${JSON.stringify(event)}\r\n\r\n`,
+    )))
 
-    await streamResponses(streamInput())
+    const events: PlaygroundRolloutEvent[] = []
+    await followServerConversation('conv-1', 0, new AbortController().signal, (item) => events.push(item), vi.fn())
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
-    expect(body.input[0].content).toEqual([
-      { type: 'input_text', text: 'summarize' },
-      { type: 'input_file', filename: 'report.pdf', file_data: attachment.dataURL },
-    ])
-  })
-
-  it('sends files using the Anthropic document content block', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('data: {"type":"message_stop"}\n\n', {
-      status: 200,
-      headers: { 'Content-Type': 'text/event-stream' },
-    }))
-    vi.stubGlobal('fetch', fetchMock)
-
-    await streamMessages(streamInput())
-
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
-    expect(body.messages[0].content).toEqual([
-      { type: 'text', text: 'summarize' },
-      {
-        type: 'document',
-        title: 'report.pdf',
-        source: { type: 'base64', media_type: 'application/pdf', data: 'cGRm' },
-      },
-    ])
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('turn_completed')
   })
 })

--- a/web/src/features/playground/api/playground.ts
+++ b/web/src/features/playground/api/playground.ts
@@ -1,71 +1,18 @@
-import { apiURL, APIError } from '@/lib/http'
+import { apiFetch, apiFetchResponse, APIError } from '@/lib/http'
 import type {
-  ChatAttachment,
   ChatProtocol,
-  ChatUsage,
+  Conversation,
   GatewayModel,
-  ImageResultItem,
+  ImageConversation,
+  PlaygroundMode,
+  PlaygroundRun,
 } from '@/features/playground/lib/types'
-import { newId } from '@/features/playground/lib/storage'
-
-const ROUTE_SITE_HEADER = 'X-Xlyra-Route-Site'
-const PLAYGROUND_API_BASE = '/api/playground/v1'
 
 export {
   listDownstreamAPIKeys,
-  revealDownstreamAPIKey,
   downstreamAPIKeyQueryKeys,
 } from '@/features/api-keys/api/api-keys'
 export type { DownstreamAPIKey } from '@/features/api-keys/api/api-keys'
-
-type GatewayErrorEnvelope = {
-  error?: { message?: string; code?: string; request_id?: string }
-}
-
-async function toGatewayError(response: Response): Promise<APIError> {
-  let message = `Request failed with status ${response.status}`
-  let code: string | undefined
-  let requestId: string | undefined
-  try {
-    const payload = (await response.json()) as GatewayErrorEnvelope
-    message = payload.error?.message ?? message
-    code = payload.error?.code
-    requestId = payload.error?.request_id
-  } catch {
-    return new APIError(message, response.status, code, requestId)
-  }
-  return new APIError(message, response.status, code, requestId)
-}
-
-function authHeaders(apiKey: string): HeadersInit {
-  return { Authorization: `Bearer ${apiKey}` }
-}
-
-function routeSiteName(response: Response): string | undefined {
-  const encoded = response.headers.get(ROUTE_SITE_HEADER)?.trim()
-  if (!encoded) return undefined
-  try {
-    return decodeURIComponent(encoded)
-  } catch {
-    return encoded
-  }
-}
-
-async function parseGatewayJSON<T>(response: Response): Promise<T> {
-  const contentType = response.headers.get('Content-Type')?.trim() || 'unknown content type'
-  if (!contentType.toLowerCase().includes('json')) {
-    throw new APIError(
-      `Playground API returned ${contentType} instead of JSON`,
-      response.status,
-      'invalid_response',
-    )
-  }
-  try {
-    return await response.json() as T
-  } catch {
-    throw new APIError('Playground API returned invalid JSON', response.status, 'invalid_response')
-  }
-}
 
 type GatewayModelPayload = {
   data?: Array<{
@@ -82,16 +29,7 @@ function normalizeEndpointTypes(value: unknown): string[] {
     .filter((item) => item.length > 0)
 }
 
-export async function listGatewayModels(apiKey: string): Promise<GatewayModel[]> {
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/models`), {
-    method: 'GET',
-    headers: authHeaders(apiKey),
-    cache: 'no-store',
-  })
-  if (!response.ok) {
-    throw await toGatewayError(response)
-  }
-  const payload = await parseGatewayJSON<GatewayModelPayload>(response)
+function gatewayModelsFromPayload(payload: GatewayModelPayload): GatewayModel[] {
   const items = Array.isArray(payload.data) ? payload.data : []
   return items
     .filter((item): item is { id: string } & typeof item => typeof item.id === 'string' && item.id.length > 0)
@@ -106,433 +44,100 @@ export async function listGatewayModels(apiKey: string): Promise<GatewayModel[]>
     .sort((left, right) => left.id.localeCompare(right.id, undefined, { sensitivity: 'base' }))
 }
 
-async function pumpSSE(response: Response, onData: (data: string) => void): Promise<void> {
-  const reader = response.body!.getReader()
+export async function listPlaygroundModels(apiKeyId: string): Promise<GatewayModel[]> {
+  const payload = await apiFetch<GatewayModelPayload>(`/api/v1/playground/models?api_key_id=${encodeURIComponent(apiKeyId)}`)
+  return gatewayModelsFromPayload(payload)
+}
+
+export type ServerConversationView = {
+  id: string
+  mode: PlaygroundMode
+  title: string
+  chat?: Conversation
+  image?: ImageConversation
+  run?: PlaygroundRun
+  last_ordinal: number
+  updated_at: number
+}
+
+export type PlaygroundRolloutEvent = {
+  timestamp: string
+  ordinal: number
+  type: string
+  run_id?: string
+  payload: unknown
+}
+
+export async function listServerConversations(mode?: PlaygroundMode): Promise<ServerConversationView[]> {
+  const suffix = mode ? `?mode=${encodeURIComponent(mode)}` : ''
+  const response = await apiFetch<{ items: ServerConversationView[] }>(`/api/v1/playground/conversations${suffix}`)
+  return response.items ?? []
+}
+
+export function getServerConversation(id: string): Promise<ServerConversationView> {
+  return apiFetch<ServerConversationView>(`/api/v1/playground/conversations/${id}`)
+}
+
+export type StartServerTurnInput = {
+  mode: PlaygroundMode
+  api_key_id: string
+  model: string
+  protocol?: ChatProtocol
+  reasoning_effort?: string
+  idempotency_key: string
+  legacy_import?: boolean
+  chat?: Conversation
+  image?: ImageConversation
+}
+
+export function startServerTurn(id: string, input: StartServerTurnInput): Promise<ServerConversationView> {
+  return apiFetch<ServerConversationView>(`/api/v1/playground/conversations/${id}/turns`, {
+    method: 'POST',
+    body: input,
+  })
+}
+
+export function cancelServerRun(id: string): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>(`/api/v1/playground/runs/${id}/cancel`, { method: 'POST' })
+}
+
+export function deleteServerConversation(id: string): Promise<void> {
+  return apiFetch<void>(`/api/v1/playground/conversations/${id}`, { method: 'DELETE' })
+}
+
+export async function followServerConversation(
+  id: string,
+  after: number,
+  signal: AbortSignal,
+  onEvent: (event: PlaygroundRolloutEvent) => void,
+  onRun: (run: PlaygroundRun) => void,
+): Promise<void> {
+  const response = await apiFetchResponse(`/api/v1/playground/conversations/${id}/events?after=${after}`, { signal })
+  if (!response.body) throw new APIError('Playground event stream is unavailable', response.status)
+  const reader = response.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
-
-  const flush = (rawEvent: string) => {
-    const dataLines = rawEvent
-      .split(/\r\n|\r|\n/)
-      .map((line) => line.trimStart())
-      .filter((line) => line.startsWith('data:'))
-      .map((line) => line.slice('data:'.length).trim())
-    if (dataLines.length === 0) return
-    const data = dataLines.join('\n')
-    if (data === '[DONE]') return
-    onData(data)
+  const flush = (raw: string) => {
+    let eventType = 'message'
+    const data: string[] = []
+    for (const line of raw.split(/\r\n|\r|\n/)) {
+      if (line.startsWith('event:')) eventType = line.slice(6).trim()
+      if (line.startsWith('data:')) data.push(line.slice(5).trim())
+    }
+    if (data.length === 0) return
+    const parsed = JSON.parse(data.join('\n')) as unknown
+    if (eventType === 'rollout') onEvent(parsed as PlaygroundRolloutEvent)
+    if (eventType === 'run_status') onRun(parsed as PlaygroundRun)
   }
-
   for (;;) {
     const { done, value } = await reader.read()
     if (done) break
     buffer += decoder.decode(value, { stream: true })
-    let boundary = /(?:\r\n|\r|\n){2}/.exec(buffer)
+    let boundary = /\r\n\r\n|\n\n|\r\r/.exec(buffer)
     while (boundary) {
       flush(buffer.slice(0, boundary.index))
       buffer = buffer.slice(boundary.index + boundary[0].length)
-      boundary = /(?:\r\n|\r|\n){2}/.exec(buffer)
+      boundary = /\r\n\r\n|\n\n|\r\r/.exec(buffer)
     }
-  }
-  buffer += decoder.decode()
-  if (buffer.trim()) flush(buffer)
-}
-
-export type ChatTurn = {
-  role: 'system' | 'user' | 'assistant'
-  content: string
-  attachments?: ChatAttachment[]
-}
-
-function availableAttachments(turn: ChatTurn): Array<ChatAttachment & { dataURL: string }> {
-  return (turn.attachments ?? []).filter(
-    (attachment): attachment is ChatAttachment & { dataURL: string } => Boolean(attachment.dataURL),
-  )
-}
-
-function openAIChatContent(turn: ChatTurn): unknown {
-  const attachments = availableAttachments(turn)
-  if (attachments.length === 0) return turn.content
-  const parts: Array<Record<string, unknown>> = []
-  if (turn.content) parts.push({ type: 'text', text: turn.content })
-  for (const attachment of attachments) {
-    if (attachment.mimeType.startsWith('image/')) {
-      parts.push({ type: 'image_url', image_url: { url: attachment.dataURL } })
-    } else {
-      parts.push({
-        type: 'file',
-        file: { filename: attachment.name, file_data: attachment.dataURL },
-      })
-    }
-  }
-  return parts
-}
-
-function responsesContent(turn: ChatTurn): unknown {
-  const attachments = availableAttachments(turn)
-  if (attachments.length === 0) return turn.content
-  const parts: Array<Record<string, unknown>> = []
-  if (turn.content) parts.push({ type: turn.role === 'assistant' ? 'output_text' : 'input_text', text: turn.content })
-  for (const attachment of attachments) {
-    if (attachment.mimeType.startsWith('image/')) {
-      parts.push({ type: 'input_image', image_url: attachment.dataURL })
-    } else {
-      parts.push({
-        type: 'input_file',
-        filename: attachment.name,
-        file_data: attachment.dataURL,
-      })
-    }
-  }
-  return parts
-}
-
-function dataURLSource(dataURL: string, fallbackMimeType: string): { mediaType: string; data: string } {
-  const match = /^data:([^;,]+)?;base64,(.*)$/s.exec(dataURL)
-  return {
-    mediaType: match?.[1] || fallbackMimeType || 'application/octet-stream',
-    data: match?.[2] || dataURL,
-  }
-}
-
-function anthropicContent(turn: ChatTurn): unknown {
-  const attachments = availableAttachments(turn)
-  if (attachments.length === 0) return turn.content
-  const parts: Array<Record<string, unknown>> = []
-  if (turn.content) parts.push({ type: 'text', text: turn.content })
-  for (const attachment of attachments) {
-    const source = dataURLSource(attachment.dataURL, attachment.mimeType)
-    if (attachment.mimeType.startsWith('image/')) {
-      parts.push({
-        type: 'image',
-        source: { type: 'base64', media_type: source.mediaType, data: source.data },
-      })
-    } else {
-      parts.push({
-        type: 'document',
-        title: attachment.name,
-        source: { type: 'base64', media_type: source.mediaType, data: source.data },
-      })
-    }
-  }
-  return parts
-}
-
-export type StreamChatInput = {
-  apiKey: string
-  model: string
-  messages: ChatTurn[]
-  reasoningEffort?: string
-  signal?: AbortSignal
-  onContent: (delta: string) => void
-  onReasoning: (delta: string) => void
-  onUsage: (usage: ChatUsage) => void
-  onRouteSite: (siteName: string) => void
-}
-
-type ChatStreamChunk = {
-  choices?: Array<{
-    delta?: { content?: string | null; reasoning_content?: string | null }
-  }>
-  usage?: ChatUsage | null
-  error?: { message?: string } | null
-}
-
-export async function streamChatCompletion(input: StreamChatInput): Promise<void> {
-  const body: Record<string, unknown> = {
-    model: input.model,
-    messages: input.messages.map((message) => ({
-      role: message.role,
-      content: openAIChatContent(message),
-    })),
-    stream: true,
-    stream_options: { include_usage: true },
-  }
-  if (input.reasoningEffort) body.reasoning_effort = input.reasoningEffort
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/chat/completions`), {
-    method: 'POST',
-    headers: { ...authHeaders(input.apiKey), 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: input.signal,
-  })
-  if (!response.ok || !response.body) {
-    throw await toGatewayError(response)
-  }
-
-  const siteName = routeSiteName(response)
-  if (siteName) input.onRouteSite(siteName)
-
-  let failure: string | null = null
-  await pumpSSE(response, (data) => {
-    let chunk: ChatStreamChunk
-    try {
-      chunk = JSON.parse(data) as ChatStreamChunk
-    } catch {
-      return
-    }
-    if (chunk.error?.message) {
-      failure = chunk.error.message
-      return
-    }
-    const delta = chunk.choices?.[0]?.delta
-    if (delta?.content) input.onContent(delta.content)
-    if (delta?.reasoning_content) input.onReasoning(delta.reasoning_content)
-    if (chunk.usage) input.onUsage(chunk.usage)
-  })
-  if (failure) throw new APIError(failure, response.status)
-}
-
-type ResponsesStreamEvent = {
-  type?: string
-  delta?: string
-  response?: {
-    usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number } | null
-    error?: { message?: string } | null
-  } | null
-  message?: string
-}
-
-export async function streamResponses(input: StreamChatInput): Promise<void> {
-  const inputItems = input.messages
-    .filter((message) => message.role !== 'system')
-    .map((message) => ({ type: 'message', role: message.role, content: responsesContent(message) }))
-  const instructions = input.messages
-    .filter((message) => message.role === 'system')
-    .map((message) => message.content)
-    .join('\n\n')
-
-  const body: Record<string, unknown> = {
-    model: input.model,
-    input: inputItems,
-    stream: true,
-  }
-  if (instructions.trim()) body.instructions = instructions.trim()
-  if (input.reasoningEffort) body.reasoning = { effort: input.reasoningEffort, summary: 'auto' }
-
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/responses`), {
-    method: 'POST',
-    headers: { ...authHeaders(input.apiKey), 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: input.signal,
-  })
-  if (!response.ok || !response.body) {
-    throw await toGatewayError(response)
-  }
-
-  const siteName = routeSiteName(response)
-  if (siteName) input.onRouteSite(siteName)
-
-  let failure: string | null = null
-  await pumpSSE(response, (data) => {
-    let event: ResponsesStreamEvent
-    try {
-      event = JSON.parse(data) as ResponsesStreamEvent
-    } catch {
-      return
-    }
-    switch (event.type) {
-      case 'response.output_text.delta':
-        if (event.delta) input.onContent(event.delta)
-        break
-      case 'response.reasoning_summary_text.delta':
-      case 'response.reasoning_text.delta':
-        if (event.delta) input.onReasoning(event.delta)
-        break
-      case 'response.completed':
-      case 'response.incomplete': {
-        const usage = event.response?.usage
-        if (usage) {
-          input.onUsage({
-            prompt_tokens: usage.input_tokens,
-            completion_tokens: usage.output_tokens,
-            total_tokens: usage.total_tokens,
-          })
-        }
-        break
-      }
-      case 'response.failed':
-      case 'error':
-        failure = event.response?.error?.message || event.message || 'response failed'
-        break
-      default:
-        break
-    }
-  })
-
-  if (failure) {
-    throw new APIError(failure, response.status)
-  }
-}
-
-type MessagesStreamEvent = {
-  type?: string
-  delta?: { type?: string; text?: string; thinking?: string }
-  message?: { usage?: { input_tokens?: number; output_tokens?: number } | null }
-  usage?: { output_tokens?: number } | null
-  error?: { message?: string } | null
-}
-
-export async function streamMessages(input: StreamChatInput): Promise<void> {
-  const system = input.messages
-    .filter((message) => message.role === 'system')
-    .map((message) => message.content)
-    .join('\n\n')
-  const messages = input.messages
-    .filter((message) => message.role !== 'system')
-    .map((message) => ({ role: message.role, content: anthropicContent(message) }))
-
-  const body: Record<string, unknown> = {
-    model: input.model,
-    max_tokens: 4096,
-    messages,
-    stream: true,
-  }
-  if (system.trim()) body.system = system.trim()
-
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/messages`), {
-    method: 'POST',
-    headers: {
-      ...authHeaders(input.apiKey),
-      'Content-Type': 'application/json',
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify(body),
-    signal: input.signal,
-  })
-  if (!response.ok || !response.body) {
-    throw await toGatewayError(response)
-  }
-
-  const siteName = routeSiteName(response)
-  if (siteName) input.onRouteSite(siteName)
-
-  let inputTokens = 0
-  let failure: string | null = null
-  await pumpSSE(response, (data) => {
-    let event: MessagesStreamEvent
-    try {
-      event = JSON.parse(data) as MessagesStreamEvent
-    } catch {
-      return
-    }
-    switch (event.type) {
-      case 'message_start':
-        inputTokens = event.message?.usage?.input_tokens ?? 0
-        break
-      case 'content_block_delta':
-        if (event.delta?.type === 'text_delta' && event.delta.text) input.onContent(event.delta.text)
-        if (event.delta?.type === 'thinking_delta' && event.delta.thinking) input.onReasoning(event.delta.thinking)
-        break
-      case 'message_delta':
-        if (event.usage?.output_tokens != null) {
-          input.onUsage({
-            prompt_tokens: inputTokens,
-            completion_tokens: event.usage.output_tokens,
-            total_tokens: inputTokens + event.usage.output_tokens,
-          })
-        }
-        break
-      case 'error':
-        failure = event.error?.message || 'message failed'
-        break
-      default:
-        break
-    }
-  })
-
-  if (failure) {
-    throw new APIError(failure, response.status)
-  }
-}
-
-export function streamChat(protocol: ChatProtocol, input: StreamChatInput): Promise<void> {
-  if (protocol === 'responses') return streamResponses(input)
-  if (protocol === 'messages') return streamMessages(input)
-  return streamChatCompletion(input)
-}
-
-type ImagePayload = {
-  data?: Array<{ b64_json?: string; url?: string }>
-}
-
-function imageItemsFromPayload(payload: ImagePayload): ImageResultItem[] {
-  const items = Array.isArray(payload.data) ? payload.data : []
-  return items
-    .map((item) => {
-      if (item.b64_json) return { id: newId(), src: `data:image/png;base64,${item.b64_json}` }
-      if (item.url) return { id: newId(), src: item.url }
-      return null
-    })
-    .filter((item): item is ImageResultItem => item !== null)
-}
-
-export type GenerateImageInput = {
-  apiKey: string
-  model: string
-  prompt: string
-  size?: string
-  n?: number
-  signal?: AbortSignal
-}
-
-export type ImageRequestResult = {
-  images: ImageResultItem[]
-  siteName?: string
-}
-
-export async function generateImage(input: GenerateImageInput): Promise<ImageRequestResult> {
-  const body: Record<string, unknown> = {
-    model: input.model,
-    prompt: input.prompt,
-    n: input.n ?? 1,
-    response_format: 'b64_json',
-  }
-  if (input.size && input.size !== 'auto') body.size = input.size
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/images/generations`), {
-    method: 'POST',
-    headers: { ...authHeaders(input.apiKey), 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: input.signal,
-  })
-  if (!response.ok) {
-    throw await toGatewayError(response)
-  }
-  return {
-    images: imageItemsFromPayload(await parseGatewayJSON<ImagePayload>(response)),
-    siteName: routeSiteName(response),
-  }
-}
-
-export type EditImageInput = {
-  apiKey: string
-  model: string
-  prompt: string
-  images: File[]
-  size?: string
-  n?: number
-  signal?: AbortSignal
-}
-
-export async function editImage(input: EditImageInput): Promise<ImageRequestResult> {
-  const form = new FormData()
-  form.append('model', input.model)
-  form.append('prompt', input.prompt)
-  form.append('n', String(input.n ?? 1))
-  if (input.size && input.size !== 'auto') form.append('size', input.size)
-  for (const file of input.images) {
-    form.append('image', file)
-  }
-  const response = await fetch(apiURL(`${PLAYGROUND_API_BASE}/images/edits`), {
-    method: 'POST',
-    headers: authHeaders(input.apiKey),
-    body: form,
-    signal: input.signal,
-  })
-  if (!response.ok) {
-    throw await toGatewayError(response)
-  }
-  return {
-    images: imageItemsFromPayload(await parseGatewayJSON<ImagePayload>(response)),
-    siteName: routeSiteName(response),
   }
 }

--- a/web/src/features/playground/components/chat-attachment.tsx
+++ b/web/src/features/playground/components/chat-attachment.tsx
@@ -100,7 +100,7 @@ function attachmentIcon(attachment: ChatAttachment): AttachmentIcon {
 }
 
 export function ChatAttachmentItem({ attachment, removeLabel, onRemove }: ChatAttachmentItemProps) {
-  const imageSource = attachment.mimeType.startsWith('image/') ? attachment.dataURL : undefined
+  const imageSource = attachment.mimeType.startsWith('image/') ? attachment.dataURL ?? attachment.src : undefined
   const { Icon, className } = attachmentIcon(attachment)
 
   return (

--- a/web/src/features/playground/components/chat-view.tsx
+++ b/web/src/features/playground/components/chat-view.tsx
@@ -1,19 +1,22 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ImageIcon, Lightbulb, Paperclip, Sparkles } from 'lucide-react'
 import { APIError } from '@/lib/http'
-import { streamChat, type ChatTurn } from '@/features/playground/api/playground'
+import {
+  cancelServerRun,
+  followServerConversation,
+  getServerConversation,
+  startServerTurn,
+  type PlaygroundRolloutEvent,
+  type ServerConversationView,
+} from '@/features/playground/api/playground'
 import { Composer } from '@/features/playground/components/composer'
 import { ModelReasoningPicker } from '@/features/playground/components/model-reasoning-picker'
 import { ChatMessageItem } from '@/features/playground/components/chat-message'
 import { ChatAttachmentItem } from '@/features/playground/components/chat-attachment'
 import { normalizeReasoningEffort } from '@/features/playground/lib/reasoning'
 import { newId } from '@/features/playground/lib/storage'
-import {
-  RESPONSE_TIMER_REVEAL_MS,
-  RESPONSE_TIMER_TICK_MS,
-  responseTimestamp,
-} from '@/features/playground/lib/response-timing'
+import { RESPONSE_TIMER_TICK_MS } from '@/features/playground/lib/response-timing'
 import { useStickToBottom } from '@/hooks/use-stick-to-bottom'
 import { saveChatAttachmentDataAsync } from '@/features/playground/lib/attachment-store'
 import type {
@@ -52,7 +55,6 @@ function attachmentMimeType(file: File): string {
 }
 
 type ChatViewProps = {
-  apiKey: string | null
   apiKeys: Array<{ id: string; name: string }>
   apiKeyId: string | null
   onAPIKeyChange: (id: string) => void
@@ -74,7 +76,6 @@ function autoProtocol(model: GatewayModel | undefined): ChatProtocol {
 }
 
 export function ChatView({
-  apiKey,
   apiKeys,
   apiKeyId,
   onAPIKeyChange,
@@ -91,16 +92,19 @@ export function ChatView({
   const [input, setInput] = useState('')
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
-  const [streaming, setStreaming] = useState(false)
-  const [streamingId, setStreamingId] = useState<string | null>(null)
+  const [sendError, setSendError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
   const [streamingElapsedMs, setStreamingElapsedMs] = useState<number | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const [stopRequested, setStopRequested] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const { handleScroll, scrollToBottom, scrollToBottomIfStuck } = useStickToBottom(scrollRef)
 
   const isEmpty = conversation.messages.length === 0
-  const canSend = Boolean(apiKey && model && (input.trim() || attachments.length > 0) && !streaming)
+  const runActive = conversation.activeRun?.status === 'queued' || conversation.activeRun?.status === 'running'
+  const streaming = starting || runActive
+  const canSend = Boolean(apiKeyId && model && (input.trim() || attachments.length > 0) && !streaming)
 
   const lastUserId = useMemo(() => {
     for (let index = conversation.messages.length - 1; index >= 0; index -= 1) {
@@ -109,7 +113,15 @@ export function ChatView({
     return null
   }, [conversation.messages])
   const lastMessageId = conversation.messages[conversation.messages.length - 1]?.id ?? null
+  const streamingId = streaming
+    ? [...conversation.messages].reverse().find((message) => message.role === 'assistant')?.id ?? null
+    : null
   const modelsById = useMemo(() => new Map(models.map((item) => [item.id, item])), [models])
+  const subscriptionState = useEffectEvent(() => ({
+    id: conversation.id,
+    lastOrdinal: conversation.lastOrdinal ?? 0,
+    run: conversation.activeRun,
+  }))
 
   useEffect(() => {
     scrollToBottom()
@@ -121,108 +133,154 @@ export function ChatView({
 
   useEffect(() => () => abortRef.current?.abort(), [])
 
-  const patchMessage = (id: string, patch: (message: ChatMessage) => ChatMessage) => {
-    onChange((current) => ({
-      ...current,
-      updatedAt: Date.now(),
-      messages: current.messages.map((message) => (message.id === id ? patch(message) : message)),
-    }))
-  }
-
-  const buildTurns = (messages: ChatMessage[]): ChatTurn[] => {
-    const turns: ChatTurn[] = []
-    if (conversation.systemPrompt.trim()) {
-      turns.push({ role: 'system', content: conversation.systemPrompt.trim() })
+  useEffect(() => {
+    if (!stopRequested) return
+    const run = conversation.activeRun
+    if (!run) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      if (run.status === 'queued' || run.status === 'running') {
+        void cancelServerRun(run.id)
+      }
+      setStopRequested(false)
+    })
+    return () => {
+      cancelled = true
     }
-    for (const message of messages) {
-      if ((message.content || message.attachments?.some((attachment) => attachment.dataURL)) && !message.error) {
-        turns.push({ role: message.role, content: message.content, attachments: message.attachments })
+  }, [stopRequested, conversation.activeRun])
+
+  useEffect(() => {
+    if (!streaming) return
+    const startedAt = conversation.activeRun?.created_at ?? Date.now()
+    const update = () => setStreamingElapsedMs(Math.max(0, Date.now() - startedAt))
+    const interval = window.setInterval(update, RESPONSE_TIMER_TICK_MS)
+    return () => window.clearInterval(interval)
+  }, [streaming, conversation.activeRun?.created_at])
+
+  const applyServerView = useCallback((view: ServerConversationView) => {
+    if (!view.chat) return
+    const next = {
+      ...view.chat,
+      serverPersisted: true,
+      lastOrdinal: view.last_ordinal,
+      activeRun: view.run,
+    }
+    onChange(() => next)
+  }, [onChange])
+
+  const applyRolloutEvent = useCallback((event: PlaygroundRolloutEvent) => {
+    onChange((current) => {
+      let messages = current.messages
+      if (event.type === 'assistant_delta') {
+        const payload = event.payload as { message_id?: string; content?: string; reasoning?: string }
+        messages = messages.map((message) => message.id === payload.message_id ? {
+          ...message,
+          content: message.content + (payload.content ?? ''),
+          reasoning: (message.reasoning ?? '') + (payload.reasoning ?? ''),
+        } : message)
+      }
+      if (event.type === 'assistant_final') {
+        const final = event.payload as ChatMessage
+        messages = messages.map((message) => message.id === final.id ? final : message)
+      }
+      if (event.type === 'turn_failed' || event.type === 'turn_cancelled' || event.type === 'turn_interrupted') {
+        const payload = event.payload as { message_id?: string; error?: string; response_duration_ms?: number }
+        messages = messages.map((message) => message.id === payload.message_id ? {
+          ...message,
+          error: payload.error,
+          responseDurationMs: payload.response_duration_ms,
+        } : message)
+      }
+      return { ...current, messages, lastOrdinal: event.ordinal, updatedAt: Date.now() }
+    })
+  }, [onChange])
+
+  useEffect(() => {
+    const current = subscriptionState()
+    const run = current.run
+    const active = run?.status === 'queued' || run?.status === 'running'
+    if (!active || !run) return
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+    let cursor = current.lastOrdinal ?? 0
+    let terminal = false
+    const follow = async () => {
+      while (!controller.signal.aborted && !terminal) {
+        try {
+          await followServerConversation(
+            current.id,
+            cursor,
+            controller.signal,
+            (event) => {
+              cursor = Math.max(cursor, event.ordinal)
+              applyRolloutEvent(event)
+            },
+            (nextRun) => {
+              terminal = nextRun.status !== 'queued' && nextRun.status !== 'running'
+            },
+          )
+          const view = await getServerConversation(current.id)
+          applyServerView(view)
+          terminal = view.run?.status !== 'queued' && view.run?.status !== 'running'
+        } catch {
+          if (controller.signal.aborted) return
+          await new Promise((resolve) => window.setTimeout(resolve, 750))
+        }
       }
     }
-    return turns
-  }
+    void follow()
+    return () => controller.abort()
+  }, [conversation.id, conversation.activeRun?.id, conversation.activeRun?.status, applyRolloutEvent, applyServerView])
 
   const streamAssistant = async (keptMessages: ChatMessage[], extra?: Partial<Conversation>) => {
-    if (!apiKey || !model || streaming) return
-    const startedAt = responseTimestamp()
+    if (!apiKeyId || !model || streaming) return
     const activeModel = models.find((item) => item.id === model)
     const protocol = autoProtocol(activeModel)
-    const assistantId = newId()
-    const assistantMessage: ChatMessage = {
-      id: assistantId,
-      role: 'assistant',
-      content: '',
-      model: model ?? undefined,
-      createdAt: Date.now(),
-    }
-    onChange((current) => ({
-      ...current,
+    const nextConversation: Conversation = {
+      ...conversation,
       ...extra,
       model,
       updatedAt: Date.now(),
-      messages: [...keptMessages, assistantMessage],
-    }))
-    setStreamingElapsedMs(null)
-    setStreaming(true)
-    setStreamingId(assistantId)
-    scrollToBottom()
-
-    let elapsedIntervalId: number | null = null
-    let revealTimerId: number | null = null
-    const updateElapsed = () => setStreamingElapsedMs(Math.round(responseTimestamp() - startedAt))
-    const revealElapsed = () => {
-      if (elapsedIntervalId !== null) return
-      if (revealTimerId !== null) window.clearTimeout(revealTimerId)
-      updateElapsed()
-      elapsedIntervalId = window.setInterval(updateElapsed, RESPONSE_TIMER_TICK_MS)
+      messages: keptMessages,
     }
-    revealTimerId = window.setTimeout(revealElapsed, RESPONSE_TIMER_REVEAL_MS)
-
-    const controller = new AbortController()
-    abortRef.current = controller
-
+    onChange(() => nextConversation)
+    setSendError(null)
+    setStarting(true)
+    scrollToBottom()
     try {
-      await streamChat(protocol, {
-        apiKey,
+      const view = await startServerTurn(conversation.id, {
+        mode: 'chat',
+        api_key_id: apiKeyId,
         model,
-        messages: buildTurns(keptMessages),
-        reasoningEffort: normalizeReasoningEffort(activeModel, effort),
-        signal: controller.signal,
-        onContent: (delta) => {
-          if (delta) revealElapsed()
-          patchMessage(assistantId, (message) => ({ ...message, content: message.content + delta }))
-        },
-        onReasoning: (delta) => {
-          if (delta) revealElapsed()
-          patchMessage(assistantId, (message) => ({
-            ...message,
-            reasoning: (message.reasoning ?? '') + delta,
-          }))
-        },
-        onUsage: (usage) => patchMessage(assistantId, (message) => ({ ...message, usage })),
-        onRouteSite: (siteName) =>
-          patchMessage(assistantId, (message) => ({ ...message, siteName })),
+        protocol,
+        reasoning_effort: normalizeReasoningEffort(activeModel, effort),
+        idempotency_key: newId(),
+        legacy_import: !conversation.serverPersisted,
+        chat: nextConversation,
       })
+      applyServerView(view)
+      setStarting(false)
     } catch (error) {
-      if (!(error instanceof DOMException && error.name === 'AbortError')) {
-        const messageText =
-          error instanceof APIError || error instanceof Error ? error.message : t('chat.errorGeneric')
-        patchMessage(assistantId, (message) => ({
-          ...message,
-          error: messageText,
-        }))
+      setStarting(false)
+      setStopRequested(false)
+      const messageText = error instanceof APIError || error instanceof Error ? error.message : t('chat.errorGeneric')
+      try {
+        const view = await getServerConversation(conversation.id)
+        applyServerView(view)
+        setSendError(messageText)
+      } catch (lookup) {
+        if (lookup instanceof APIError && lookup.status === 404) {
+          onChange((current) => ({
+            ...current,
+            serverPersisted: false,
+            messages: [...current.messages, { id: newId(), role: 'assistant', content: '', error: messageText, model: model ?? undefined, createdAt: Date.now() }],
+          }))
+        } else {
+          setSendError(messageText)
+        }
       }
-    } finally {
-      if (revealTimerId !== null) window.clearTimeout(revealTimerId)
-      if (elapsedIntervalId !== null) window.clearInterval(elapsedIntervalId)
-      patchMessage(assistantId, (message) => ({
-        ...message,
-        responseDurationMs: Math.round(responseTimestamp() - startedAt),
-      }))
-      setStreamingElapsedMs(null)
-      setStreaming(false)
-      setStreamingId(null)
-      abortRef.current = null
     }
   }
 
@@ -261,7 +319,7 @@ export function ChatView({
   }
 
   const handleSend = () => {
-    if (!apiKey || !model) return
+    if (!apiKeyId || !model) return
     const text = input.trim()
     if ((!text && attachments.length === 0) || streaming) return
     const userMessage: ChatMessage = {
@@ -311,7 +369,14 @@ export function ChatView({
       value={input}
       onChange={setInput}
       onSubmit={handleSend}
-      onStop={() => abortRef.current?.abort()}
+      onStop={() => {
+        const runId = conversation.activeRun?.id
+        if (runId && runActive) {
+          void cancelServerRun(runId)
+        } else if (starting) {
+          setStopRequested(true)
+        }
+      }}
       streaming={streaming}
       canSubmit={canSend}
       placeholder={t('chat.inputPlaceholder')}
@@ -340,7 +405,7 @@ export function ChatView({
           </button>
         </>
       }
-      attachments={attachments.length > 0 || attachmentError ? (
+      attachments={attachments.length > 0 || attachmentError || sendError ? (
         <div className="space-y-2">
           {attachments.length > 0 ? (
             <div className="flex flex-wrap gap-2">
@@ -355,6 +420,7 @@ export function ChatView({
             </div>
           ) : null}
           {attachmentError ? <p className="px-1 text-xs text-red-500">{attachmentError}</p> : null}
+          {sendError ? <p className="px-1 text-xs text-red-500">{sendError}</p> : null}
         </div>
       ) : undefined}
       trailingControls={
@@ -366,7 +432,7 @@ export function ChatView({
               onModelChange={onModelChange}
               effort={effort}
               onEffortChange={onEffortChange}
-              disabled={!apiKey}
+              disabled={!apiKeyId}
             />
           </div>
           <div className="min-w-0 md:hidden">

--- a/web/src/features/playground/components/image-view.tsx
+++ b/web/src/features/playground/components/image-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Copy, Download, ImagePlus, Loader2, Paperclip, Pencil } from 'lucide-react'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
@@ -6,7 +6,14 @@ import { Button } from '@/components/ui/button'
 import { TextArea } from '@/components/ui/textarea'
 import { copyToClipboard } from '@/components/common/copy-to-clipboard'
 import { APIError } from '@/lib/http'
-import { editImage, generateImage } from '@/features/playground/api/playground'
+import {
+  cancelServerRun,
+  followServerConversation,
+  getServerConversation,
+  startServerTurn,
+  type PlaygroundRolloutEvent,
+  type ServerConversationView,
+} from '@/features/playground/api/playground'
 import { Composer } from '@/features/playground/components/composer'
 import { ChatAttachmentItem } from '@/features/playground/components/chat-attachment'
 import { ModelParameterPicker } from '@/features/playground/components/model-parameter-picker'
@@ -19,7 +26,6 @@ import { CollapsibleUserMessage } from '@/features/playground/components/collaps
 import { newId } from '@/features/playground/lib/storage'
 import {
   formatResponseDuration,
-  RESPONSE_TIMER_REVEAL_MS,
   RESPONSE_TIMER_TICK_MS,
   responseTimestamp,
 } from '@/features/playground/lib/response-timing'
@@ -27,7 +33,6 @@ import { useStickToBottom } from '@/hooks/use-stick-to-bottom'
 import type { GatewayModel, ImageConversation, ImageHistoryEntry } from '@/features/playground/lib/types'
 
 type ImageViewProps = {
-  apiKey: string | null
   apiKeys: Array<{ id: string; name: string }>
   apiKeyId: string | null
   onAPIKeyChange: (id: string) => void
@@ -96,8 +101,19 @@ function ImageAttachment({
   )
 }
 
+async function resyncServerConversation(
+  id: string,
+  apply: (view: ServerConversationView) => void,
+): Promise<'ok' | 'missing' | 'error'> {
+  try {
+    apply(await getServerConversation(id))
+    return 'ok'
+  } catch (lookup) {
+    return lookup instanceof APIError && lookup.status === 404 ? 'missing' : 'error'
+  }
+}
+
 export function ImageView({
-  apiKey,
   apiKeys,
   apiKeyId,
   onAPIKeyChange,
@@ -111,20 +127,29 @@ export function ImageView({
   const [prompt, setPrompt] = useState('')
   const [size, setSize] = useState('auto')
   const [files, setFiles] = useState<File[]>([])
-  const [submitting, setSubmitting] = useState(false)
-  const [submittingEntryId, setSubmittingEntryId] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
+  const [sendError, setSendError] = useState<string | null>(null)
   const [submittingElapsedMs, setSubmittingElapsedMs] = useState<number | null>(null)
   const [lightbox, setLightbox] = useState<string | null>(null)
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null)
   const [editDraft, setEditDraft] = useState('')
+  const [stopRequested, setStopRequested] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const abortRef = useRef<AbortController | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const { handleScroll, scrollToBottom, scrollToBottomIfStuck } = useStickToBottom(scrollRef)
 
   const isEmpty = conversation.entries.length === 0
-  const canSubmit = Boolean(apiKey && model && prompt.trim() && !submitting)
+  const runActive = conversation.activeRun?.status === 'queued' || conversation.activeRun?.status === 'running'
+  const submitting = starting || runActive
+  const submittingEntryId = submitting ? conversation.entries[conversation.entries.length - 1]?.id ?? null : null
+  const canSubmit = Boolean(apiKeyId && model && prompt.trim() && !submitting)
   const modelsById = useMemo(() => new Map(models.map((item) => [item.id, item])), [models])
+  const subscriptionState = useEffectEvent(() => ({
+    id: conversation.id,
+    lastOrdinal: conversation.lastOrdinal ?? 0,
+    run: conversation.activeRun,
+  }))
 
   const lastImageSrc = useMemo(() => {
     for (let index = conversation.entries.length - 1; index >= 0; index -= 1) {
@@ -134,8 +159,7 @@ export function ImageView({
     return null
   }, [conversation.entries])
 
-  const carrySource =
-    files.length === 0 && lastImageSrc && lastImageSrc.startsWith('data:') ? lastImageSrc : null
+  const carrySource = files.length === 0 ? lastImageSrc : null
 
   useEffect(() => {
     scrollToBottom()
@@ -146,6 +170,31 @@ export function ImageView({
   }, [conversation.entries, submitting, scrollToBottomIfStuck])
 
   useEffect(() => () => abortRef.current?.abort(), [])
+
+  useEffect(() => {
+    if (!stopRequested) return
+    const run = conversation.activeRun
+    if (!run) return
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      if (run.status === 'queued' || run.status === 'running') {
+        void cancelServerRun(run.id)
+      }
+      setStopRequested(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [stopRequested, conversation.activeRun])
+
+  useEffect(() => {
+    if (!submitting) return
+    const startedAt = conversation.activeRun?.created_at ?? Date.now()
+    const update = () => setSubmittingElapsedMs(Math.max(0, Date.now() - startedAt))
+    const interval = window.setInterval(update, RESPONSE_TIMER_TICK_MS)
+    return () => window.clearInterval(interval)
+  }, [submitting, conversation.activeRun?.created_at])
 
   const addFiles = (list: FileList | File[] | null) => {
     if (!list) return
@@ -169,28 +218,97 @@ export function ImageView({
     }))
   }
 
+  const applyServerView = useCallback((view: ServerConversationView) => {
+    if (!view.image) return
+    const next = {
+      ...view.image,
+      serverPersisted: true,
+      lastOrdinal: view.last_ordinal,
+      activeRun: view.run,
+    }
+    onChange(() => next)
+  }, [onChange])
+
+  const applyRolloutEvent = useCallback((event: PlaygroundRolloutEvent) => {
+    onChange((current) => {
+      let entries = current.entries
+      if (event.type === 'image_final') {
+        const final = event.payload as ImageHistoryEntry
+        entries = entries.map((entry) => entry.id === final.id ? final : entry)
+      }
+      if (event.type === 'turn_failed' || event.type === 'turn_cancelled' || event.type === 'turn_interrupted') {
+        const payload = event.payload as { entry_id?: string; error?: string; response_duration_ms?: number }
+        entries = entries.map((entry) => entry.id === payload.entry_id ? {
+          ...entry,
+          pending: false,
+          error: payload.error,
+          responseDurationMs: payload.response_duration_ms,
+        } : entry)
+      }
+      return { ...current, entries, lastOrdinal: event.ordinal, updatedAt: Date.now() }
+    })
+  }, [onChange])
+
+  useEffect(() => {
+    const current = subscriptionState()
+    const run = current.run
+    const active = run?.status === 'queued' || run?.status === 'running'
+    if (!active || !run) return
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+    let cursor = current.lastOrdinal ?? 0
+    let terminal = false
+    const follow = async () => {
+      while (!controller.signal.aborted && !terminal) {
+        try {
+          await followServerConversation(
+            current.id,
+            cursor,
+            controller.signal,
+            (event) => {
+              cursor = Math.max(cursor, event.ordinal)
+              applyRolloutEvent(event)
+            },
+            (nextRun) => {
+              terminal = nextRun.status !== 'queued' && nextRun.status !== 'running'
+            },
+          )
+          const view = await getServerConversation(current.id)
+          applyServerView(view)
+          terminal = view.run?.status !== 'queued' && view.run?.status !== 'running'
+        } catch {
+          if (controller.signal.aborted) return
+          await new Promise((resolve) => window.setTimeout(resolve, 750))
+        }
+      }
+    }
+    void follow()
+    return () => controller.abort()
+  }, [conversation.id, conversation.activeRun?.id, conversation.activeRun?.status, applyRolloutEvent, applyServerView])
+
   const runEntry = async ({
     entryId,
     text,
     requestModel,
     requestSize,
     mode,
-    sourceFiles,
     sourceImages,
     append,
     startedAt,
+    createdAt,
   }: {
     entryId: string
     text: string
     requestModel: string
     requestSize: string
     mode: ImageHistoryEntry['mode']
-    sourceFiles: File[]
     sourceImages: string[]
     append: boolean
     startedAt: number
+    createdAt: number
   }) => {
-    if (!apiKey || submitting) return
+    if (!apiKeyId || submitting) return
 
     if (append) {
       onChange((current) => ({
@@ -227,64 +345,69 @@ export function ImageView({
       })
     }
 
-    setSubmittingEntryId(entryId)
-    setSubmittingElapsedMs(null)
-    setSubmitting(true)
+    setStarting(true)
+    setSendError(null)
     scrollToBottom()
 
-    let elapsedIntervalId: number | null = null
-    const updateElapsed = () => setSubmittingElapsedMs(Math.round(responseTimestamp() - startedAt))
-    const revealTimerId = window.setTimeout(() => {
-      updateElapsed()
-      elapsedIntervalId = window.setInterval(updateElapsed, RESPONSE_TIMER_TICK_MS)
-    }, RESPONSE_TIMER_REVEAL_MS)
-
-    const controller = new AbortController()
-    abortRef.current = controller
     try {
-      const result =
-        mode === 'generation'
-          ? await generateImage({ apiKey, model: requestModel, prompt: text, size: requestSize, signal: controller.signal })
-          : await editImage({ apiKey, model: requestModel, prompt: text, images: sourceFiles, size: requestSize, signal: controller.signal })
-      patchEntry(entryId, { images: result.images, siteName: result.siteName, pending: false })
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        if (append) {
-          onChange((current) => ({
-            ...current,
-            entries: current.entries.filter((entry) => entry.id !== entryId),
-          }))
-        } else {
-          patchEntry(entryId, { pending: false, error: t('image.errorGeneric') })
-        }
-      } else {
-        const messageText =
-          err instanceof APIError || err instanceof Error ? err.message : t('image.errorGeneric')
-        patchEntry(entryId, { pending: false, error: messageText })
+      const nextEntry: ImageHistoryEntry = {
+        id: entryId,
+        mode,
+        model: requestModel,
+        prompt: text,
+        size: requestSize,
+        sourceImages,
+        images: [],
+        pending: true,
+        createdAt,
       }
-    } finally {
-      window.clearTimeout(revealTimerId)
-      if (elapsedIntervalId !== null) window.clearInterval(elapsedIntervalId)
-      patchEntry(entryId, { responseDurationMs: Math.round(responseTimestamp() - startedAt) })
-      setSubmittingElapsedMs(null)
-      setSubmittingEntryId(null)
-      setSubmitting(false)
-      abortRef.current = null
+      const entries = append
+        ? [...conversation.entries, nextEntry]
+        : conversation.entries.map((entry) => entry.id === entryId ? nextEntry : entry)
+      const requestConversation: ImageConversation = {
+        ...conversation,
+        title: conversation.title || text.slice(0, 40),
+        entries,
+        updatedAt: createdAt,
+      }
+      const view = await startServerTurn(conversation.id, {
+        mode: 'image',
+        api_key_id: apiKeyId,
+        model: requestModel,
+        idempotency_key: newId(),
+        legacy_import: !conversation.serverPersisted,
+        image: requestConversation,
+      })
+      applyServerView(view)
+      setStarting(false)
+    } catch (err) {
+      setStarting(false)
+      setStopRequested(false)
+      const messageText = err instanceof APIError || err instanceof Error ? err.message : t('image.errorGeneric')
+      const outcome = await resyncServerConversation(conversation.id, applyServerView)
+      if (outcome === 'missing') {
+        onChange((current) => ({ ...current, serverPersisted: false }))
+        patchEntry(entryId, { pending: false, error: messageText, responseDurationMs: Math.round(responseTimestamp() - startedAt) })
+      } else {
+        setSendError(messageText)
+      }
     }
   }
 
   const handleSubmit = async () => {
-    if (!apiKey || !model || !prompt.trim() || submitting) return
+    if (!apiKeyId || !model || !prompt.trim() || submitting) return
     const startedAt = responseTimestamp()
     const text = prompt.trim()
     const sourceFiles =
       files.length > 0
         ? files
-        : carrySource
+        : carrySource?.startsWith('data:')
           ? [dataURLToFile(carrySource, 'source.png')]
           : []
-    const sourceImages = await Promise.all(sourceFiles.map(fileToDataURL))
-    const mode = sourceFiles.length > 0 ? 'edit' : 'generation'
+    const sourceImages = sourceFiles.length > 0
+      ? await Promise.all(sourceFiles.map(fileToDataURL))
+      : carrySource ? [carrySource] : []
+    const mode = sourceImages.length > 0 ? 'edit' : 'generation'
     setPrompt('')
     setFiles([])
     await runEntry({
@@ -293,10 +416,10 @@ export function ImageView({
       requestModel: model,
       requestSize: size,
       mode,
-      sourceFiles,
       sourceImages,
       append: true,
       startedAt,
+      createdAt: Date.now(),
     })
   }
 
@@ -313,10 +436,8 @@ export function ImageView({
       }
     }
     const fallbackImages = previousImages.length > 0 ? previousImages : entry.images.map((image) => image.src)
-    const sourceImages = (entry.sourceImages?.length ? entry.sourceImages : fallbackImages)
-      .filter((source) => source.startsWith('data:'))
-    const sourceFiles = sourceImages.map((source, index) => dataURLToFile(source, `source-${index + 1}.png`))
-    const mode = entry.mode === 'edit' && sourceFiles.length > 0 ? 'edit' : 'generation'
+    const sourceImages = entry.sourceImages?.length ? entry.sourceImages : fallbackImages
+    const mode = entry.mode === 'edit' && sourceImages.length > 0 ? 'edit' : 'generation'
     setEditingEntryId(null)
     await runEntry({
       entryId: entry.id,
@@ -324,24 +445,29 @@ export function ImageView({
       requestModel: entry.model,
       requestSize: entry.size ?? 'auto',
       mode,
-      sourceFiles,
       sourceImages,
       append: false,
       startedAt,
+      createdAt: entry.createdAt,
     })
   }
 
   const attachments =
-    files.length > 0 ? (
-      <div className="flex flex-wrap gap-2">
-        {files.map((file, index) => (
-          <ImageAttachment
-            key={`${file.name}-${index}`}
-            file={file}
-            removeLabel={t('image.removeFile')}
-            onRemove={() => setFiles((current) => current.filter((_, i) => i !== index))}
-          />
-        ))}
+    files.length > 0 || sendError ? (
+      <div className="space-y-2">
+        {files.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {files.map((file, index) => (
+              <ImageAttachment
+                key={`${file.name}-${index}`}
+                file={file}
+                removeLabel={t('image.removeFile')}
+                onRemove={() => setFiles((current) => current.filter((_, i) => i !== index))}
+              />
+            ))}
+          </div>
+        ) : null}
+        {sendError ? <p className="px-1 text-xs text-red-500">{sendError}</p> : null}
       </div>
     ) : null
 
@@ -386,7 +512,7 @@ export function ImageView({
           parameterValue={size}
           parameterOptions={sizeOptions}
           onParameterChange={setSize}
-          disabled={!apiKey}
+          disabled={!apiKeyId}
         />
       </div>
       <div className="min-w-0 md:hidden">
@@ -413,7 +539,14 @@ export function ImageView({
       value={prompt}
       onChange={setPrompt}
       onSubmit={() => void handleSubmit()}
-      onStop={() => abortRef.current?.abort()}
+      onStop={() => {
+        const runId = conversation.activeRun?.id
+        if (runId && runActive) {
+          void cancelServerRun(runId)
+        } else if (starting) {
+          setStopRequested(true)
+        }
+      }}
       streaming={submitting}
       canSubmit={canSubmit}
       placeholder={t('image.promptPlaceholder')}

--- a/web/src/features/playground/components/playground-workspace.tsx
+++ b/web/src/features/playground/components/playground-workspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { SquarePen } from 'lucide-react'
@@ -12,9 +12,10 @@ import { EmptyState } from '@/components/common/empty-state'
 import { APIError } from '@/lib/http'
 import {
   downstreamAPIKeyQueryKeys,
+  deleteServerConversation,
   listDownstreamAPIKeys,
-  listGatewayModels,
-  revealDownstreamAPIKey,
+  listPlaygroundModels,
+  listServerConversations,
 } from '@/features/playground/api/playground'
 import { sortAPIKeysForDisplay } from '@/features/api-keys/lib/api-key-utils'
 import { PlaygroundRail } from '@/features/playground/components/playground-rail'
@@ -74,6 +75,7 @@ export function PlaygroundWorkspace() {
   ])
   const [activeImageId, setActiveImageId] = useState<string>(() => imageConversations[0]?.id ?? '')
   const imageLoadedRef = useRef(false)
+  const serverMergedRef = useRef(false)
   const conversationsRef = useRef(conversations)
 
   useEffect(() => saveSettings(settings), [settings])
@@ -102,8 +104,10 @@ export function PlaygroundWorkspace() {
       if (cancelled) return
       imageLoadedRef.current = true
       if (stored.length > 0) {
-        setImageConversations(stored)
-        setActiveImageId(stored[0].id)
+        setImageConversations((current) => {
+          const storedIds = new Set(stored.map((item) => item.id))
+          return [...current.filter((item) => item.serverPersisted && !storedIds.has(item.id)), ...stored]
+        })
       }
     })
     return () => {
@@ -132,22 +136,61 @@ export function PlaygroundWorkspace() {
     return apiKeys[0]?.id ?? null
   }, [apiKeys, settings.apiKeyId])
 
-  const revealQuery = useQuery({
-    queryKey: ['playground', 'reveal', effectiveApiKeyId],
-    queryFn: () => revealDownstreamAPIKey(effectiveApiKeyId as string),
-    enabled: Boolean(effectiveApiKeyId),
-    staleTime: Infinity,
-    retry: false,
-  })
-  const plaintextKey = revealQuery.data?.key ?? null
-
   const modelsQuery = useQuery({
     queryKey: ['playground', 'models', effectiveApiKeyId],
-    queryFn: () => listGatewayModels(plaintextKey as string),
-    enabled: Boolean(plaintextKey),
+    queryFn: () => listPlaygroundModels(effectiveApiKeyId as string),
+    enabled: Boolean(effectiveApiKeyId),
     staleTime: 5 * 60 * 1000,
     retry: false,
   })
+  const serverConversationsQuery = useQuery({
+    queryKey: ['playground', 'conversations'],
+    queryFn: () => listServerConversations(),
+    staleTime: 30 * 1000,
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (!serverConversationsQuery.data) return
+    let cancelled = false
+    const items = serverConversationsQuery.data
+    const exhaustive = items.length < 50
+    queueMicrotask(() => {
+      if (cancelled) return
+      const chatItems = items.flatMap((item) => item.chat ? [{
+        ...item.chat,
+        serverPersisted: true,
+        lastOrdinal: item.last_ordinal,
+        activeRun: item.run,
+      }] : [])
+      const imageItems = items.flatMap((item) => item.image ? [{
+        ...item.image,
+        serverPersisted: true,
+        lastOrdinal: item.last_ordinal,
+        activeRun: item.run,
+      }] : [])
+      setConversations((current) => {
+        const serverIds = new Set(chatItems.map((item) => item.id))
+        return [...chatItems, ...current.filter((item) =>
+          !serverIds.has(item.id) && !(exhaustive && item.serverPersisted),
+        )]
+      })
+      setImageConversations((current) => {
+        const serverIds = new Set(imageItems.map((item) => item.id))
+        return [...imageItems, ...current.filter((item) =>
+          !serverIds.has(item.id) && !(exhaustive && item.serverPersisted),
+        )]
+      })
+      if (!serverMergedRef.current) {
+        if (chatItems.length > 0) setActiveId(chatItems[0].id)
+        if (imageItems.length > 0) setActiveImageId(imageItems[0].id)
+        serverMergedRef.current = true
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [serverConversationsQuery.data])
   const models = useMemo(() => modelsQuery.data ?? [], [modelsQuery.data])
   const chatModels = useMemo(() => models.filter((model) => isChatModel(model.category)), [models])
   const imageModels = useMemo(() => models.filter((model) => model.category === 'image'), [models])
@@ -176,10 +219,10 @@ export function PlaygroundWorkspace() {
   )
 
   const modelsError = useMemo(() => {
-    const error = revealQuery.error ?? modelsQuery.error
+    const error = modelsQuery.error ?? serverConversationsQuery.error
     if (!error) return null
     return error instanceof APIError || error instanceof Error ? error.message : String(error)
-  }, [revealQuery.error, modelsQuery.error])
+  }, [modelsQuery.error, serverConversationsQuery.error])
 
   const setApiKeyId = (id: string) => {
     setSettings((current) => ({
@@ -190,21 +233,21 @@ export function PlaygroundWorkspace() {
     }))
   }
 
-  const updateActiveConversation = (updater: (conversation: Conversation) => Conversation) => {
+  const updateActiveConversation = useCallback((updater: (conversation: Conversation) => Conversation) => {
     setConversations((current) =>
       current.map((conversation) =>
         conversation.id === activeConversation?.id ? updater(conversation) : conversation,
       ),
     )
-  }
+  }, [activeConversation?.id])
 
-  const updateActiveImageConversation = (updater: (conversation: ImageConversation) => ImageConversation) => {
+  const updateActiveImageConversation = useCallback((updater: (conversation: ImageConversation) => ImageConversation) => {
     setImageConversations((current) =>
       current.map((conversation) =>
         conversation.id === activeImageConversation?.id ? updater(conversation) : conversation,
       ),
     )
-  }
+  }, [activeImageConversation?.id])
 
   const handleNewConversation = () => {
     if (activeConversation && activeConversation.messages.length === 0) {
@@ -217,6 +260,8 @@ export function PlaygroundWorkspace() {
   }
 
   const handleDeleteConversation = (id: string) => {
+    const target = conversations.find((conversation) => conversation.id === id)
+    if (target?.serverPersisted) void deleteServerConversation(id).catch(() => {})
     setConversations((current) => {
       const next = current.filter((conversation) => conversation.id !== id)
       if (next.length === 0) {
@@ -240,6 +285,8 @@ export function PlaygroundWorkspace() {
   }
 
   const handleDeleteImageConversation = (id: string) => {
+    const target = imageConversations.find((conversation) => conversation.id === id)
+    if (target?.serverPersisted) void deleteServerConversation(id).catch(() => {})
     setImageConversations((current) => {
       const next = current.filter((conversation) => conversation.id !== id)
       if (next.length === 0) {
@@ -341,7 +388,6 @@ export function PlaygroundWorkspace() {
             {isChat ? (
               activeConversation ? (
                 <ChatView
-                  apiKey={plaintextKey}
                   apiKeys={apiKeys}
                   apiKeyId={effectiveApiKeyId}
                   onAPIKeyChange={setApiKeyId}
@@ -358,7 +404,6 @@ export function PlaygroundWorkspace() {
             ) : activeImageConversation ? (
               <ImageView
                 key={activeImageConversation.id}
-                apiKey={plaintextKey}
                 apiKeys={apiKeys}
                 apiKeyId={effectiveApiKeyId}
                 onAPIKeyChange={setApiKeyId}

--- a/web/src/features/playground/lib/attachment-store.ts
+++ b/web/src/features/playground/lib/attachment-store.ts
@@ -77,7 +77,7 @@ export async function hydrateChatAttachmentsAsync(items: Conversation[]): Promis
 export async function pruneChatAttachmentDataAsync(items: Conversation[]): Promise<void> {
   const activeIDs = new Set(
     items.flatMap((conversation) =>
-      conversation.messages.flatMap((message) => message.attachments?.map((attachment) => attachment.id) ?? []),
+      conversation.messages.flatMap((message) => message.attachments?.filter((attachment) => !attachment.assetId).map((attachment) => attachment.id) ?? []),
     ),
   )
   await updateAttachmentData((data) => (

--- a/web/src/features/playground/lib/storage.ts
+++ b/web/src/features/playground/lib/storage.ts
@@ -45,6 +45,8 @@ export function saveConversations(items: Conversation[]) {
         name: attachment.name,
         mimeType: attachment.mimeType,
         size: attachment.size,
+        assetId: attachment.assetId,
+        src: attachment.src,
       })),
     })),
   })))

--- a/web/src/features/playground/lib/types.ts
+++ b/web/src/features/playground/lib/types.ts
@@ -6,6 +6,8 @@ export type ChatAttachment = {
   mimeType: string
   size: number
   dataURL?: string
+  assetId?: string
+  src?: string
 }
 
 export type ChatMessage = {
@@ -36,6 +38,9 @@ export type Conversation = {
   messages: ChatMessage[]
   createdAt: number
   updatedAt: number
+  serverPersisted?: boolean
+  lastOrdinal?: number
+  activeRun?: PlaygroundRun
 }
 
 export type GatewayModel = {
@@ -54,6 +59,7 @@ export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ult
 export type ImageResultItem = {
   id: string
   src: string
+  assetId?: string
 }
 
 export type ImageHistoryEntry = {
@@ -63,6 +69,7 @@ export type ImageHistoryEntry = {
   prompt: string
   size?: string
   sourceImages?: string[]
+  sourceAssetIds?: string[]
   images: ImageResultItem[]
   siteName?: string
   responseDurationMs?: number
@@ -77,6 +84,17 @@ export type ImageConversation = {
   entries: ImageHistoryEntry[]
   createdAt: number
   updatedAt: number
+  serverPersisted?: boolean
+  lastOrdinal?: number
+  activeRun?: PlaygroundRun
+}
+
+export type PlaygroundRun = {
+  id: string
+  status: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled' | 'interrupted' | string
+  error?: string
+  created_at: number
+  completed_at?: number
 }
 
 export type PlaygroundMode = 'chat' | 'image'


### PR DESCRIPTION
## 背景

模型体验此前以浏览器本地存储作为唯一数据源，导致以下限制：

- 同一管理员切换浏览器或设备后无法查看既有记录
- 页面刷新、关闭或重新打开时，正在生成的回复无法从服务端事件位置继续跟进
- 生图结果依赖上游 URL 或浏览器内 Base64，缺少项目侧稳定文件副本
- 浏览器需要直接持有并使用下游 API Key 请求网关

本 PR 将服务端设为已持久化会话的权威数据源，同时保留旧浏览器记录的延迟迁移兼容策略。

## 用户可见行为

| 场景 | 行为 |
|---|---|
| 新建 Chat 会话 | 第一次发送消息即创建服务端会话，并持续写入用户消息、推理增量、回复增量和最终结果 |
| 新建图片会话 | 第一次文生图或图生图即创建服务端会话；提示词、参数、输入图和输出图均持久化 |
| 同一管理员切换浏览器 | 页面加载时从服务端恢复 Chat 与图片会话 |
| 页面刷新或重新打开 | 读取最后事件序号；任务仍运行时从该序号继续接收 SSE 事件 |
| 服务进程重启 | 保留已写入历史，并把尚未结束的任务标记为 `interrupted`，不会伪装成已完成 |
| 旧浏览器本地记录 | 仅打开旧记录不会上传；用户继续发送消息或生成图片时，先全量导入一次再追加新任务 |
| 删除已持久化会话 | 删除数据库索引、JSONL、附件及图片资源；并处理正在运行任务的取消与收尾 |

## 架构与数据流

```mermaid
flowchart LR
    Browser[Playground 页面] -->|管理员会话 + API Key ID| API[Playground API]
    API --> Service[Playground Service]
    Service --> Gateway[Gateway 路由与上游调用]
    Service --> Rollout[JSONL Rollout]
    Service --> Files[图片与附件文件]
    Service --> DB[(PostgreSQL 索引与运行状态)]
    Gateway --> Service
    Service -->|SSE: ordinal 增量| Browser
```

前端不再揭示明文 API Key 或直接调用 Playground 网关。后端根据管理员选择的 API Key ID 读取凭据，并复用现有网关路由、站点选择和协议转换逻辑。

## 持久化职责

| 载体 | 保存内容 | 不保存内容 |
|---|---|---|
| JSONL | 会话快照、追加消息、图片条目、流式增量、最终结果、失败/取消/中断事件 | 图片二进制 |
| PostgreSQL | 管理员归属、会话标题与模式、JSONL 相对路径、事件游标、运行状态、幂等键、轮次索引、资源相对路径与摘要 | 完整会话正文、图片二进制 |
| 文件系统 | 生成图、输入参考图、聊天附件 | 会话索引与权限关系 |

目录布局：

```text
<WORKDIR>/playground/
├── sessions/YYYY/MM/DD/rollout-<timestamp>-<conversation-id>.jsonl
├── assets/<conversation-id>/generated-images/<asset-id>.<ext>
├── assets/<conversation-id>/input-images/<asset-id>.<ext>
├── assets/<conversation-id>/attachments/<asset-id>.<ext>
└── thread-writer-locks/
```

JSONL 采用仅追加事件模型，主要事件包括：

- `session_meta`
- `conversation_snapshot` / `branch_reset`
- `message_added` / `image_entry_added`
- `turn_started`
- `assistant_delta` / `assistant_final` / `image_final`
- `turn_completed` / `turn_failed` / `turn_cancelled` / `turn_interrupted`

## 图片与附件处理

- 上游返回 Base64：后端解码后写入对应图片格式文件
- 上游返回 URL：后端立即下载并保存本地副本，不把远程 URL 作为最终持久化结果
- 数据库仅记录相对路径、MIME、大小和 SHA-256
- 图生图输入、历史生成图和聊天附件统一转换为受管理员权限保护的资源地址
- 多图响应部分落盘后若后续图片失败，会清理已保存的部分结果，避免孤立资源
- 文件通过临时文件写入、`fsync` 和原子重命名发布

远程图片下载额外限制：

- 仅允许 HTTP/HTTPS
- 拒绝回环、私网、链路本地和未指定地址，包含重定向后的再次校验
- 最多 5 次重定向、45 秒超时、单文件最大 25 MiB
- 校验响应为图片 MIME

## 一致性与恢复

- 每个会话使用进程内互斥锁和文件写锁，避免并发写坏 JSONL
- 每次追加后执行 `fsync`，数据库游标仅在文件写入成功后更新
- 下次追加前自动裁掉崩溃留下的不完整尾行
- 事件序号与字节偏移支持刷新后从断点继续读取
- `(conversation_id, idempotency_key)` 唯一索引避免重复创建任务
- 同一会话同时只允许一个活动任务，并处理“开始请求尚未返回时点击停止”的竞态
- 删除活动会话前等待任务取消收尾，避免后台任务重新创建已删除文件
- 服务启动时将残留的 `queued` / `running` 任务收敛为 `interrupted`

## 权限与安全边界

- 所有会话查询、读取和删除均按当前管理员 ID 限定
- 资源读取先通过资源所属会话验证管理员权限
- 浏览器只提交 API Key ID，不再获取或持有明文 Key
- 资源响应设置私有缓存、`nosniff` 和沙箱 CSP；非图片资源强制下载
- 新增数据库访问全部使用 GORM 模型、条件、事务和 clause API，没有新增手写 SQL

## 新增管理端接口

| 方法 | 路径 | 用途 |
|---|---|---|
| `GET` | `/api/v1/playground/models` | 使用选定 API Key 获取可用模型 |
| `GET` | `/api/v1/playground/conversations` | 获取当前管理员最近的服务端会话 |
| `GET` | `/api/v1/playground/conversations/{id}` | 重建单个会话视图 |
| `POST` | `/api/v1/playground/conversations/{id}/turns` | 启动 Chat、文生图或图生图任务 |
| `GET` | `/api/v1/playground/conversations/{id}/events` | 按事件序号持续接收增量与运行状态 |
| `DELETE` | `/api/v1/playground/conversations/{id}` | 删除会话及其资源 |
| `POST` | `/api/v1/playground/runs/{id}/cancel` | 取消活动任务 |
| `GET` | `/api/v1/playground/assets/{id}` | 按管理员权限读取图片或附件 |

## 数据库变更

新增 ORM 模型及索引：

- `playground_conversations`
- `playground_runs`
- `playground_turn_indexes`
- `playground_assets`

Schema 通过现有 GORM migrator 启动流程维护，并显式补齐管理员列表、运行幂等、时间排序和资源关联索引。

## 兼容性与范围

- 保留浏览器本地记录读取，不在用户打开页面时主动上传历史数据
- 旧记录仅在用户继续操作时执行一次全量导入，符合延迟迁移要求
- 已进入服务端的记录以后以服务端为准，本地存储只承担兼容和前端缓存角色
- 列表目前返回每个管理员最近 50 个会话；达到上限时不会把本地较旧记录误判为远端已删除
- 自动备份、导出与恢复不在本 PR 范围，作为后续阶段处理

## 验证

本地已通过：

- `cd server && go test ./...`
- `cd server && go test -race ./internal/playground`
- `cd server && govulncheck ./...`
- `cd web && npm run typecheck`
- `cd web && npm run lint`
- `cd web && npm test -- --run`（23 个测试文件、139 项测试）
- `cd web && npm run build`

另已验证：

- Chat JSONL 序号连续，流式 delta 可完整拼回 final
- 文生图结果实际落盘，页面资源地址指向受保护的服务端 Asset API
- worktree 开发数据已归并至统一 `<WORKDIR>/playground` 路径

## 建议审查顺序

1. `server/internal/playground/types.go`：请求、事件和视图结构
2. `server/internal/playground/rollout.go`：JSONL 追加、修复与回放
3. `server/internal/playground/assets.go`：文件落盘与远程下载安全
4. `server/internal/playground/service.go`：会话、幂等、并发与兼容导入
5. `server/internal/playground/runner.go`：Chat/图片上游执行与事件写入
6. `server/internal/store/playground_repository.go`：ORM 索引与状态存取
7. `web/src/features/playground/`：服务端列表合并、SSE 跟随和错误恢复
