### PR TITLE
fix: 🐛 修复站点与 API 密钥提交阻塞并完善后台同步体验

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -148,6 +148,13 @@ func run() int {
 		backgroundTasks.Wait()
 	}()
 
+	siteSyncWorker := site.NewSyncWorker(siteService, logger.With("thread", "site-sync-worker"), gatewayHandler.InvalidateModelsCache)
+	backgroundTasks.Add(1)
+	go func() {
+		defer backgroundTasks.Done()
+		siteSyncWorker.Run(backgroundCtx)
+	}()
+
 	backgroundTasks.Add(1)
 	go func() {
 		defer backgroundTasks.Done()

--- a/server/internal/admin/handler_sites.go
+++ b/server/internal/admin/handler_sites.go
@@ -126,6 +126,7 @@ func (h Handler) CreateSite(w http.ResponseWriter, r *http.Request) {
 		ProxyID:         payload.ProxyID,
 		RequestHeaders:  requestHeadersFromInput(payload.RequestHeaders),
 		Credentials:     credentials,
+		QueueSync:       true,
 	})
 	if err != nil {
 		h.writeError(w, r, http.StatusBadRequest, "site_create_failed", err.Error())
@@ -133,9 +134,11 @@ func (h Handler) CreateSite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logInfo("site created", "site_id", created.ID, "slug", created.Slug, "site_type", created.SiteType, "enabled", created.Enabled)
-	response := h.siteSetupResponse(r, created)
 	h.invalidateGatewayModelsCache()
-	h.writePayload(w, http.StatusCreated, response)
+	h.writePayload(w, http.StatusAccepted, map[string]any{
+		"ok":   true,
+		"site": h.sitePayloadWithStats(r, created),
+	})
 }
 
 func (h Handler) UpdateSite(w http.ResponseWriter, r *http.Request) {
@@ -859,19 +862,11 @@ func (h Handler) CreateSiteAPIKey(w http.ResponseWriter, r *http.Request) {
 		RoutingPriority:        payload.RoutingPriority,
 		UpstreamCostMultiplier: payload.UpstreamCostMultiplier,
 		CacheDomain:            payload.CacheDomain,
+		QueueSync:              true,
 	})
 	if err != nil {
 		h.writeError(w, r, http.StatusBadRequest, "site_api_key_create_failed", err.Error())
 		return
-	}
-
-	// Fetch and bind the new key's models immediately so it is routable (and its
-	// models are testable) without waiting for a manual or scheduled refresh.
-	// Best-effort: a refresh failure must not fail key creation.
-	if _, refreshErr := h.sites.RefreshSingleAPIKey(r.Context(), siteID, apiKey.Credential.ID); refreshErr != nil {
-		h.logWarn("site api key initial refresh failed", "site_id", siteID, "credential_id", apiKey.Credential.ID, "error", refreshErr)
-	} else if refreshed, err := h.sites.APIKeyByCredentialID(r.Context(), siteID, apiKey.Credential.ID); err == nil {
-		apiKey = refreshed
 	}
 
 	apiKeyStates, _ := h.sites.APIKeyStates(r.Context(), siteID)
@@ -890,7 +885,7 @@ func (h Handler) CreateSiteAPIKey(w http.ResponseWriter, r *http.Request) {
 		"cache_domain":             apiKey.CacheDomain,
 		"enabled":                  apiKey.Enabled,
 	})
-	h.writeResource(w, http.StatusCreated, "api_key", h.siteAPIKeyPayloadFromState(item, apiKey, statesByCredentialID[apiKey.Credential.ID], models, h.siteAPIKeyDefaultName(r.Context(), siteID, apiKey.Credential.ID)))
+	h.writeResource(w, http.StatusAccepted, "api_key", h.siteAPIKeyPayloadFromState(item, apiKey, statesByCredentialID[apiKey.Credential.ID], models, h.siteAPIKeyDefaultName(r.Context(), siteID, apiKey.Credential.ID)))
 }
 
 func (h Handler) DeleteSiteAPIKey(w http.ResponseWriter, r *http.Request) {
@@ -1143,7 +1138,7 @@ func (h Handler) UpdateSiteAPIKeySecret(w http.ResponseWriter, r *http.Request) 
 	h.recordAudit(r, currentAdminActor(r), "site_api_key.secret_update", "site_api_key", apiKeyID.String(), true, "", map[string]any{
 		"site_id": siteID.String(),
 	})
-	h.writeResource(w, http.StatusOK, "api_key", h.siteAPIKeyPayloadFromState(item, apiKey, statesByCredentialID[apiKey.Credential.ID], models, h.siteAPIKeyDefaultName(r.Context(), siteID, apiKey.Credential.ID)))
+	h.writeResource(w, http.StatusAccepted, "api_key", h.siteAPIKeyPayloadFromState(item, apiKey, statesByCredentialID[apiKey.Credential.ID], models, h.siteAPIKeyDefaultName(r.Context(), siteID, apiKey.Credential.ID)))
 }
 
 func (h Handler) UpdateSiteAPIKeyModel(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/site/service.go
+++ b/server/internal/site/service.go
@@ -56,6 +56,7 @@ type CreateSiteParams struct {
 	RequestHeaders  map[string]string
 	Credential      *CredentialInput
 	Credentials     []CredentialInput
+	QueueSync       bool
 }
 
 type UpdateSiteParams struct {
@@ -516,10 +517,6 @@ func (s *Service) Create(ctx context.Context, params CreateSiteParams) (store.Si
 		}
 
 		created = site
-		if len(credentials) == 0 {
-			return nil
-		}
-
 		for index, input := range credentials {
 			credential, err := s.saveCredentialInput(ctx, credentialRepo, site.ID, input)
 			if err != nil {
@@ -537,6 +534,20 @@ func (s *Service) Create(ctx context.Context, params CreateSiteParams) (store.Si
 			}
 			if index == 0 {
 				savedCredential = &credential
+			}
+		}
+		if params.QueueSync {
+			if _, err := store.NewSiteStateRepository(tx).Upsert(ctx, store.UpsertSiteStateParams{
+				SiteID:     site.ID,
+				SyncStatus: "pending",
+			}); err != nil {
+				return err
+			}
+			if _, err := store.NewSiteSyncJobRepository(tx).Enqueue(ctx, store.EnqueueSiteSyncJobParams{
+				Kind:   store.SiteSyncJobKindSiteRefresh,
+				SiteID: site.ID,
+			}); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -855,6 +866,7 @@ type CreateAPIKeyInput struct {
 	RoutingPriority        *float64
 	UpstreamCostMultiplier *float64
 	CacheDomain            string
+	QueueSync              bool
 }
 
 type UpdateAPIKeyInput struct {
@@ -942,6 +954,20 @@ func (s *Service) CreateAPIKey(ctx context.Context, siteID uuid.UUID, input Crea
 			return err
 		}
 		created = credential
+		if input.QueueSync {
+			enabled := credentialEnabledFromMeta(credential.Meta)
+			if _, err := store.NewSiteAPIKeyStateRepository(tx).MarkSyncPending(ctx, siteID, credential.ID, enabled); err != nil {
+				return err
+			}
+			credentialID := credential.ID
+			if _, err := store.NewSiteSyncJobRepository(tx).Enqueue(ctx, store.EnqueueSiteSyncJobParams{
+				Kind:             store.SiteSyncJobKindAPIKeyRefresh,
+				SiteID:           siteID,
+				SiteCredentialID: &credentialID,
+			}); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -1918,10 +1944,28 @@ func (s *Service) SetAPIKeySecret(ctx context.Context, siteID uuid.UUID, credent
 	meta["manually_completed"] = true
 	delete(meta, "upstream_masked_key")
 
-	updated, err := s.saveCredentialInput(ctx, store.NewSiteCredentialRepository(s.db.DB()), siteID, CredentialInput{
-		Type:   credential.CredentialType,
-		Secret: secret,
-		Meta:   meta,
+	var updated store.SiteCredential
+	err = s.db.WithinTx(ctx, func(tx store.Tx) error {
+		saved, err := s.saveCredentialInput(ctx, store.NewSiteCredentialRepository(tx), siteID, CredentialInput{
+			Type:   credential.CredentialType,
+			Secret: secret,
+			Meta:   meta,
+		})
+		if err != nil {
+			return err
+		}
+		updated = saved
+		enabled := credentialEnabledFromMeta(saved.Meta)
+		if _, err := store.NewSiteAPIKeyStateRepository(tx).MarkSyncPending(ctx, siteID, saved.ID, enabled); err != nil {
+			return err
+		}
+		queuedCredentialID := saved.ID
+		_, err = store.NewSiteSyncJobRepository(tx).Enqueue(ctx, store.EnqueueSiteSyncJobParams{
+			Kind:             store.SiteSyncJobKindAPIKeyRefresh,
+			SiteID:           siteID,
+			SiteCredentialID: &queuedCredentialID,
+		})
+		return err
 	})
 	if err != nil {
 		return APIKeyCredential{}, err

--- a/server/internal/site/sync_worker.go
+++ b/server/internal/site/sync_worker.go
@@ -1,0 +1,221 @@
+package site
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"xlyra/server/internal/store"
+)
+
+const (
+	siteSyncWorkerPollInterval   = 500 * time.Millisecond
+	siteSyncWorkerConcurrency    = 3
+	siteSyncJobTimeout           = 10 * time.Minute
+	siteSyncJobStaleAfter        = 15 * time.Minute
+	siteSyncMaintenanceInterval  = 5 * time.Minute
+	siteSyncFinishedJobRetention = 7 * 24 * time.Hour
+)
+
+type SyncWorker struct {
+	service      *Service
+	logger       *slog.Logger
+	invalidate   func()
+	pollInterval time.Duration
+}
+
+func NewSyncWorker(service *Service, logger *slog.Logger, invalidate func()) *SyncWorker {
+	return &SyncWorker{
+		service:      service,
+		logger:       logger,
+		invalidate:   invalidate,
+		pollInterval: siteSyncWorkerPollInterval,
+	}
+}
+
+func (w *SyncWorker) Run(ctx context.Context) {
+	if w == nil || w.service == nil || w.service.db == nil {
+		return
+	}
+	if w.logger == nil {
+		w.logger = slog.Default()
+	}
+	w.runMaintenance(ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < siteSyncWorkerConcurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.supervise(ctx, "job", w.runJobLoop)
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.supervise(ctx, "maintenance", w.runMaintenanceLoop)
+	}()
+	wg.Wait()
+}
+
+func (w *SyncWorker) supervise(ctx context.Context, name string, fn func(context.Context)) {
+	for ctx.Err() == nil {
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					w.logger.Error("site sync worker loop panicked; restarting", "loop", name, "panic", recovered)
+				}
+			}()
+			fn(ctx)
+		}()
+	}
+}
+
+func (w *SyncWorker) runJobLoop(ctx context.Context) {
+	for {
+		processed, err := w.processNext(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			w.logger.Error("site sync worker failed", "error", err)
+		}
+		if processed {
+			continue
+		}
+		timer := time.NewTimer(w.pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (w *SyncWorker) runMaintenanceLoop(ctx context.Context) {
+	ticker := time.NewTicker(siteSyncMaintenanceInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.runMaintenance(ctx)
+		}
+	}
+}
+
+func (w *SyncWorker) runMaintenance(ctx context.Context) {
+	repo := store.NewSiteSyncJobRepository(w.service.db.DB())
+	if err := repo.RequeueStale(ctx, time.Now().Add(-siteSyncJobStaleAfter)); err != nil {
+		w.logger.Error("site sync worker stale job recovery failed", "error", err)
+	}
+	if err := repo.PurgeFinished(ctx, time.Now().Add(-siteSyncFinishedJobRetention)); err != nil {
+		w.logger.Error("site sync worker finished job purge failed", "error", err)
+	}
+}
+
+func (w *SyncWorker) processNext(ctx context.Context) (bool, error) {
+	repo := store.NewSiteSyncJobRepository(w.service.db.DB())
+	job, ok, err := repo.ClaimNext(ctx, time.Now())
+	if err != nil || !ok {
+		return ok, err
+	}
+
+	jobCtx, cancel := context.WithTimeout(ctx, siteSyncJobTimeout)
+	defer cancel()
+	runErr := w.executeJob(ctx, jobCtx, job)
+	status := store.SiteSyncJobStatusSucceeded
+	message := ""
+	if runErr != nil {
+		status = store.SiteSyncJobStatusFailed
+		message = runErr.Error()
+	}
+	if err := repo.Finish(ctx, job.ID, status, message, time.Now()); err != nil {
+		return true, err
+	}
+	if w.invalidate != nil {
+		w.invalidate()
+	}
+	if runErr != nil {
+		w.logger.Warn("site sync job failed", "job_id", job.ID, "kind", job.Kind, "site_id", job.SiteID, "error", runErr)
+	} else {
+		w.logger.Info("site sync job completed", "job_id", job.ID, "kind", job.Kind, "site_id", job.SiteID)
+	}
+	return true, nil
+}
+
+func (w *SyncWorker) executeJob(workerCtx context.Context, jobCtx context.Context, job store.SiteSyncJob) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("site sync job panicked: %v", recovered)
+		}
+		if err != nil {
+			w.markStateFailedBestEffort(workerCtx, job, err)
+		}
+	}()
+	return w.runJob(jobCtx, job)
+}
+
+func (w *SyncWorker) markStateFailedBestEffort(ctx context.Context, job store.SiteSyncJob, jobErr error) {
+	switch job.Kind {
+	case store.SiteSyncJobKindSiteRefresh:
+		stateRepo := store.NewSiteStateRepository(w.service.db.DB())
+		state, err := stateRepo.GetBySite(ctx, job.SiteID)
+		if err != nil || (state.SyncStatus != "pending" && state.SyncStatus != "syncing") {
+			return
+		}
+		if _, err := stateRepo.MarkSyncFailed(ctx, job.SiteID, jobErr.Error()); err != nil {
+			w.logger.Warn("record site sync failure failed", "job_id", job.ID, "site_id", job.SiteID, "error", err)
+		}
+	case store.SiteSyncJobKindAPIKeyRefresh:
+		if job.SiteCredentialID == nil {
+			return
+		}
+		credential, err := store.NewSiteCredentialRepository(w.service.db.DB()).GetByID(ctx, *job.SiteCredentialID)
+		if err != nil {
+			return
+		}
+		enabled := credentialEnabledFromMeta(credential.Meta)
+		if _, err := store.NewSiteAPIKeyStateRepository(w.service.db.DB()).MarkSyncFailed(ctx, job.SiteID, *job.SiteCredentialID, enabled, jobErr.Error()); err != nil {
+			w.logger.Warn("record api key sync failure failed", "job_id", job.ID, "site_id", job.SiteID, "credential_id", *job.SiteCredentialID, "error", err)
+		}
+	}
+}
+
+func (w *SyncWorker) runJob(ctx context.Context, job store.SiteSyncJob) error {
+	switch job.Kind {
+	case store.SiteSyncJobKindSiteRefresh:
+		_, err := w.service.RefreshState(ctx, job.SiteID)
+		return err
+	case store.SiteSyncJobKindAPIKeyRefresh:
+		if job.SiteCredentialID == nil {
+			return fmt.Errorf("site credential id is required")
+		}
+		credential, err := store.NewSiteCredentialRepository(w.service.db.DB()).GetByID(ctx, *job.SiteCredentialID)
+		if err != nil {
+			return fmt.Errorf("get credential: %w", err)
+		}
+		enabled := credentialEnabledFromMeta(credential.Meta)
+		if _, err := store.NewSiteAPIKeyStateRepository(w.service.db.DB()).MarkSyncStarted(ctx, job.SiteID, *job.SiteCredentialID, enabled); err != nil {
+			return err
+		}
+		result, err := w.service.RefreshSingleAPIKey(ctx, job.SiteID, *job.SiteCredentialID)
+		if err != nil {
+			return fmt.Errorf("refresh api key: %w", err)
+		}
+		if strings.EqualFold(strings.TrimSpace(result.State.SyncStatus), "failed") {
+			if result.State.SyncMessage.Valid && strings.TrimSpace(result.State.SyncMessage.String) != "" {
+				return fmt.Errorf("%s", result.State.SyncMessage.String)
+			}
+			return fmt.Errorf("api key refresh failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported site sync job kind %q", job.Kind)
+	}
+}

--- a/server/internal/store/bootstrap.go
+++ b/server/internal/store/bootstrap.go
@@ -148,6 +148,16 @@ func ensureSchemaUpgrades(ctx context.Context, db *gorm.DB) error {
 			return fmt.Errorf("ensure request_usage_hourly_summaries table: %w", err)
 		}
 	}
+	if !migrator.HasTable(&SiteSyncJob{}) {
+		if err := migrator.CreateTable(&SiteSyncJob{}); err != nil {
+			return fmt.Errorf("ensure site_sync_jobs table: %w", err)
+		}
+	}
+	if migrator.HasTable(&SiteSyncJob{}) && !migrator.HasColumn(&SiteSyncJob{}, "RerunRequested") {
+		if err := migrator.AddColumn(&SiteSyncJob{}, "RerunRequested"); err != nil {
+			return fmt.Errorf("ensure site_sync_jobs.rerun_requested column: %w", err)
+		}
+	}
 	for _, model := range []any{
 		&PlaygroundConversation{},
 		&PlaygroundRun{},

--- a/server/internal/store/orm.go
+++ b/server/internal/store/orm.go
@@ -125,6 +125,7 @@ func (SiteState) TableName() string           { return "site_states" }
 func (OAuthSession) TableName() string        { return "oauth_sessions" }
 func (OAuthConnection) TableName() string     { return "oauth_connections" }
 func (SiteAPIKeyState) TableName() string     { return "site_api_key_states" }
+func (SiteSyncJob) TableName() string         { return "site_sync_jobs" }
 func (SiteAPIKeyModel) TableName() string     { return "site_api_key_models" }
 func (CanonicalModel) TableName() string      { return "canonical_models" }
 func (CanonicalModelAlias) TableName() string { return "canonical_model_aliases" }

--- a/server/internal/store/site_api_key_state_repository.go
+++ b/server/internal/store/site_api_key_state_repository.go
@@ -234,3 +234,43 @@ func (r SiteAPIKeyStateRepository) RecoverPending(ctx context.Context, siteCrede
 	}
 	return state, nil
 }
+
+func (r SiteAPIKeyStateRepository) MarkSyncPending(ctx context.Context, siteID uuid.UUID, siteCredentialID uuid.UUID, enabled bool) (SiteAPIKeyState, error) {
+	return r.markSyncStatus(ctx, siteID, siteCredentialID, enabled, "pending", "")
+}
+
+func (r SiteAPIKeyStateRepository) MarkSyncStarted(ctx context.Context, siteID uuid.UUID, siteCredentialID uuid.UUID, enabled bool) (SiteAPIKeyState, error) {
+	return r.markSyncStatus(ctx, siteID, siteCredentialID, enabled, "syncing", "")
+}
+
+func (r SiteAPIKeyStateRepository) MarkSyncFailed(ctx context.Context, siteID uuid.UUID, siteCredentialID uuid.UUID, enabled bool, message string) (SiteAPIKeyState, error) {
+	return r.markSyncStatus(ctx, siteID, siteCredentialID, enabled, "failed", message)
+}
+
+func (r SiteAPIKeyStateRepository) markSyncStatus(ctx context.Context, siteID uuid.UUID, siteCredentialID uuid.UUID, enabled bool, status string, message string) (SiteAPIKeyState, error) {
+	db := r.db.WithContext(ctx)
+	var state SiteAPIKeyState
+	err := db.Where(&SiteAPIKeyState{SiteCredentialID: siteCredentialID}).First(&state).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return SiteAPIKeyState{}, fmt.Errorf("mark site api key sync status: %w", err)
+	}
+	state.SiteCredentialID = siteCredentialID
+	state.SiteID = siteID
+	state.SyncStatus = status
+	state.SyncMessage = sql.NullString{String: message, Valid: message != ""}
+	if err == gorm.ErrRecordNotFound {
+		state.Enabled = enabled
+		state.UpstreamStatus = jsonDefault(nil, "null")
+		state.ModelLimits = jsonDefault(nil, "[]")
+		state.Usage = jsonDefault(nil, "{}")
+		state.Raw = jsonDefault(nil, "{}")
+		if err := db.Create(&state).Error; err != nil {
+			return SiteAPIKeyState{}, fmt.Errorf("mark site api key sync status: %w", err)
+		}
+		return state, nil
+	}
+	if err := db.Save(&state).Error; err != nil {
+		return SiteAPIKeyState{}, fmt.Errorf("mark site api key sync status: %w", err)
+	}
+	return state, nil
+}

--- a/server/internal/store/site_state_repository.go
+++ b/server/internal/store/site_state_repository.go
@@ -126,6 +126,20 @@ func (r SiteStateRepository) MarkSyncStarted(ctx context.Context, siteID uuid.UU
 	return state, nil
 }
 
+func (r SiteStateRepository) MarkSyncFailed(ctx context.Context, siteID uuid.UUID, message string) (SiteState, error) {
+	db := r.db.WithContext(ctx)
+	var state SiteState
+	if err := db.Where(&SiteState{SiteID: siteID}).First(&state).Error; err != nil {
+		return SiteState{}, fmt.Errorf("mark site sync failed: %w", err)
+	}
+	state.SyncStatus = "failed"
+	state.SyncMessage = sql.NullString{String: message, Valid: message != ""}
+	if err := db.Save(&state).Error; err != nil {
+		return SiteState{}, fmt.Errorf("mark site sync failed: %w", err)
+	}
+	return state, nil
+}
+
 func (r SiteStateRepository) MarkPricingGap(ctx context.Context, siteID uuid.UUID, message string) (SiteState, error) {
 	db := r.db.WithContext(ctx)
 	var state SiteState

--- a/server/internal/store/site_sync_job_repository.go
+++ b/server/internal/store/site_sync_job_repository.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	SiteSyncJobKindSiteRefresh   = "site_refresh"
+	SiteSyncJobKindAPIKeyRefresh = "api_key_refresh"
+	SiteSyncJobStatusQueued      = "queued"
+	SiteSyncJobStatusRunning     = "running"
+	SiteSyncJobStatusSucceeded   = "succeeded"
+	SiteSyncJobStatusFailed      = "failed"
+)
+
+type SiteSyncJob struct {
+	ID               uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	Kind             string
+	SiteID           uuid.UUID `gorm:"index:site_sync_jobs_site_id_idx"`
+	SiteCredentialID *uuid.UUID
+	Status           string  `gorm:"index:site_sync_jobs_status_created_idx,priority:1"`
+	ActiveKey        *string `gorm:"uniqueIndex:site_sync_jobs_active_key_idx"`
+	Attempts         int
+	RerunRequested   bool `gorm:"default:false"`
+	Error            sql.NullString
+	StartedAt        sql.NullTime
+	FinishedAt       sql.NullTime
+	CreatedAt        time.Time `gorm:"index:site_sync_jobs_status_created_idx,priority:2"`
+	UpdatedAt        time.Time
+	Site             Site            `gorm:"foreignKey:SiteID;references:ID;constraint:OnDelete:CASCADE"`
+	SiteCredential   *SiteCredential `gorm:"foreignKey:SiteCredentialID;references:ID;constraint:OnDelete:CASCADE"`
+}
+
+type EnqueueSiteSyncJobParams struct {
+	Kind             string
+	SiteID           uuid.UUID
+	SiteCredentialID *uuid.UUID
+}
+
+type SiteSyncJobRepository struct {
+	db *gorm.DB
+}
+
+func NewSiteSyncJobRepository(db *gorm.DB) SiteSyncJobRepository {
+	return SiteSyncJobRepository{db: db}
+}
+
+func (r SiteSyncJobRepository) Enqueue(ctx context.Context, params EnqueueSiteSyncJobParams) (SiteSyncJob, error) {
+	if params.SiteID == uuid.Nil {
+		return SiteSyncJob{}, fmt.Errorf("enqueue site sync job: site id is required")
+	}
+	if params.Kind != SiteSyncJobKindSiteRefresh && params.Kind != SiteSyncJobKindAPIKeyRefresh {
+		return SiteSyncJob{}, fmt.Errorf("enqueue site sync job: unsupported kind %q", params.Kind)
+	}
+	if params.Kind == SiteSyncJobKindAPIKeyRefresh && (params.SiteCredentialID == nil || *params.SiteCredentialID == uuid.Nil) {
+		return SiteSyncJob{}, fmt.Errorf("enqueue site sync job: site credential id is required")
+	}
+
+	activeKey := siteSyncJobActiveKey(params)
+	for attempt := 0; attempt < 3; attempt++ {
+		job := SiteSyncJob{
+			Kind:             params.Kind,
+			SiteID:           params.SiteID,
+			SiteCredentialID: params.SiteCredentialID,
+			Status:           SiteSyncJobStatusQueued,
+			ActiveKey:        &activeKey,
+		}
+		result := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "active_key"}},
+			DoNothing: true,
+		}).Create(&job)
+		if result.Error != nil {
+			return SiteSyncJob{}, fmt.Errorf("enqueue site sync job: %w", result.Error)
+		}
+		if result.RowsAffected > 0 {
+			return job, nil
+		}
+		result = r.db.WithContext(ctx).
+			Model(&SiteSyncJob{}).
+			Where(clause.And(
+				clause.Eq{Column: "active_key", Value: activeKey},
+				clause.Eq{Column: "status", Value: SiteSyncJobStatusRunning},
+			)).
+			Update("rerun_requested", true)
+		if result.Error != nil {
+			return SiteSyncJob{}, fmt.Errorf("request site sync job rerun: %w", result.Error)
+		}
+		var existing SiteSyncJob
+		err := r.db.WithContext(ctx).Where(&SiteSyncJob{ActiveKey: &activeKey}).First(&existing).Error
+		if err == nil {
+			return existing, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return SiteSyncJob{}, fmt.Errorf("get active site sync job: %w", err)
+		}
+	}
+	return SiteSyncJob{}, fmt.Errorf("enqueue site sync job: conflicting active job disappeared before it could be read")
+}
+
+func (r SiteSyncJobRepository) ClaimNext(ctx context.Context, now time.Time) (SiteSyncJob, bool, error) {
+	var claimed SiteSyncJob
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		query := tx.Clauses(
+			clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"},
+			clause.OrderBy{Columns: []clause.OrderByColumn{{Column: clause.Column{Name: "created_at"}}}},
+		).Where(&SiteSyncJob{Status: SiteSyncJobStatusQueued})
+		if err := query.First(&claimed).Error; err != nil {
+			return err
+		}
+		claimed.Status = SiteSyncJobStatusRunning
+		claimed.Attempts++
+		claimed.StartedAt = sql.NullTime{Time: now, Valid: true}
+		claimed.FinishedAt = sql.NullTime{}
+		claimed.Error = sql.NullString{}
+		if err := tx.Save(&claimed).Error; err != nil {
+			return fmt.Errorf("mark site sync job running: %w", err)
+		}
+		return nil
+	})
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return SiteSyncJob{}, false, nil
+	}
+	if err != nil {
+		return SiteSyncJob{}, false, fmt.Errorf("claim site sync job: %w", err)
+	}
+	return claimed, true, nil
+}
+
+func (r SiteSyncJobRepository) Finish(ctx context.Context, id uuid.UUID, status string, message string, now time.Time) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var job SiteSyncJob
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where(&SiteSyncJob{ID: id}).First(&job).Error; err != nil {
+			return fmt.Errorf("get site sync job to finish: %w", err)
+		}
+		applySiteSyncJobFinish(&job, status, message, now)
+		if err := tx.Save(&job).Error; err != nil {
+			return fmt.Errorf("finish site sync job: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r SiteSyncJobRepository) PurgeFinished(ctx context.Context, cutoff time.Time) error {
+	result := r.db.WithContext(ctx).
+		Where(map[string]any{"status": []string{SiteSyncJobStatusSucceeded, SiteSyncJobStatusFailed}}).
+		Where(clause.Lt{Column: "finished_at", Value: cutoff}).
+		Delete(&SiteSyncJob{})
+	if result.Error != nil {
+		return fmt.Errorf("purge finished site sync jobs: %w", result.Error)
+	}
+	return nil
+}
+
+func (r SiteSyncJobRepository) RequeueStale(ctx context.Context, cutoff time.Time) error {
+	result := r.db.WithContext(ctx).
+		Model(&SiteSyncJob{}).
+		Where(clause.And(
+			clause.Eq{Column: "status", Value: SiteSyncJobStatusRunning},
+			clause.Lt{Column: "started_at", Value: cutoff},
+		)).
+		Updates(map[string]any{
+			"status":          SiteSyncJobStatusQueued,
+			"rerun_requested": false,
+			"error":           nil,
+			"started_at":      nil,
+			"finished_at":     nil,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("requeue stale site sync jobs: %w", result.Error)
+	}
+	return nil
+}
+
+func applySiteSyncJobFinish(job *SiteSyncJob, status string, message string, now time.Time) {
+	if job.RerunRequested {
+		job.Status = SiteSyncJobStatusQueued
+		job.RerunRequested = false
+		job.Error = sql.NullString{}
+		job.StartedAt = sql.NullTime{}
+		job.FinishedAt = sql.NullTime{}
+		return
+	}
+	job.Status = status
+	job.ActiveKey = nil
+	job.Error = sql.NullString{String: message, Valid: message != ""}
+	job.FinishedAt = sql.NullTime{Time: now, Valid: true}
+}
+
+func siteSyncJobActiveKey(params EnqueueSiteSyncJobParams) string {
+	if params.SiteCredentialID == nil {
+		return params.Kind + ":" + params.SiteID.String()
+	}
+	return params.Kind + ":" + params.SiteID.String() + ":" + params.SiteCredentialID.String()
+}

--- a/server/internal/store/site_sync_job_repository_test.go
+++ b/server/internal/store/site_sync_job_repository_test.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestApplySiteSyncJobFinishRequeuesRequestedRerun(t *testing.T) {
+	activeKey := "api_key_refresh:site:credential"
+	job := SiteSyncJob{
+		ID:             uuid.New(),
+		Status:         SiteSyncJobStatusRunning,
+		ActiveKey:      &activeKey,
+		RerunRequested: true,
+		StartedAt:      sql.NullTime{Time: time.Now(), Valid: true},
+	}
+
+	applySiteSyncJobFinish(&job, SiteSyncJobStatusSucceeded, "", time.Now())
+
+	if job.Status != SiteSyncJobStatusQueued || job.ActiveKey == nil || *job.ActiveKey != activeKey {
+		t.Fatalf("rerun job = %#v", job)
+	}
+	if job.RerunRequested || job.StartedAt.Valid || job.FinishedAt.Valid || job.Error.Valid {
+		t.Fatalf("rerun job retained terminal fields = %#v", job)
+	}
+}
+
+func TestApplySiteSyncJobFinishCompletesWithoutRerun(t *testing.T) {
+	activeKey := "site_refresh:site"
+	finishedAt := time.Now()
+	job := SiteSyncJob{
+		ID:        uuid.New(),
+		Status:    SiteSyncJobStatusRunning,
+		ActiveKey: &activeKey,
+	}
+
+	applySiteSyncJobFinish(&job, SiteSyncJobStatusFailed, "upstream unavailable", finishedAt)
+
+	if job.Status != SiteSyncJobStatusFailed || job.ActiveKey != nil {
+		t.Fatalf("finished job = %#v", job)
+	}
+	if !job.Error.Valid || job.Error.String != "upstream unavailable" || !job.FinishedAt.Valid || !job.FinishedAt.Time.Equal(finishedAt) {
+		t.Fatalf("finished job fields = %#v", job)
+	}
+}

--- a/server/migrations/00001_initial_schema.sql
+++ b/server/migrations/00001_initial_schema.sql
@@ -271,6 +271,25 @@ CREATE TABLE site_api_key_states (
 CREATE INDEX site_api_key_states_site_id_idx ON site_api_key_states (site_id);
 CREATE INDEX site_api_key_states_upstream_id_idx ON site_api_key_states (site_id, upstream_id);
 
+CREATE TABLE site_sync_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind TEXT NOT NULL,
+  site_id UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  site_credential_id UUID REFERENCES site_credentials(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'queued',
+  active_key TEXT UNIQUE,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  rerun_requested BOOLEAN NOT NULL DEFAULT FALSE,
+  error TEXT,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX site_sync_jobs_status_created_idx ON site_sync_jobs (status, created_at);
+CREATE INDEX site_sync_jobs_site_id_idx ON site_sync_jobs (site_id);
+
 CREATE TABLE canonical_models (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   model_key TEXT NOT NULL,

--- a/web/src/features/sites/components/site-api-keys-draw.tsx
+++ b/web/src/features/sites/components/site-api-keys-draw.tsx
@@ -150,6 +150,7 @@ export function SiteAPIKeysDraw({
       )
       setAddingAPIKey(false)
       setNewAPIKeyDraft(DEFAULT_API_KEY_FORM_DRAFT)
+      onOpenChange(false)
       if (site) {
         await queryClient.invalidateQueries({
           queryKey: sitesQueryKeys.models(site.id),
@@ -163,7 +164,7 @@ export function SiteAPIKeysDraw({
       })
       await queryClient.invalidateQueries({ queryKey: routeQueryKeys.all })
       await invalidatePricingViews()
-      toast.success(t('apiKeys.toast.created'))
+      toast.success(t('apiKeys.toast.syncQueued'))
     },
     onError: (error) =>
       toast.error(t('apiKeys.toast.createFailed'), {
@@ -229,6 +230,7 @@ export function SiteAPIKeysDraw({
         current?.id === result.api_key.id ? result.api_key : current,
       )
       setConfiguringAPIKey(null)
+      onOpenChange(false)
       await queryClient.invalidateQueries({ queryKey: routeQueryKeys.all })
       await invalidatePricingViews()
       toast.success(t('apiKeys.toast.updated'))
@@ -260,6 +262,7 @@ export function SiteAPIKeysDraw({
       )
       setEditingAPIKey(null)
       setSecretInput('')
+      onOpenChange(false)
       await queryClient.invalidateQueries({
         queryKey: [...sitesQueryKeys.all, 'canonical-models'],
       })
@@ -268,7 +271,7 @@ export function SiteAPIKeysDraw({
       })
       await queryClient.invalidateQueries({ queryKey: routeQueryKeys.all })
       await invalidatePricingViews()
-      toast.success(t('apiKeys.toast.updated'))
+      toast.success(t('apiKeys.toast.syncQueued'))
     },
     onError: (error) =>
       toast.error(t('apiKeys.toast.updateFailed'), {
@@ -1053,6 +1056,16 @@ function apiKeySyncBadge(status?: string | null): {
       return {
         className: 'border-red-500/40 text-red-400',
         label: (t) => t('apiKeys.sync.stale'),
+      }
+    case 'pending':
+      return {
+        className: 'border-sky-500/40 text-sky-400',
+        label: (t) => t('apiKeys.sync.pending'),
+      }
+    case 'syncing':
+      return {
+        className: 'border-sky-500/40 text-sky-400',
+        label: (t) => t('apiKeys.sync.syncing'),
       }
     default:
       return {

--- a/web/src/features/sites/components/site-health-badge.tsx
+++ b/web/src/features/sites/components/site-health-badge.tsx
@@ -74,10 +74,18 @@ export function SiteHealthBadge({ site, validation, className }: SiteHealthBadge
 }
 
 function siteHealthStatus(site: Site, validation: ValidationSnapshot | Site['validation'] | undefined, t: (key: string) => string): {
-  status: 'healthy' | 'error' | 'idle'
+  status: 'healthy' | 'error' | 'syncing' | 'idle'
   label: string
   message?: string
 } {
+  const syncStatus = site.sync_state?.status?.trim().toLowerCase()
+  if (syncStatus === 'pending') {
+    return { status: 'syncing', label: t('table.health.pending') }
+  }
+  if (syncStatus === 'syncing') {
+    return { status: 'syncing', label: t('table.health.syncing') }
+  }
+
   if (isSiteAbnormal(site, validation)) {
     const message =
       (validation && validation.ok === false ? stringValue(validation.message) : undefined) ??

--- a/web/src/features/sites/components/sites-workspace.tsx
+++ b/web/src/features/sites/components/sites-workspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   useMutation,
   useQueries,
@@ -100,6 +100,12 @@ const EMPTY_API_KEYS: SiteAPIKey[] = []
 const EMPTY_SITE_TYPES: SiteTypeInfo[] = []
 const EMPTY_SITE_GROUPS: SiteGroup[] = []
 const EMPTY_OAUTH_CONNECTIONS: OAuthConnectionListItem[] = []
+const SITE_SYNC_POLL_INTERVAL = 2000
+
+function syncStatusActive(status?: string | null) {
+  const normalized = status?.trim().toLowerCase()
+  return normalized === 'pending' || normalized === 'syncing'
+}
 
 function siteURLTarget(params: URLSearchParams) {
   return {
@@ -143,10 +149,18 @@ export function SitesWorkspace({
   const [updatedAtMode, setUpdatedAtMode] =
     useState<SiteUpdatedAtDisplayMode>(readUpdatedAtMode)
   const [now, setNow] = useState(() => Date.now())
+  const previousSiteSyncStatuses = useRef<Record<string, string>>({})
+  const previousAPIKeySyncStatuses = useRef<Record<string, string>>({})
 
   const sitesQuery = useQuery({
     queryKey: sitesQueryKeys.list(),
     queryFn: () => listSites(),
+    refetchInterval: (query) =>
+      query.state.data?.items.some((site) =>
+        syncStatusActive(site.sync_state?.status),
+      )
+        ? SITE_SYNC_POLL_INTERVAL
+        : false,
   })
   const splitSitesQuery = useQuery({
     queryKey: sitesQueryKeys.list('all', 'with_requests'),
@@ -206,6 +220,14 @@ export function SitesWorkspace({
     queries: sitesWithAPIKeys.map((site) => ({
       queryKey: [...sitesQueryKeys.detail(site.id), 'api-keys'],
       queryFn: () => listSiteAPIKeys(site.id),
+      refetchInterval: (query: {
+        state: { data?: { items?: SiteAPIKey[] } }
+      }) =>
+        query.state.data?.items?.some((apiKey) =>
+          syncStatusActive(apiKey.sync_status),
+        )
+          ? SITE_SYNC_POLL_INTERVAL
+          : false,
     })),
   })
 
@@ -240,6 +262,93 @@ export function SitesWorkspace({
   const siteTypes = siteTypesQuery.data?.items ?? EMPTY_SITE_TYPES
   const siteGroups = siteGroupsQuery.data?.items ?? EMPTY_SITE_GROUPS
   const proxies = systemProxyQuery.data?.proxies ?? []
+
+  useEffect(() => {
+    const nextStatuses: Record<string, string> = {}
+    const completedSiteIds: string[] = []
+    for (const site of sites) {
+      const status = site.sync_state?.status?.trim().toLowerCase() ?? ''
+      nextStatuses[site.id] = status
+      if (
+        syncStatusActive(previousSiteSyncStatuses.current[site.id]) &&
+        !syncStatusActive(status)
+      ) {
+        completedSiteIds.push(site.id)
+      }
+    }
+    previousSiteSyncStatuses.current = nextStatuses
+    if (!completedSiteIds.length) return
+    void Promise.all([
+      ...completedSiteIds.map((siteId) =>
+        queryClient.invalidateQueries({
+          queryKey: sitesQueryKeys.models(siteId),
+        }),
+      ),
+      ...completedSiteIds.map((siteId) =>
+        queryClient.invalidateQueries({
+          queryKey: [...sitesQueryKeys.detail(siteId), 'api-keys'],
+        }),
+      ),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'canonical-models'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'routes-matrix'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'all-pricings'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['settings', 'model-prices'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: downstreamAPIKeyQueryKeys.list(),
+      }),
+    ])
+  }, [queryClient, sites])
+
+  useEffect(() => {
+    const nextStatuses: Record<string, string> = {}
+    const completedSiteIds = new Set<string>()
+    for (const [siteId, apiKeys] of Object.entries(siteAPIKeysMap)) {
+      for (const apiKey of apiKeys) {
+        const key = `${siteId}:${apiKey.id}`
+        const status = apiKey.sync_status?.trim().toLowerCase() ?? ''
+        nextStatuses[key] = status
+        if (
+          syncStatusActive(previousAPIKeySyncStatuses.current[key]) &&
+          !syncStatusActive(status)
+        ) {
+          completedSiteIds.add(siteId)
+        }
+      }
+    }
+    previousAPIKeySyncStatuses.current = nextStatuses
+    if (!completedSiteIds.size) return
+    void Promise.all([
+      ...Array.from(completedSiteIds).map((siteId) =>
+        queryClient.invalidateQueries({
+          queryKey: sitesQueryKeys.models(siteId),
+        }),
+      ),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'canonical-models'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'routes-matrix'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: [...sitesQueryKeys.all, 'all-pricings'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['settings', 'model-prices'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: downstreamAPIKeyQueryKeys.list(),
+      }),
+    ])
+  }, [queryClient, siteAPIKeysMap])
+
   const urlTargetSearch = urlTargetSite
     ? urlTargetSite.name || urlTargetSite.slug
     : ''
@@ -300,16 +409,8 @@ export function SitesWorkspace({
   )
 
   const createMutation = useMutation({
-    mutationFn: async (input: SiteCreateSubmitInput) => {
-      const result = await createSite(input)
-      await updateSiteGroupMembershipForSite(
-        siteGroups,
-        result.site.id,
-        input.siteGroupIds ?? [],
-      )
-      return result
-    },
-    onSuccess: async (result) => {
+    mutationFn: (input: SiteCreateSubmitInput) => createSite(input),
+    onSuccess: async (result, input) => {
       queryClient.setQueryData(
         sitesQueryKeys.list(),
         (current: { items: Site[]; meta: { count: number } } | undefined) =>
@@ -333,6 +434,18 @@ export function SitesWorkspace({
       notifySiteSetupIncomplete(result)
       setEditingSite(null)
       setCreateOpen(false)
+      toast.success(t('page.toast.syncQueued'))
+      try {
+        await updateSiteGroupMembershipForSite(
+          siteGroups,
+          result.site.id,
+          input.siteGroupIds ?? [],
+        )
+      } catch (error) {
+        toast.error(t('page.toast.saveFailed'), {
+          description: error instanceof Error ? error.message : String(error),
+        })
+      }
       await invalidateSiteLists()
     },
     onError: (error) =>

--- a/web/src/locales/en/sites.json
+++ b/web/src/locales/en/sites.json
@@ -31,7 +31,8 @@
       "refreshPartialFailed": "Some sites failed to refresh",
       "refreshPartialDesc": "{{count}} site(s) failed to refresh",
       "refreshPartialDescFallback": "Some sites failed to refresh",
-      "statusFailed": "Failed to update site status"
+      "statusFailed": "Failed to update site status",
+      "syncQueued": "Saved and syncing in the background"
     }
   },
   "table": {
@@ -51,7 +52,9 @@
     "health": {
       "unchecked": "Unchecked",
       "healthy": "Healthy",
-      "abnormal": "Abnormal"
+      "abnormal": "Abnormal",
+      "pending": "Waiting to sync",
+      "syncing": "Syncing"
     },
     "quotaDetails": {
       "keyAvailable": "Key available quota",
@@ -238,6 +241,7 @@
     "toast": {
       "createFailed": "API key create failed",
       "created": "API key created",
+      "syncQueued": "API key saved and syncing in the background",
       "deleteFailed": "API key delete failed",
       "deleted": "API key deleted",
       "updateFailed": "API key update failed",
@@ -259,7 +263,9 @@
       "failed": "Failed",
       "partial": "Partial",
       "stale": "Removed upstream",
-      "unknown": "Not synced"
+      "unknown": "Not synced",
+      "pending": "Waiting to sync",
+      "syncing": "Syncing"
     }
   },
   "grokAccounts": {

--- a/web/src/locales/jp/sites.json
+++ b/web/src/locales/jp/sites.json
@@ -31,7 +31,8 @@
       "refreshPartialFailed": "一部のサイト更新に失敗しました",
       "refreshPartialDesc": "{{count}} サイトの更新に失敗しました",
       "refreshPartialDescFallback": "一部のサイト更新に失敗しました",
-      "statusFailed": "サイト状態の更新に失敗しました"
+      "statusFailed": "サイト状態の更新に失敗しました",
+      "syncQueued": "保存しました。バックグラウンドで同期しています"
     }
   },
   "table": {
@@ -51,7 +52,9 @@
     "health": {
       "unchecked": "未確認",
       "healthy": "正常",
-      "abnormal": "Abnormal"
+      "abnormal": "Abnormal",
+      "pending": "同期待ち",
+      "syncing": "同期中"
     },
     "quotaDetails": {
       "keyAvailable": "キーの利用可能枠",
@@ -229,6 +232,7 @@
     "toast": {
       "createFailed": "API キー作成に失敗しました",
       "created": "API キーを作成しました",
+      "syncQueued": "API キーを保存しました。バックグラウンドで同期しています",
       "deleteFailed": "API キー削除に失敗しました",
       "deleted": "API キーを削除しました",
       "updateFailed": "API キー更新に失敗しました",
@@ -250,7 +254,9 @@
       "failed": "失敗",
       "partial": "一部",
       "stale": "上流で削除済み",
-      "unknown": "未同期"
+      "unknown": "未同期",
+      "pending": "同期待ち",
+      "syncing": "同期中"
     }
   },
   "grokAccounts": {

--- a/web/src/locales/zh/sites.json
+++ b/web/src/locales/zh/sites.json
@@ -31,7 +31,8 @@
       "refreshPartialFailed": "部分站点刷新失败",
       "refreshPartialDesc": "{{count}} 个站点刷新失败",
       "refreshPartialDescFallback": "部分站点刷新失败",
-      "statusFailed": "站点状态更新失败"
+      "statusFailed": "站点状态更新失败",
+      "syncQueued": "已保存，正在后台同步"
     }
   },
   "table": {
@@ -51,7 +52,9 @@
     "health": {
       "unchecked": "未检测",
       "healthy": "可用",
-      "abnormal": "异常"
+      "abnormal": "异常",
+      "pending": "等待同步",
+      "syncing": "同步中"
     },
     "quotaDetails": {
       "keyAvailable": "Key 可用额度",
@@ -238,6 +241,7 @@
     "toast": {
       "createFailed": "ApiKey 创建失败",
       "created": "ApiKey 已创建",
+      "syncQueued": "ApiKey 已保存，正在后台同步",
       "deleteFailed": "ApiKey 删除失败",
       "deleted": "ApiKey 已删除",
       "updateFailed": "ApiKey 更新失败",
@@ -261,7 +265,9 @@
       "failed": "失败",
       "partial": "部分",
       "stale": "上游已移除",
-      "unknown": "未同步"
+      "unknown": "未同步",
+      "pending": "等待同步",
+      "syncing": "同步中"
     }
   },
   "grokAccounts": {


### PR DESCRIPTION
## 背景

当前新增站点、添加 API 密钥和更新 API 密钥时，接口会同步等待后端向上游获取站点或密钥信息。上游请求耗时或失败时，提交请求和前端弹窗会持续等待，影响配置操作。

原有创建链路也没有持久化后台任务状态，用户返回列表后无法观察同步进度，服务重启后未完成的同步缺少可靠的恢复机制。

## 本次变更

### 1. 解耦配置提交与上游同步

- 创建站点、添加 API 密钥、更新 API 密钥 Secret 改为在同一事务内保存配置并创建同步任务
- 接口保存成功后立即返回 `202 Accepted`，不再等待上游请求完成
- 站点和 API 密钥初始状态标记为 `pending`，由后台任务推进到最终状态
- 保留现有同步结果、模型和价格数据，后台同步完成后再更新

### 2. 增加持久化同步队列和后台 Worker

新增 `site_sync_jobs` 任务表和常驻 Worker：

```text
提交配置
    │
    ▼
保存配置 + 创建同步任务
    │
    ▼
立即返回 202 Accepted
    │
    ▼
后台 Worker 领取任务
    │
    ├── 站点信息、模型和价格同步
    └── API 密钥信息和模型同步
    │
    ▼
pending → syncing → synced / partial / failed
```

- 使用数据库任务状态和行锁领取任务，支持多个 Worker 并发处理
- 运行任务超过恢复阈值后自动重新入队
- 已完成任务定期清理，避免队列表无限增长
- 同一站点或 API 密钥在同步期间再次提交时保留重跑请求，当前任务结束后自动再次同步
- Worker 对超时、异常和刷新失败补写终态，避免页面永久停留在“同步中”
- 同步完成后统一失效网关模型缓存

### 3. 完善 Sites 页面交互

- 创建站点、添加 API 密钥、编辑 API 密钥 Secret 成功后立即关闭弹窗并返回列表
- 列表自动轮询 `pending/syncing` 状态，任务完成后停止轮询
- 增加“等待同步”和“同步中”状态展示
- 同步完成后刷新模型、价格、路由矩阵、API 密钥和相关设置缓存
- 站点分组关系更新不再阻塞弹窗关闭，失败时单独提示

### 4. 兼容已有数据库

- 初始迁移增加 `site_sync_jobs` 表及索引
- 已存在的数据库通过启动升级逻辑补建任务表和重跑字段
- 未改变现有同步接口和已存储站点、模型、价格数据的结构

## 安全性与兼容性

- 配置保存、同步状态初始化和任务入队在同一数据库事务内完成，避免出现“配置已保存但没有同步任务”的中间状态
- API 密钥明文仍沿用现有凭据加密和审计链路
- 任务去重使用站点/凭据范围的活动键，不会阻止不同站点或不同 API 密钥并发同步
- 未新增手写 SQL；ORM 约束扫描未发现本次新增违规调用，结果仅包含仓库原有已知位置

## 测试覆盖

新增或扩展覆盖：

- 同步任务成功和失败终态
- 同步期间重复提交后的重跑请求
- 任务终态字段和活动键清理
- 站点、API 密钥服务及管理接口回归
- 前端轮询、状态展示和异步提交后的缓存刷新

## 验证结果

- `cd server && go test ./...`：通过
- `cd server && govulncheck ./...`：无可达漏洞
- `cd web && npm run typecheck`：通过
- `cd web && npm run lint`：通过
- `cd web && npm run build`：通过

## 建议审查重点

1. 配置保存、同步状态初始化和任务入队之间的事务边界
2. Worker 领取任务、超时恢复和重复提交重跑之间的并发行为
3. 失败或超时场景下站点/API 密钥状态是否能够可靠收敛
4. 前端轮询停止条件和同步完成后的缓存刷新范围