### PR TITLE
fix: 🐛 修复备份恢复未覆盖模型体验会话记录与图片附件的问题

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -116,7 +116,7 @@ func run() int {
 	siteService := site.NewServiceWithTimeZone(db, masterKey, appTimeZone, confFile)
 	syncService := catalog.NewSyncService(db, logger.With("thread", "models-dev-sync"), confFile)
 	usageSummaryService := usage.NewSummaryService(db, confFile, appTimeZone)
-	backupService := backup.NewService(db, confFile, masterKey, appTimeZone)
+	backupService := backup.NewService(db, confFile, masterKey, filepath.Join(config.ResolveWorkdir(), "playground"), appTimeZone)
 	automaticBackupService := backup.NewAutomaticService(backupService, masterKey)
 	reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	if err := catalog.ReconcileCategories(reconcileCtx, db.DB()); err != nil {

--- a/server/internal/app/router.go
+++ b/server/internal/app/router.go
@@ -72,7 +72,8 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 	downloadService := downloads.NewService()
 	gatewayHandler := gateway.NewHandlerWithTimeZone(logger.With("thread", "gateway"), authService, routerService, db, masterKey, appTimeZone, confFile)
 	playgroundGatewayHandler := gatewayHandler.WithRouteSiteHeader()
-	playgroundService := playground.NewService(logger.With("thread", "playground"), db, gatewayHandler, filepath.Join(config.ResolveWorkdir(), "playground"))
+	playgroundRoot := filepath.Join(config.ResolveWorkdir(), "playground")
+	playgroundService := playground.NewService(logger.With("thread", "playground"), db, gatewayHandler, playgroundRoot)
 	playgroundHandler := playground.NewHandler(playgroundService)
 	if db != nil {
 		go func() {
@@ -83,7 +84,12 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 	}
 	adminHandler := admin.NewHandler(logger.With("thread", "admin"), authService, siteService, catalogService, routerService, usageService, dashboardService, systemStatsService, &gatewayHandler, newAPIService, oauthService, appTimeZone).WithDownloadService(downloadService).WithTrafficFlowStore(db).WithAnalyticsService(analyticsService)
 	healthHandler := health.NewHandler(cfg, db)
-	settingsHandler := settings.NewHandlerWithBackup(logger.With("thread", "settings"), confFile, db, masterKey, downloadService, appTimeZone)
+	var preRestore, postRestore func(context.Context) error
+	if playgroundService != nil {
+		preRestore = playgroundService.QuiesceForRestore
+		postRestore = playgroundService.RecoverAfterRestore
+	}
+	settingsHandler := settings.NewHandlerWithBackup(logger.With("thread", "settings"), confFile, db, masterKey, downloadService, playgroundRoot, preRestore, postRestore, appTimeZone)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)

--- a/server/internal/backup/archive.go
+++ b/server/internal/backup/archive.go
@@ -77,22 +77,23 @@ func parseArchiveContext(ctx context.Context, filename string) (archivePayload, 
 	}
 
 	dump := databaseDump{Tables: make(map[string][]map[string]any, len(exportTables)), archivePath: filename}
+	strict := payload.Manifest.FormatVersion == currentFormatVersion
 	for _, table := range backupTables {
 		if _, streamed := streamedImportTables[table.Name]; streamed {
 			// Large detail tables are streamed from the archive during import;
 			// only verify the entry exists so validation still fails fast.
-			if archiveFile(zr.File, path.Join("database", table.Name+".jsonl")) == nil {
+			if strict && archiveFile(zr.File, path.Join("database", table.Name+".jsonl")) == nil {
 				return archivePayload{}, databaseDump{}, fmt.Errorf("backup archive missing %s", path.Join("database", table.Name+".jsonl"))
 			}
 			continue
 		}
-		rows, err := decodeArchiveTable(zr.File, table.Name)
+		rows, err := decodeArchiveTable(zr.File, table.Name, strict)
 		if err != nil {
 			return archivePayload{}, databaseDump{}, err
 		}
 		dump.Tables[table.Name] = rows
 	}
-	totalRows, err := archiveTotalRows(ctx, zr.File, dump.Tables)
+	totalRows, err := archiveTotalRows(ctx, zr.File, dump.Tables, strict)
 	if err != nil {
 		return archivePayload{}, databaseDump{}, err
 	}
@@ -100,7 +101,7 @@ func parseArchiveContext(ctx context.Context, filename string) (archivePayload, 
 	return payload, dump, nil
 }
 
-func archiveTotalRows(ctx context.Context, files []*zip.File, loaded map[string][]map[string]any) (int, error) {
+func archiveTotalRows(ctx context.Context, files []*zip.File, loaded map[string][]map[string]any, strict bool) (int, error) {
 	if archiveFile(files, archiveRowCountsFile) != nil {
 		rowCounts := map[string]int{}
 		if err := decodeArchiveJSON(files, archiveRowCountsFile, &rowCounts); err != nil {
@@ -109,7 +110,13 @@ func archiveTotalRows(ctx context.Context, files []*zip.File, loaded map[string]
 		total := 0
 		for _, table := range backupTables {
 			rows, ok := rowCounts[table.Name]
-			if !ok || rows < 0 {
+			if !ok {
+				if strict {
+					return 0, fmt.Errorf("invalid row count for %s", table.Name)
+				}
+				continue
+			}
+			if rows < 0 {
 				return 0, fmt.Errorf("invalid row count for %s", table.Name)
 			}
 			total += rows
@@ -124,6 +131,12 @@ func archiveTotalRows(ctx context.Context, files []*zip.File, loaded map[string]
 		}
 		name := path.Join("database", table.Name+".jsonl")
 		file := archiveFile(files, name)
+		if file == nil {
+			if strict {
+				return 0, fmt.Errorf("backup archive missing %s", name)
+			}
+			continue
+		}
 		rows, err := countArchiveRowsContext(ctx, file)
 		if err != nil {
 			return 0, fmt.Errorf("count %s: %w", name, err)
@@ -173,19 +186,27 @@ func countArchiveRowsContext(ctx context.Context, file *zip.File) (int, error) {
 }
 
 func writeArchiveJSONFile(zw *zip.Writer, name string, value any) error {
-	w, err := zw.CreateHeader(&zip.FileHeader{
-		Name:     name,
-		Method:   zip.Deflate,
-		Modified: time.Now().UTC(),
-	})
+	w, err := createArchiveEntry(zw, name, zip.Deflate)
 	if err != nil {
-		return fmt.Errorf("write zip header %s: %w", name, err)
+		return err
 	}
 	encoder := json.NewEncoder(w)
 	if err := encoder.Encode(value); err != nil {
 		return fmt.Errorf("encode %s: %w", name, err)
 	}
 	return nil
+}
+
+func createArchiveEntry(zw *zip.Writer, name string, method uint16) (io.Writer, error) {
+	w, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     name,
+		Method:   method,
+		Modified: time.Now().UTC(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("write zip header %s: %w", name, err)
+	}
+	return w, nil
 }
 
 func decodeArchiveJSON(files []*zip.File, name string, dst any) error {
@@ -207,11 +228,14 @@ func decodeArchiveJSON(files []*zip.File, name string, dst any) error {
 	return nil
 }
 
-func decodeArchiveTable(files []*zip.File, table string) ([]map[string]any, error) {
+func decodeArchiveTable(files []*zip.File, table string, required bool) ([]map[string]any, error) {
 	name := path.Join("database", table+".jsonl")
 	file := archiveFile(files, name)
 	if file == nil {
-		return nil, fmt.Errorf("backup archive missing %s", name)
+		if required {
+			return nil, fmt.Errorf("backup archive missing %s", name)
+		}
+		return []map[string]any{}, nil
 	}
 	reader, err := file.Open()
 	if err != nil {

--- a/server/internal/backup/archive_error_test.go
+++ b/server/internal/backup/archive_error_test.go
@@ -32,7 +32,45 @@ func TestWriteArchiveReturnsDatabaseWriterError(t *testing.T) {
 	}
 }
 
-func TestParseArchiveRejectsMissingDatabaseTable(t *testing.T) {
+func TestParseArchiveToleratesMissingDatabaseTables(t *testing.T) {
+	t.Parallel()
+
+	filename := writeArchiveFixture(t, func(zw *zip.Writer) {
+		if err := writeArchiveJSONFile(zw, "manifest.json", manifest{
+			FormatVersion: minImportFormatVersion,
+			App:           backupAppName,
+			Payload:       backupPayload,
+			CreatedAt:     time.Now().UTC(),
+			Tables:        exportTables[:len(exportTables)-4],
+		}); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		if err := writeArchiveJSONFile(zw, "config.json", map[string]any{}); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	})
+
+	_, dump, err := parseArchive(filename)
+	if err != nil {
+		t.Fatalf("parseArchive error = %v, want nil", err)
+	}
+	if dump.TotalRows != 0 {
+		t.Fatalf("expected zero total rows, got %d", dump.TotalRows)
+	}
+	if err := validateDumpTables(dump); err != nil {
+		t.Fatalf("expected dump with empty tables to validate: %v", err)
+	}
+	for _, table := range backupTables {
+		if _, streamed := streamedImportTables[table.Name]; streamed {
+			continue
+		}
+		if rows := dump.Tables[table.Name]; len(rows) != 0 {
+			t.Fatalf("expected table %s to be empty, got %d rows", table.Name, len(rows))
+		}
+	}
+}
+
+func TestParseArchiveRejectsCurrentVersionArchiveMissingTables(t *testing.T) {
 	t.Parallel()
 
 	filename := writeArchiveFixture(t, func(zw *zip.Writer) {
@@ -65,7 +103,7 @@ func TestDecodeArchiveJSONRejectsMalformedJSON(t *testing.T) {
 func TestDecodeArchiveTableRejectsMalformedJSONLRow(t *testing.T) {
 	t.Parallel()
 
-	_, err := decodeArchiveTable(archivePayloadZipFiles(t, map[string]string{"database/sites.jsonl": "{"}), "sites")
+	_, err := decodeArchiveTable(archivePayloadZipFiles(t, map[string]string{"database/sites.jsonl": "{"}), "sites", true)
 	assertBackupErrorContains(t, "decodeArchiveTable", err, "decode database/sites.jsonl")
 }
 

--- a/server/internal/backup/archive_payload_helpers_test.go
+++ b/server/internal/backup/archive_payload_helpers_test.go
@@ -182,24 +182,28 @@ func TestArchivePayloadDecodersPreserveNumbersAndReportMalformedEntries(t *testi
 		t.Fatalf("expected malformed JSON error, got %v", err)
 	}
 
-	rows, err := decodeArchiveTable(files, "sites")
+	rows, err := decodeArchiveTable(files, "sites", true)
 	if err != nil {
 		t.Fatalf("decode archive table: %v", err)
 	}
 	if len(rows) != 2 || rows[0]["id"] != "site-1" || rows[0]["priority"] != json.Number("1") {
 		t.Fatalf("unexpected decoded rows: %#v", rows)
 	}
-	emptyRows, err := decodeArchiveTable(files, "empty_table")
+	emptyRows, err := decodeArchiveTable(files, "empty_table", true)
 	if err != nil {
 		t.Fatalf("decode empty archive table: %v", err)
 	}
 	if len(emptyRows) != 0 {
 		t.Fatalf("expected empty table, got %#v", emptyRows)
 	}
-	if _, err := decodeArchiveTable(files, "missing_table"); err == nil || !strings.Contains(err.Error(), "missing database/missing_table.jsonl") {
-		t.Fatalf("expected missing table error, got %v", err)
+	missingRows, err := decodeArchiveTable(files, "missing_table", false)
+	if err != nil {
+		t.Fatalf("expected missing table to decode as empty, got %v", err)
 	}
-	if _, err := decodeArchiveTable(files, "malformed"); err == nil || !strings.Contains(err.Error(), "decode database/malformed.jsonl") {
+	if len(missingRows) != 0 {
+		t.Fatalf("expected missing table to decode as empty, got %#v", missingRows)
+	}
+	if _, err := decodeArchiveTable(files, "malformed", true); err == nil || !strings.Contains(err.Error(), "decode database/malformed.jsonl") {
 		t.Fatalf("expected malformed table error, got %v", err)
 	}
 }

--- a/server/internal/backup/automatic.go
+++ b/server/internal/backup/automatic.go
@@ -317,12 +317,12 @@ func (s *AutomaticService) run(ctx context.Context, cfg config.AutomaticBackupCo
 	return result, nil
 }
 
-func (s *AutomaticService) Restore(ctx context.Context, key string) (ImportSummary, error) {
-	return s.restore(ctx, key, nil)
+func (s *AutomaticService) Restore(ctx context.Context, key string, opts ImportOptions) (ImportSummary, error) {
+	return s.restore(ctx, key, opts, nil)
 }
 
-func (s *AutomaticService) RestoreWithProgress(ctx context.Context, key string, progress ProgressFunc) (ImportSummary, error) {
-	return s.restore(ctx, key, progress)
+func (s *AutomaticService) RestoreWithProgress(ctx context.Context, key string, opts ImportOptions, progress ProgressFunc) (ImportSummary, error) {
+	return s.restore(ctx, key, opts, progress)
 }
 
 type restoreDownloadCounter struct {
@@ -341,7 +341,7 @@ func (c *restoreDownloadCounter) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (s *AutomaticService) restore(ctx context.Context, key string, progress ProgressFunc) (ImportSummary, error) {
+func (s *AutomaticService) restore(ctx context.Context, key string, opts ImportOptions, progress ProgressFunc) (ImportSummary, error) {
 	cfg, client, err := s.readyClient()
 	if err != nil {
 		return ImportSummary{}, err
@@ -394,7 +394,7 @@ func (s *AutomaticService) restore(ctx context.Context, key string, progress Pro
 		progress(ProgressEvent{Step: "download", Status: "complete", Bytes: counter.read, Total: stat.Size})
 	}
 
-	return s.base.Import(ctx, passphrase, data, progress)
+	return s.base.Import(ctx, passphrase, data, opts, progress)
 }
 
 func validateRestoreObjectSize(size int64) error {

--- a/server/internal/backup/automatic_config_lifecycle_edges_test.go
+++ b/server/internal/backup/automatic_config_lifecycle_edges_test.go
@@ -203,7 +203,7 @@ func TestServiceReadyAndBackupFilenameUseConfiguredTimezone(t *testing.T) {
 	}
 
 	loc := time.FixedZone("UTC+2", 2*60*60)
-	service := NewService(nil, nil, "master", config.TimeZone{Name: "UTC+2", Location: loc})
+	service := NewService(nil, nil, "master", "", config.TimeZone{Name: "UTC+2", Location: loc})
 	createdAt := time.Date(2026, 6, 21, 23, 30, 5, 0, time.UTC)
 
 	if got := service.backupFilename(createdAt); got != "xlyra-backup-20260622-013005.zip.xlyra" {
@@ -229,10 +229,12 @@ func TestValidateManifestRejectsMismatches(t *testing.T) {
 		mutate func(*manifest)
 	}{
 		{name: "app", mutate: func(m *manifest) { m.App = "other" }},
-		{name: "version", mutate: func(m *manifest) { m.FormatVersion++ }},
+		{name: "version above supported", mutate: func(m *manifest) { m.FormatVersion = currentFormatVersion + 1 }},
+		{name: "version below supported", mutate: func(m *manifest) { m.FormatVersion = minImportFormatVersion - 1 }},
 		{name: "payload", mutate: func(m *manifest) { m.Payload = "other" }},
-		{name: "table count", mutate: func(m *manifest) { m.Tables = m.Tables[:len(m.Tables)-1] }},
-		{name: "table order", mutate: func(m *manifest) { m.Tables[0], m.Tables[1] = m.Tables[1], m.Tables[0] }},
+		{name: "unknown table", mutate: func(m *manifest) { m.Tables = append(m.Tables, "not_a_backup_table") }},
+		{name: "current version table count", mutate: func(m *manifest) { m.Tables = m.Tables[:len(m.Tables)-1] }},
+		{name: "current version table order", mutate: func(m *manifest) { m.Tables[0], m.Tables[1] = m.Tables[1], m.Tables[0] }},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -247,6 +249,27 @@ func TestValidateManifestRejectsMismatches(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("older version table subset", func(t *testing.T) {
+		t.Parallel()
+
+		value := valid
+		value.FormatVersion = minImportFormatVersion
+		value.Tables = append([]string(nil), exportTables[:len(exportTables)-4]...)
+		if err := validateManifest(value); err != nil {
+			t.Fatalf("expected older table subset to be accepted, got %v", err)
+		}
+	})
+	t.Run("older version unknown table", func(t *testing.T) {
+		t.Parallel()
+
+		value := valid
+		value.FormatVersion = minImportFormatVersion
+		value.Tables = append(append([]string(nil), valid.Tables...), "not_a_backup_table")
+		if err := validateManifest(value); err == nil {
+			t.Fatal("expected unknown table to be rejected")
+		}
+	})
 }
 
 func TestIsAlreadyRunningError(t *testing.T) {
@@ -357,7 +380,7 @@ func TestAutomaticServiceReadyClientAndRunEarlyFailures(t *testing.T) {
 		{
 			name: "restore",
 			call: func() error {
-				_, err := missingConfig.Restore(context.Background(), "xlyra/prod/xlyra-backup-20260621-030000.zip.xlyra")
+				_, err := missingConfig.Restore(context.Background(), "xlyra/prod/xlyra-backup-20260621-030000.zip.xlyra", ImportOptions{})
 				return err
 			},
 		},

--- a/server/internal/backup/automatic_ready_database_edges_test.go
+++ b/server/internal/backup/automatic_ready_database_edges_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"xlyra/server/internal/config"
@@ -150,7 +151,7 @@ func TestDatabaseImportExportWrapTransactionBeginFailures(t *testing.T) {
 
 	txErr := errors.New("transaction begin failed")
 	db := backupTransactionGorm(t, txErr)
-	_, err := exportDatabase(context.Background(), db, "master-key", nil)
+	_, err := exportDatabase(context.Background(), db, "master-key", "", nil)
 	if !errors.Is(err, txErr) {
 		t.Fatalf("exportDatabase err=%v, want transaction begin failure", err)
 	}
@@ -159,7 +160,7 @@ func TestDatabaseImportExportWrapTransactionBeginFailures(t *testing.T) {
 	for _, table := range backupTables {
 		dump.Tables[table.Name] = nil
 	}
-	_, _, err = importDatabase(context.Background(), db, "master-key", dump)
+	_, _, err = importDatabase(context.Background(), db, "master-key", dump, uuid.Nil)
 	if !errors.Is(err, txErr) {
 		t.Fatalf("importDatabase err=%v, want transaction begin failure", err)
 	}
@@ -204,7 +205,7 @@ func TestAutomaticFileMutationsRejectBlankObjectKey(t *testing.T) {
 		{
 			name: "restore",
 			call: func() error {
-				_, err := service.Restore(context.Background(), " ")
+				_, err := service.Restore(context.Background(), " ", ImportOptions{})
 				return err
 			},
 		},
@@ -267,7 +268,7 @@ func TestImportDatabaseRejectsUnregisteredDeleteOrderTable(t *testing.T) {
 		importDeleteOrder = original
 	})
 
-	_, _, err := importDatabase(context.Background(), backupTransactionGorm(t, nil), "master-key", dump)
+	_, _, err := importDatabase(context.Background(), backupTransactionGorm(t, nil), "master-key", dump, uuid.Nil)
 	if err == nil || !strings.Contains(err.Error(), "backup table not_registered was not registered") {
 		t.Fatalf("importDatabase err=%v, want unregistered table error", err)
 	}

--- a/server/internal/backup/automatic_run_archive_edges_test.go
+++ b/server/internal/backup/automatic_run_archive_edges_test.go
@@ -78,7 +78,7 @@ func TestDecodeArchiveTableAcceptsEmptyFile(t *testing.T) {
 
 	rows, err := decodeArchiveTable(archivePayloadZipFiles(t, map[string]string{
 		"database/sites.jsonl": "",
-	}), "sites")
+	}), "sites", true)
 	if err != nil {
 		t.Fatalf("decodeArchiveTable empty file: %v", err)
 	}

--- a/server/internal/backup/automatic_validation_edges_test.go
+++ b/server/internal/backup/automatic_validation_edges_test.go
@@ -12,13 +12,13 @@ import (
 func TestServiceExportImportRequireReadyDatabase(t *testing.T) {
 	t.Parallel()
 
-	service := NewService(nil, nil, "master-key")
+	service := NewService(nil, nil, "master-key", "")
 	if path, filename, err := service.Export(context.Background(), "secret"); path != "" || filename != "" {
 		t.Fatalf("Export error = %v, path=%q filename=%q; want ready database validation", err, path, filename)
 	} else {
 		assertBackupErrorContains(t, "Export", err, "database is not available")
 	}
-	if summary, err := service.Import(context.Background(), "secret", []byte("encrypted")); err == nil {
+	if summary, err := service.Import(context.Background(), "secret", []byte("encrypted"), ImportOptions{}); err == nil {
 		t.Fatalf("Import error = %v, summary=%#v; want ready database validation", err, summary)
 	} else {
 		assertBackupErrorContains(t, "Import", err, "database is not available")
@@ -124,7 +124,7 @@ func TestRestoreAndDeleteValidateObjectKeysBeforeRemoteCall(t *testing.T) {
 	cfg.Storage.UseSSL = true
 	service := NewAutomaticService(Service{confFile: automaticConfigFile(t, cfg)}, "master-key")
 
-	if _, err := service.Restore(context.Background(), "other/xlyra-backup-20260621-030000.zip.xlyra"); err == nil || !strings.Contains(err.Error(), "outside configured prefix") {
+	if _, err := service.Restore(context.Background(), "other/xlyra-backup-20260621-030000.zip.xlyra", ImportOptions{}); err == nil || !strings.Contains(err.Error(), "outside configured prefix") {
 		t.Fatalf("Restore error = %v, want prefix validation", err)
 	}
 	if err := service.Delete(context.Background(), "prod/notes.txt"); err == nil || !strings.Contains(err.Error(), "format") {

--- a/server/internal/backup/crypto_test.go
+++ b/server/internal/backup/crypto_test.go
@@ -164,8 +164,17 @@ func TestBackupTablesIncludeRequestUsageSummaries(t *testing.T) {
 	if _, ok := backupTableByName(summaryDays); !ok {
 		t.Fatalf("expected backup table %s to be registered", summaryDays)
 	}
-	if len(importDeleteOrder) < 2 || importDeleteOrder[0] != summaryDays || importDeleteOrder[1] != dailySummary {
-		t.Fatalf("expected summary tables to be cleared first, got %#v", importDeleteOrder[:min(len(importDeleteOrder), 4)])
+	playgroundFirst := []string{"playground_assets", "playground_turn_indexes", "playground_runs", "playground_conversations"}
+	if len(importDeleteOrder) < len(playgroundFirst)+2 {
+		t.Fatalf("delete order too short: %#v", importDeleteOrder)
+	}
+	for i, table := range playgroundFirst {
+		if importDeleteOrder[i] != table {
+			t.Fatalf("expected playground tables to be cleared first, got %#v", importDeleteOrder[:min(len(importDeleteOrder), 6)])
+		}
+	}
+	if importDeleteOrder[4] != summaryDays || importDeleteOrder[5] != dailySummary {
+		t.Fatalf("expected summary tables to follow playground tables, got %#v", importDeleteOrder[:min(len(importDeleteOrder), 6)])
 	}
 }
 

--- a/server/internal/backup/database.go
+++ b/server/internal/backup/database.go
@@ -69,6 +69,10 @@ var exportTables = []string{
 	"usage_records",
 	"request_usage_daily_summaries",
 	"request_usage_summary_days",
+	"playground_conversations",
+	"playground_runs",
+	"playground_turn_indexes",
+	"playground_assets",
 }
 
 type backupTable struct {
@@ -100,9 +104,17 @@ var backupTables = []backupTable{
 	{Name: "usage_records", Model: &store.UsageRecord{}, NewSlice: func() any { return &[]store.UsageRecord{} }},
 	{Name: "request_usage_daily_summaries", Model: &store.RequestUsageDailySummary{}, NewSlice: func() any { return &[]store.RequestUsageDailySummary{} }},
 	{Name: "request_usage_summary_days", Model: &store.RequestUsageSummaryDay{}, NewSlice: func() any { return &[]store.RequestUsageSummaryDay{} }},
+	{Name: "playground_conversations", Model: &store.PlaygroundConversation{}, NewSlice: func() any { return &[]store.PlaygroundConversation{} }},
+	{Name: "playground_runs", Model: &store.PlaygroundRun{}, NewSlice: func() any { return &[]store.PlaygroundRun{} }},
+	{Name: "playground_turn_indexes", Model: &store.PlaygroundTurnIndex{}, NewSlice: func() any { return &[]store.PlaygroundTurnIndex{} }},
+	{Name: "playground_assets", Model: &store.PlaygroundAsset{}, NewSlice: func() any { return &[]store.PlaygroundAsset{} }},
 }
 
 var importDeleteOrder = []string{
+	"playground_assets",
+	"playground_turn_indexes",
+	"playground_runs",
+	"playground_conversations",
 	"request_usage_summary_days",
 	"request_usage_daily_summaries",
 	"usage_records",
@@ -133,14 +145,23 @@ var textSecretColumns = map[string][]string{
 	"oauth_connections": {"encrypted_access_token", "encrypted_refresh_token", "encrypted_id_token"},
 }
 
-func exportDatabase(ctx context.Context, db *gorm.DB, masterKey string, zw *zip.Writer) (map[string]int, error) {
+func exportDatabase(ctx context.Context, db *gorm.DB, masterKey string, playgroundRoot string, zw *zip.Writer) (map[string]int, error) {
 	var rowCounts map[string]int
+	var conversations []store.PlaygroundConversation
+	var assets []store.PlaygroundAsset
 	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
 		rowCounts, err = exportDatabaseSnapshot(ctx, tx, masterKey, zw)
+		if err != nil {
+			return err
+		}
+		conversations, assets, err = listPlaygroundFileRefs(ctx, tx)
 		return err
 	}, &sql.TxOptions{ReadOnly: true, Isolation: sql.LevelRepeatableRead})
 	if err != nil {
+		return nil, err
+	}
+	if _, _, err := exportPlaygroundFileEntries(ctx, db, zw, playgroundRoot, conversations, assets); err != nil {
 		return nil, err
 	}
 	return rowCounts, nil
@@ -158,7 +179,7 @@ func exportDatabaseSnapshot(ctx context.Context, db *gorm.DB, masterKey string, 
 	return rowCounts, nil
 }
 
-func importDatabase(ctx context.Context, db *gorm.DB, masterKey string, dump databaseDump, progress ...ProgressFunc) (int, int, error) {
+func importDatabase(ctx context.Context, db *gorm.DB, masterKey string, dump databaseDump, adminID uuid.UUID, progress ...ProgressFunc) (int, int, error) {
 	if err := validateDumpTables(dump); err != nil {
 		return 0, 0, err
 	}
@@ -261,6 +282,9 @@ func importDatabase(ctx context.Context, db *gorm.DB, masterKey string, dump dat
 						row["created_by_admin_id"] = nil
 					}
 				}
+				if table.Name == "playground_conversations" && adminID != uuid.Nil {
+					reownPlaygroundConversations(rows, adminID)
+				}
 				if err := importTable(ctx, tx, table, rows, func(imported int) {
 					emit(ProgressEvent{Step: "import", Status: "in_progress", Rows: total + imported, TotalRows: progressTotal - skippedTotal, Table: table.Name})
 				}); err != nil {
@@ -343,7 +367,7 @@ func forEachArchiveTableChunk(archivePath string, tableName string, chunkSize in
 	name := path.Join("database", tableName+".jsonl")
 	file := archiveFile(zr.File, name)
 	if file == nil {
-		return fmt.Errorf("backup archive missing %s", name)
+		return nil
 	}
 	reader, err := file.Open()
 	if err != nil {
@@ -378,13 +402,9 @@ func forEachArchiveTableChunk(archivePath string, tableName string, chunkSize in
 }
 
 func exportTable(ctx context.Context, db *gorm.DB, table backupTable, masterKey string, zw *zip.Writer) (int, error) {
-	w, err := zw.CreateHeader(&zip.FileHeader{
-		Name:     path.Join("database", table.Name+".jsonl"),
-		Method:   zip.Deflate,
-		Modified: time.Now().UTC(),
-	})
+	w, err := createArchiveEntry(zw, path.Join("database", table.Name+".jsonl"), zip.Deflate)
 	if err != nil {
-		return 0, fmt.Errorf("write zip header %s: %w", table.Name, err)
+		return 0, err
 	}
 	encoder := json.NewEncoder(w)
 	rows, err := exportTableRows(ctx, db, table, masterKey, encoder)
@@ -580,7 +600,7 @@ func validateDumpTables(dump databaseDump) error {
 			continue
 		}
 		if _, ok := dump.Tables[table.Name]; !ok {
-			return fmt.Errorf("backup database payload missing table %s", table.Name)
+			dump.Tables[table.Name] = []map[string]any{}
 		}
 	}
 	return nil
@@ -867,4 +887,10 @@ func cloneRows(rows []map[string]any) []map[string]any {
 		out = append(out, next)
 	}
 	return out
+}
+
+func reownPlaygroundConversations(rows []map[string]any, adminID uuid.UUID) {
+	for _, row := range rows {
+		row["admin_id"] = adminID.String()
+	}
 }

--- a/server/internal/backup/database_helpers_test.go
+++ b/server/internal/backup/database_helpers_test.go
@@ -57,8 +57,12 @@ func TestValidateDumpTablesRequiresRegisteredTables(t *testing.T) {
 	for _, table := range backupTables[1:] {
 		dump.Tables[table.Name] = nil
 	}
-	if err := validateDumpTables(dump); err == nil || !strings.Contains(err.Error(), backupTables[0].Name) {
-		t.Fatalf("expected missing registered table to be named, got %v", err)
+	if err := validateDumpTables(dump); err != nil {
+		t.Fatalf("expected missing registered table to be tolerated, got %v", err)
+	}
+	filled, ok := dump.Tables[backupTables[0].Name]
+	if !ok || filled == nil || len(filled) != 0 {
+		t.Fatalf("expected missing table to be filled with empty rows, got %#v", filled)
 	}
 
 	dump.Tables[backupTables[0].Name] = nil

--- a/server/internal/backup/database_import_export_edges_test.go
+++ b/server/internal/backup/database_import_export_edges_test.go
@@ -19,7 +19,7 @@ import (
 func TestImportDatabaseRejectsInvalidDumpBeforeTransaction(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := importDatabase(context.Background(), nil, "master-key", databaseDump{})
+	_, _, err := importDatabase(context.Background(), nil, "master-key", databaseDump{}, uuid.Nil)
 	assertBackupErrorContains(t, "importDatabase invalid dump", err, "missing tables")
 }
 

--- a/server/internal/backup/database_stream_import_test.go
+++ b/server/internal/backup/database_stream_import_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -204,7 +205,7 @@ func TestImportDatabaseAdjustsProgressTotalForFilteredRows(t *testing.T) {
 		dump.Tables[table.Name] = nil
 	}
 	var last ProgressEvent
-	rows, totalRows, err := importDatabase(context.Background(), db, "master-key", dump, func(event ProgressEvent) {
+	rows, totalRows, err := importDatabase(context.Background(), db, "master-key", dump, uuid.Nil, func(event ProgressEvent) {
 		last = event
 	})
 	if err != nil {
@@ -215,12 +216,19 @@ func TestImportDatabaseAdjustsProgressTotalForFilteredRows(t *testing.T) {
 	}
 }
 
-func TestForEachArchiveTableChunkMissingEntryErrors(t *testing.T) {
+func TestForEachArchiveTableChunkMissingEntryYieldsNoRows(t *testing.T) {
 	t.Parallel()
 
 	archivePath := writeStreamTestArchive(t, 1)
-	err := forEachArchiveTableChunk(archivePath, "usage_records", 2, func([]map[string]any) error { return nil })
-	if err == nil {
-		t.Fatal("expected error for missing table entry")
+	calls := 0
+	err := forEachArchiveTableChunk(archivePath, "usage_records", 2, func([]map[string]any) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected missing table entry to be tolerated, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no chunks for missing table entry, got %d", calls)
 	}
 }

--- a/server/internal/backup/import_export_passphrase_edges_test.go
+++ b/server/internal/backup/import_export_passphrase_edges_test.go
@@ -10,7 +10,7 @@ func TestImportRejectsDamagedEncryptedPayloadBeforeDatabaseImport(t *testing.T) 
 
 	service := backupImportExportService(t)
 
-	summary, err := service.Import(context.Background(), "passphrase", []byte("not an encrypted backup"))
+	summary, err := service.Import(context.Background(), "passphrase", []byte("not an encrypted backup"), ImportOptions{})
 	assertBackupErrorContains(t, "Import damaged payload", err, "unsupported backup format")
 	if summary != (ImportSummary{}) {
 		t.Fatalf("Import damaged payload summary = %#v, want zero", summary)

--- a/server/internal/backup/playground_files.go
+++ b/server/internal/backup/playground_files.go
@@ -1,0 +1,283 @@
+package backup
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"xlyra/server/internal/store"
+)
+
+const (
+	playgroundArchivePrefix = "playground/"
+	maxPlaygroundFileBytes  = 1 << 30
+	maxPlaygroundTotalBytes = 4 << 30
+)
+
+var playgroundDirs = []string{"sessions", "assets"}
+
+func listPlaygroundFileRefs(ctx context.Context, db *gorm.DB) ([]store.PlaygroundConversation, []store.PlaygroundAsset, error) {
+	var conversations []store.PlaygroundConversation
+	if err := db.WithContext(ctx).Find(&conversations).Error; err != nil {
+		return nil, nil, fmt.Errorf("list playground conversations for file export: %w", err)
+	}
+	var assets []store.PlaygroundAsset
+	if err := db.WithContext(ctx).Find(&assets).Error; err != nil {
+		return nil, nil, fmt.Errorf("list playground assets for file export: %w", err)
+	}
+	return conversations, assets, nil
+}
+
+func exportPlaygroundFileEntries(ctx context.Context, db *gorm.DB, zw *zip.Writer, root string, conversations []store.PlaygroundConversation, assets []store.PlaygroundAsset) (int, int64, error) {
+	files := 0
+	var total int64
+	for _, conversation := range conversations {
+		relPath, err := cleanArchivedRelativePath(conversation.RolloutPath)
+		if err != nil {
+			return files, total, fmt.Errorf("export rollout for conversation %s: %w", conversation.ID, err)
+		}
+		if conversation.LastByteOffset <= 0 {
+			continue
+		}
+		written, copyErr := zipPlaygroundFile(zw, relPath, filepath.Join(root, filepath.FromSlash(relPath)), conversation.LastByteOffset)
+		short := copyErr == nil && written < conversation.LastByteOffset
+		if copyErr != nil || short {
+			if playgroundRowGone(ctx, db, &store.PlaygroundConversation{}, &store.PlaygroundConversation{ID: conversation.ID}) {
+				continue
+			}
+			if copyErr != nil {
+				return files, total, fmt.Errorf("export rollout for conversation %s: %w", conversation.ID, copyErr)
+			}
+			return files, total, fmt.Errorf("export rollout for conversation %s: file shorter than recorded cursor (%d < %d)", conversation.ID, written, conversation.LastByteOffset)
+		}
+		files++
+		total += written
+	}
+	for _, asset := range assets {
+		relPath, err := cleanArchivedRelativePath(asset.Path)
+		if err != nil {
+			return files, total, fmt.Errorf("export playground asset %s: %w", asset.ID, err)
+		}
+		written, err := zipPlaygroundFile(zw, relPath, filepath.Join(root, filepath.FromSlash(relPath)), -1)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) && playgroundRowGone(ctx, db, &store.PlaygroundAsset{}, &store.PlaygroundAsset{ID: asset.ID}) {
+				continue
+			}
+			return files, total, fmt.Errorf("export playground asset %s: %w", asset.ID, err)
+		}
+		files++
+		total += written
+	}
+	return files, total, nil
+}
+
+func playgroundRowGone(ctx context.Context, db *gorm.DB, model any, condition any) bool {
+	if db == nil {
+		return false
+	}
+	var count int64
+	if err := db.WithContext(ctx).Model(model).Where(condition).Count(&count).Error; err != nil {
+		return false
+	}
+	return count == 0
+}
+
+func cleanArchivedRelativePath(relPath string) (string, error) {
+	relPath = strings.TrimSpace(filepath.ToSlash(relPath))
+	clean := path.Clean(relPath)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) || strings.ContainsRune(relPath, '\\') {
+		return "", fmt.Errorf("invalid relative path %q", relPath)
+	}
+	return clean, nil
+}
+
+func zipPlaygroundFile(zw *zip.Writer, relPath string, absPath string, limit int64) (int64, error) {
+	file, err := os.Open(absPath)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", relPath, err)
+	}
+	defer file.Close()
+
+	w, err := createArchiveEntry(zw, playgroundArchivePrefix+relPath, zipMethodForFile(relPath))
+	if err != nil {
+		return 0, err
+	}
+	source := io.Reader(file)
+	if limit >= 0 {
+		source = io.LimitReader(file, limit)
+	}
+	written, err := io.Copy(w, source)
+	if err != nil {
+		return written, fmt.Errorf("copy %s: %w", relPath, err)
+	}
+	return written, nil
+}
+
+func zipMethodForFile(relPath string) uint16 {
+	switch strings.ToLower(path.Ext(relPath)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".mp4", ".webm", ".zip", ".gz":
+		return zip.Store
+	default:
+		return zip.Deflate
+	}
+}
+
+func restorePlaygroundFiles(archivePath string, root string, progress func(int64)) (int, int64, error) {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("open backup archive: %w", err)
+	}
+	defer zr.Close()
+
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		return 0, 0, fmt.Errorf("create playground root: %w", err)
+	}
+	staging, err := os.MkdirTemp(root, ".restore-staging-")
+	if err != nil {
+		return 0, 0, fmt.Errorf("create playground restore staging: %w", err)
+	}
+	defer os.RemoveAll(staging)
+
+	files := 0
+	var total int64
+	for _, entry := range zr.File {
+		if !strings.HasPrefix(entry.Name, playgroundArchivePrefix) {
+			continue
+		}
+		written, isFile, err := extractPlaygroundEntry(entry, staging)
+		if err != nil {
+			return files, total, err
+		}
+		if !isFile {
+			continue
+		}
+		files++
+		total += written
+		if total > maxPlaygroundTotalBytes {
+			return files, total, fmt.Errorf("playground payload exceeds maximum total size")
+		}
+		if progress != nil {
+			progress(total)
+		}
+	}
+
+	if err := swapPlaygroundDirs(root, staging); err != nil {
+		return files, total, err
+	}
+	return files, total, nil
+}
+
+func extractPlaygroundEntry(entry *zip.File, staging string) (int64, bool, error) {
+	relPath, err := cleanArchivePlaygroundPath(entry.Name)
+	if err != nil {
+		return 0, false, err
+	}
+	if relPath == "" {
+		return 0, false, nil
+	}
+	if entry.UncompressedSize64 > maxPlaygroundFileBytes {
+		return 0, false, fmt.Errorf("playground file %s exceeds maximum size", relPath)
+	}
+	reader, err := entry.Open()
+	if err != nil {
+		return 0, false, fmt.Errorf("open archived playground file %s: %w", relPath, err)
+	}
+	defer reader.Close()
+
+	target := filepath.Join(staging, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return 0, false, fmt.Errorf("create playground directory for %s: %w", relPath, err)
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
+	if err != nil {
+		return 0, false, fmt.Errorf("create playground file %s: %w", relPath, err)
+	}
+	written, copyErr := io.Copy(out, io.LimitReader(reader, maxPlaygroundFileBytes+1))
+	closeErr := out.Close()
+	if copyErr != nil {
+		return 0, false, fmt.Errorf("extract playground file %s: %w", relPath, copyErr)
+	}
+	if closeErr != nil {
+		return 0, false, fmt.Errorf("close playground file %s: %w", relPath, closeErr)
+	}
+	if written > maxPlaygroundFileBytes {
+		return 0, false, fmt.Errorf("playground file %s exceeds maximum size", relPath)
+	}
+	return written, true, nil
+}
+
+func cleanArchivePlaygroundPath(name string) (string, error) {
+	relPath := strings.TrimPrefix(name, playgroundArchivePrefix)
+	clean := path.Clean(relPath)
+	if clean == "." {
+		return "", nil
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) || strings.ContainsRune(relPath, '\\') {
+		return "", fmt.Errorf("backup archive contains invalid playground path %q", name)
+	}
+	top, _, _ := strings.Cut(clean, "/")
+	if !slices.Contains(playgroundDirs, top) {
+		return "", fmt.Errorf("backup archive contains unexpected playground path %q", name)
+	}
+	if strings.HasSuffix(name, "/") {
+		return "", nil
+	}
+	return clean, nil
+}
+
+func swapPlaygroundDirs(root string, staging string) error {
+	trashed := make([]string, 0, len(playgroundDirs))
+	rollback := func() {
+		for _, dir := range trashed {
+			_ = os.Rename(filepath.Join(root, ".trash-"+dir), filepath.Join(root, dir))
+		}
+	}
+	for _, dir := range playgroundDirs {
+		current := filepath.Join(root, dir)
+		trash := filepath.Join(root, ".trash-"+dir)
+		_ = os.RemoveAll(trash)
+		if !dirExists(current) {
+			continue
+		}
+		if err := os.Rename(current, trash); err != nil {
+			rollback()
+			return fmt.Errorf("set aside existing playground %s: %w", dir, err)
+		}
+		trashed = append(trashed, dir)
+	}
+	installed := make([]string, 0, len(playgroundDirs))
+	for _, dir := range playgroundDirs {
+		staged := filepath.Join(staging, dir)
+		if !dirExists(staged) {
+			continue
+		}
+		if err := os.Rename(staged, filepath.Join(root, dir)); err != nil {
+			for _, done := range installed {
+				_ = os.RemoveAll(filepath.Join(root, done))
+			}
+			rollback()
+			return fmt.Errorf("install restored playground %s: %w", dir, err)
+		}
+		installed = append(installed, dir)
+	}
+	for _, dir := range trashed {
+		if err := os.RemoveAll(filepath.Join(root, ".trash-"+dir)); err != nil {
+			return fmt.Errorf("remove previous playground %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func dirExists(path string) bool {
+	stat, err := os.Stat(path)
+	return err == nil && stat.IsDir()
+}

--- a/server/internal/backup/playground_files_test.go
+++ b/server/internal/backup/playground_files_test.go
@@ -1,0 +1,326 @@
+package backup
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+func writePlaygroundTestFile(t *testing.T, root string, relPath string, content string) {
+	t.Helper()
+	absPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o750); err != nil {
+		t.Fatalf("create test file dir: %v", err)
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o640); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+}
+
+func readZipEntry(t *testing.T, archivePath string, name string) string {
+	t.Helper()
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer zr.Close()
+	file := archiveFile(zr.File, name)
+	if file == nil {
+		names := make([]string, 0, len(zr.File))
+		for _, entry := range zr.File {
+			names = append(names, entry.Name)
+		}
+		t.Fatalf("archive entry %s not found in %#v", name, names)
+	}
+	reader, err := file.Open()
+	if err != nil {
+		t.Fatalf("open archive entry %s: %v", name, err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read archive entry %s: %v", name, err)
+	}
+	return string(data)
+}
+
+func zipEntryMethod(t *testing.T, archivePath string, name string) uint16 {
+	t.Helper()
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer zr.Close()
+	file := archiveFile(zr.File, name)
+	if file == nil {
+		t.Fatalf("archive entry %s not found", name)
+	}
+	return file.Method
+}
+
+func TestExportPlaygroundFileEntriesTruncatesRolloutAtCursor(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	line1 := `{"ordinal":1,"type":"session_meta"}` + "\n"
+	line2 := `{"ordinal":2,"type":"message_added"}` + "\n"
+	relPath := "sessions/2026/08/24/rollout-test.jsonl"
+	writePlaygroundTestFile(t, root, relPath, line1+line2)
+	assetRel := "assets/conv-1/generated-images/asset-1.png"
+	writePlaygroundTestFile(t, root, assetRel, "png-bytes")
+
+	conversationID := uuid.New()
+	assetID := uuid.New()
+	conversations := []store.PlaygroundConversation{{
+		ID:             conversationID,
+		RolloutPath:    relPath,
+		LastByteOffset: int64(len(line1)),
+	}}
+	assets := []store.PlaygroundAsset{{ID: assetID, ConversationID: conversationID, Path: assetRel}}
+
+	archivePath := filepath.Join(t.TempDir(), "files.zip")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(out)
+	files, total, err := exportPlaygroundFileEntries(context.Background(), nil, zw, root, conversations, assets)
+	if err != nil {
+		t.Fatalf("export playground files: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive file: %v", err)
+	}
+
+	if files != 2 {
+		t.Fatalf("expected 2 exported files, got %d", files)
+	}
+	if total != int64(len(line1)+len("png-bytes")) {
+		t.Fatalf("unexpected exported bytes: %d", total)
+	}
+	if got := readZipEntry(t, archivePath, "playground/"+relPath); got != line1 {
+		t.Fatalf("rollout not truncated at cursor:\n got %q\nwant %q", got, line1)
+	}
+	if got := readZipEntry(t, archivePath, "playground/"+assetRel); got != "png-bytes" {
+		t.Fatalf("asset payload mismatch: %q", got)
+	}
+	if method := zipEntryMethod(t, archivePath, "playground/"+relPath); method != zip.Deflate {
+		t.Fatalf("expected rollout to use deflate, got method %d", method)
+	}
+	if method := zipEntryMethod(t, archivePath, "playground/"+assetRel); method != zip.Store {
+		t.Fatalf("expected image asset to be stored uncompressed, got method %d", method)
+	}
+}
+
+func TestExportPlaygroundFileEntriesRejectsInconsistentSources(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	relPath := "sessions/2026/08/24/rollout-test.jsonl"
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	conversations := []store.PlaygroundConversation{{ID: uuid.New(), RolloutPath: relPath, LastByteOffset: 10}}
+	if _, _, err := exportPlaygroundFileEntries(context.Background(), nil, zw, root, conversations, nil); err == nil || !strings.Contains(err.Error(), "open") {
+		t.Fatalf("expected missing rollout error, got %v", err)
+	}
+
+	writePlaygroundTestFile(t, root, relPath, "short\n")
+	buf.Reset()
+	zw = zip.NewWriter(&buf)
+	if _, _, err := exportPlaygroundFileEntries(context.Background(), nil, zw, root, conversations, nil); err == nil || !strings.Contains(err.Error(), "shorter than recorded cursor") {
+		t.Fatalf("expected short rollout error, got %v", err)
+	}
+
+	buf.Reset()
+	zw = zip.NewWriter(&buf)
+	conversations[0].RolloutPath = "../outside.jsonl"
+	if _, _, err := exportPlaygroundFileEntries(context.Background(), nil, zw, root, conversations, nil); err == nil || !strings.Contains(err.Error(), "invalid relative path") {
+		t.Fatalf("expected traversal error, got %v", err)
+	}
+}
+
+func TestRestorePlaygroundFilesReplacesDirectories(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "files.zip")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(out)
+	for name, content := range map[string]string{
+		"playground/sessions/2026/08/24/rollout-new.jsonl": "new-rollout\n",
+		"playground/assets/conv-1/generated-images/a.png":  "new-asset",
+		"manifest.json": "{}",
+	} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create archive entry: %v", err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("write archive entry: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive file: %v", err)
+	}
+
+	root := t.TempDir()
+	writePlaygroundTestFile(t, root, "sessions/2026/01/01/rollout-old.jsonl", "old-rollout\n")
+	writePlaygroundTestFile(t, root, "assets/conv-old/generated-images/old.png", "old-asset")
+	writePlaygroundTestFile(t, root, "thread-writer-locks/conv-old.lock", "")
+
+	var progressed int64
+	files, total, err := restorePlaygroundFiles(archivePath, root, func(bytes int64) { progressed = bytes })
+	if err != nil {
+		t.Fatalf("restore playground files: %v", err)
+	}
+	if files != 2 {
+		t.Fatalf("expected 2 restored files, got %d", files)
+	}
+	if total != int64(len("new-rollout\n")+len("new-asset")) || progressed != total {
+		t.Fatalf("unexpected restored bytes %d (progress %d)", total, progressed)
+	}
+
+	restored, err := os.ReadFile(filepath.Join(root, "sessions", "2026", "08", "24", "rollout-new.jsonl"))
+	if err != nil || string(restored) != "new-rollout\n" {
+		t.Fatalf("restored rollout mismatch: %q, %v", restored, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "sessions", "2026", "01", "01", "rollout-old.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale rollout to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "assets", "conv-old")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale assets to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "thread-writer-locks", "conv-old.lock")); err != nil {
+		t.Fatalf("expected transient lock directory to survive: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(root, "assets", "conv-1", "generated-images", "a.png"))
+	if err != nil {
+		t.Fatalf("restored asset missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("expected 0640 permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestRestorePlaygroundFilesClearsDirectoriesWithoutPayload(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "empty.zip")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(out)
+	w, err := zw.Create("manifest.json")
+	if err != nil {
+		t.Fatalf("create manifest entry: %v", err)
+	}
+	if _, err := w.Write([]byte("{}")); err != nil {
+		t.Fatalf("write manifest entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive file: %v", err)
+	}
+
+	root := t.TempDir()
+	writePlaygroundTestFile(t, root, "sessions/2026/01/01/rollout-old.jsonl", "old\n")
+	writePlaygroundTestFile(t, root, "assets/conv-old/generated-images/old.png", "old")
+
+	files, total, err := restorePlaygroundFiles(archivePath, root, nil)
+	if err != nil {
+		t.Fatalf("restore playground files: %v", err)
+	}
+	if files != 0 || total != 0 {
+		t.Fatalf("expected no restored files, got %d files %d bytes", files, total)
+	}
+	for _, dir := range playgroundDirs {
+		if entries, err := os.ReadDir(filepath.Join(root, dir)); err == nil && len(entries) > 0 {
+			t.Fatalf("expected %s to be empty after restore, found %d entries", dir, len(entries))
+		}
+	}
+}
+
+func TestRestorePlaygroundFilesRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"parent traversal": "playground/../evil.txt",
+		"nested traversal": "playground/sessions/../../evil.txt",
+		"unexpected dir":   "playground/other/file.txt",
+		"backslash":        `playground/sessions\evil.txt`,
+		"absolute":         "playground//etc/passwd",
+	}
+	for name, entryName := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			writePlaygroundTestFile(t, root, "sessions/existing.jsonl", "keep\n")
+
+			archivePath := filepath.Join(t.TempDir(), "evil.zip")
+			out, err := os.Create(archivePath)
+			if err != nil {
+				t.Fatalf("create archive: %v", err)
+			}
+			zw := zip.NewWriter(out)
+			w, err := zw.Create(entryName)
+			if err != nil {
+				t.Fatalf("create archive entry: %v", err)
+			}
+			if _, err := w.Write([]byte("evil")); err != nil {
+				t.Fatalf("write archive entry: %v", err)
+			}
+			if err := zw.Close(); err != nil {
+				t.Fatalf("close archive: %v", err)
+			}
+			if err := out.Close(); err != nil {
+				t.Fatalf("close archive file: %v", err)
+			}
+
+			if _, _, err := restorePlaygroundFiles(archivePath, root, nil); err == nil || !strings.Contains(err.Error(), "playground path") {
+				t.Fatalf("expected invalid path error, got %v", err)
+			}
+			content, err := os.ReadFile(filepath.Join(root, "sessions", "existing.jsonl"))
+			if err != nil || string(content) != "keep\n" {
+				t.Fatalf("existing session file modified: %q, %v", content, err)
+			}
+		})
+	}
+}
+
+func TestReownPlaygroundConversations(t *testing.T) {
+	t.Parallel()
+
+	adminID := uuid.New()
+	rows := []map[string]any{
+		{"id": uuid.New().String(), "admin_id": uuid.New().String()},
+		{"id": uuid.New().String(), "admin_id": nil},
+	}
+	reownPlaygroundConversations(rows, adminID)
+	for i, row := range rows {
+		if row["admin_id"] != adminID.String() {
+			t.Fatalf("row %d admin_id = %#v, want %s", i, row["admin_id"], adminID)
+		}
+	}
+}

--- a/server/internal/backup/service.go
+++ b/server/internal/backup/service.go
@@ -10,29 +10,41 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"xlyra/server/internal/config"
 	"xlyra/server/internal/store"
 )
 
 const (
-	currentFormatVersion       = 2
-	backupAppName              = "xlyra"
-	MaxImportBytes       int64 = 512 << 20
+	currentFormatVersion         = 3
+	minImportFormatVersion       = 2
+	backupAppName                = "xlyra"
+	MaxImportBytes         int64 = 2 << 30
 )
 
 type Service struct {
-	db        *store.Store
-	confFile  *config.ConfigFile
-	masterKey string
-	now       func() time.Time
-	timeZone  config.TimeZone
+	db             *store.Store
+	confFile       *config.ConfigFile
+	masterKey      string
+	playgroundRoot string
+	preRestore     func(context.Context) error
+	postRestore    func(context.Context) error
+	now            func() time.Time
+	timeZone       config.TimeZone
 }
 
 type ImportSummary struct {
-	Tables        int `json:"tables"`
-	Rows          int `json:"rows"`
-	ConfigKeys    int `json:"config_keys"`
-	FormatVersion int `json:"format_version"`
+	Tables        int   `json:"tables"`
+	Rows          int   `json:"rows"`
+	ConfigKeys    int   `json:"config_keys"`
+	FormatVersion int   `json:"format_version"`
+	Files         int   `json:"files"`
+	FileBytes     int64 `json:"file_bytes"`
+}
+
+type ImportOptions struct {
+	AdminID uuid.UUID
 }
 
 type ProgressEvent struct {
@@ -49,14 +61,21 @@ type ProgressEvent struct {
 
 type ProgressFunc func(ProgressEvent)
 
-func NewService(db *store.Store, confFile *config.ConfigFile, masterKey string, timeZones ...config.TimeZone) Service {
+func NewService(db *store.Store, confFile *config.ConfigFile, masterKey string, playgroundRoot string, timeZones ...config.TimeZone) Service {
 	return Service{
-		db:        db,
-		confFile:  confFile,
-		masterKey: masterKey,
-		now:       func() time.Time { return time.Now().UTC() },
-		timeZone:  backupTimeZone(timeZones...),
+		db:             db,
+		confFile:       confFile,
+		masterKey:      masterKey,
+		playgroundRoot: playgroundRoot,
+		now:            func() time.Time { return time.Now().UTC() },
+		timeZone:       backupTimeZone(timeZones...),
 	}
+}
+
+func (s Service) WithRestoreHooks(pre func(context.Context) error, post func(context.Context) error) Service {
+	s.preRestore = pre
+	s.postRestore = post
+	return s
 }
 
 func (s Service) Export(ctx context.Context, passphrase string) (string, string, error) {
@@ -97,7 +116,7 @@ func (s Service) exportAt(ctx context.Context, passphrase string, createdAt time
 	writeErrs := make(chan error, 1)
 	go func() {
 		writeErr := writeArchive(payload, func(zw *zip.Writer) (map[string]int, error) {
-			return exportDatabase(ctx, s.db.DB(), s.masterKey, zw)
+			return exportDatabase(ctx, s.db.DB(), s.masterKey, s.playgroundRoot, zw)
 		}, plainWriter)
 		if writeErr != nil {
 			_ = plainWriter.CloseWithError(writeErr)
@@ -126,6 +145,13 @@ func (s Service) exportAt(ctx context.Context, passphrase string, createdAt time
 	if closeEncryptedErr != nil {
 		return "", "", fmt.Errorf("close encrypted backup: %w", closeEncryptedErr)
 	}
+	stat, err := os.Stat(encryptedPath)
+	if err != nil {
+		return "", "", fmt.Errorf("stat encrypted backup: %w", err)
+	}
+	if stat.Size() > MaxImportBytes {
+		return "", "", fmt.Errorf("backup size %d exceeds maximum restorable size %d", stat.Size(), MaxImportBytes)
+	}
 
 	success = true
 	return encryptedPath, s.backupFilename(createdAt), nil
@@ -139,7 +165,7 @@ func backupTimeZone(timeZones ...config.TimeZone) config.TimeZone {
 	return config.TimeZoneOrDefault(timeZones...)
 }
 
-func (s Service) Import(ctx context.Context, passphrase string, encrypted []byte, progress ...ProgressFunc) (ImportSummary, error) {
+func (s Service) Import(ctx context.Context, passphrase string, encrypted []byte, opts ImportOptions, progress ...ProgressFunc) (ImportSummary, error) {
 	if err := s.ready(); err != nil {
 		return ImportSummary{}, err
 	}
@@ -194,14 +220,50 @@ func (s Service) Import(ctx context.Context, passphrase string, encrypted []byte
 	defer preparedConfig.Discard()
 
 	emit(ProgressEvent{Step: "parse", Status: "complete", TotalRows: dbDump.TotalRows})
+
+	quiesced := false
+	if s.preRestore != nil {
+		if err := s.preRestore(ctx); err != nil {
+			return ImportSummary{}, fmt.Errorf("prepare restore: %w", err)
+		}
+		quiesced = true
+	}
+	converge := func() {
+		if quiesced && s.postRestore != nil {
+			_ = s.postRestore(ctx)
+		}
+	}
+
 	emit(ProgressEvent{Step: "import", Status: "in_progress", TotalRows: dbDump.TotalRows, Message: "Writing backup data to database"})
 
-	importedRows, totalRows, err := importDatabase(ctx, s.db.DB(), s.masterKey, dbDump, prog)
+	importedRows, totalRows, err := importDatabase(ctx, s.db.DB(), s.masterKey, dbDump, opts.AdminID, prog)
 	if err != nil {
+		converge()
 		return ImportSummary{}, err
 	}
 
 	emit(ProgressEvent{Step: "import", Status: "complete", Rows: importedRows, TotalRows: totalRows})
+	emit(ProgressEvent{Step: "files", Status: "in_progress", Message: "Restoring playground session files"})
+
+	lastFileProgress := int64(0)
+	restoredFiles, restoredBytes, err := restorePlaygroundFiles(archivePath, s.playgroundRoot, func(restored int64) {
+		if restored-lastFileProgress >= 4<<20 {
+			lastFileProgress = restored
+			emit(ProgressEvent{Step: "files", Status: "in_progress", Bytes: restored})
+		}
+	})
+	if err != nil {
+		converge()
+		return ImportSummary{}, err
+	}
+
+	emit(ProgressEvent{Step: "files", Status: "complete", Bytes: restoredBytes})
+
+	if s.postRestore != nil {
+		if err := s.postRestore(ctx); err != nil {
+			return ImportSummary{}, fmt.Errorf("finish restore: %w", err)
+		}
+	}
 
 	if err := preparedConfig.Commit(); err != nil {
 		return ImportSummary{}, fmt.Errorf("replace config: %w", err)
@@ -212,6 +274,8 @@ func (s Service) Import(ctx context.Context, passphrase string, encrypted []byte
 		Rows:          importedRows,
 		ConfigKeys:    len(payload.Config),
 		FormatVersion: payload.Manifest.FormatVersion,
+		Files:         restoredFiles,
+		FileBytes:     restoredBytes,
 	}
 	emit(ProgressEvent{Step: "complete", Status: "complete", Rows: importedRows, TotalRows: totalRows, Summary: &summary})
 
@@ -235,17 +299,25 @@ func validateManifest(value manifest) error {
 	if value.App != backupAppName {
 		return fmt.Errorf("backup app mismatch")
 	}
-	if value.FormatVersion != currentFormatVersion {
+	if value.FormatVersion < minImportFormatVersion || value.FormatVersion > currentFormatVersion {
 		return fmt.Errorf("unsupported backup format version %d", value.FormatVersion)
 	}
 	if value.Payload != backupPayload {
 		return fmt.Errorf("unsupported backup payload %q", value.Payload)
 	}
-	if len(value.Tables) != len(exportTables) {
-		return fmt.Errorf("backup table list mismatch")
+	if value.FormatVersion == currentFormatVersion {
+		if len(value.Tables) != len(exportTables) {
+			return fmt.Errorf("backup table list mismatch")
+		}
+		for i, table := range exportTables {
+			if value.Tables[i] != table {
+				return fmt.Errorf("backup table list mismatch")
+			}
+		}
+		return nil
 	}
-	for i, table := range exportTables {
-		if value.Tables[i] != table {
+	for _, table := range value.Tables {
+		if _, ok := backupTableByName(table); !ok {
 			return fmt.Errorf("backup table list mismatch")
 		}
 	}

--- a/server/internal/backup/service_validation_and_row_mapping_test.go
+++ b/server/internal/backup/service_validation_and_row_mapping_test.go
@@ -24,13 +24,13 @@ func TestServiceValidatesPassphraseAndImportPayloadAfterReadiness(t *testing.T) 
 	}
 	assertBackupErrorContains(t, "exportAt blank passphrase", err, "backup passphrase is required")
 
-	summary, err := service.Import(context.Background(), "  ", []byte("encrypted"))
+	summary, err := service.Import(context.Background(), "  ", []byte("encrypted"), ImportOptions{})
 	if summary != (ImportSummary{}) {
 		t.Fatalf("Import blank passphrase summary=%#v, want zero", summary)
 	}
 	assertBackupErrorContains(t, "Import blank passphrase", err, "backup passphrase is required")
 
-	summary, err = service.Import(context.Background(), "passphrase", nil)
+	summary, err = service.Import(context.Background(), "passphrase", nil, ImportOptions{})
 	if summary != (ImportSummary{}) {
 		t.Fatalf("Import empty file summary=%#v, want zero", summary)
 	}

--- a/server/internal/backup/table_metadata_and_field_values_test.go
+++ b/server/internal/backup/table_metadata_and_field_values_test.go
@@ -26,7 +26,7 @@ func TestImportChecksReadinessBeforeReadingBackupPayload(t *testing.T) {
 
 	service := Service{db: &store.Store{}, confFile: nil, masterKey: "master-key"}
 
-	_, err := service.Import(context.Background(), "passphrase", []byte("encrypted"))
+	_, err := service.Import(context.Background(), "passphrase", []byte("encrypted"), ImportOptions{})
 	assertBackupErrorContains(t, "Import readiness", err, "database is not available")
 }
 

--- a/server/internal/playground/handler.go
+++ b/server/internal/playground/handler.go
@@ -260,5 +260,9 @@ func (h Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {
 		status = http.StatusRequestTimeout
 		code = "request_cancelled"
 	}
+	if errors.Is(err, ErrPlaygroundRestoring) {
+		status = http.StatusConflict
+		code = "playground_restoring"
+	}
 	httpx.Error(w, r, status, code, err.Error())
 }

--- a/server/internal/playground/restore_test.go
+++ b/server/internal/playground/restore_test.go
@@ -1,0 +1,86 @@
+package playground
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/store"
+)
+
+func TestQuiesceForRestoreCancelsRunsAndClearsState(t *testing.T) {
+	t.Parallel()
+
+	runID := uuid.New()
+	conversationID := uuid.New()
+	cancelled := false
+	finished := make(chan struct{})
+	service := &Service{
+		cancels: map[uuid.UUID]context.CancelFunc{
+			runID: func() { cancelled = true },
+		},
+		finishes: map[uuid.UUID]chan struct{}{runID: finished},
+		turns:    map[uuid.UUID]*sync.Mutex{conversationID: {}},
+		runs:     map[uuid.UUID]store.PlaygroundRun{conversationID: {ID: runID}},
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(finished)
+	}()
+
+	if err := service.QuiesceForRestore(context.Background()); err != nil {
+		t.Fatalf("quiesce for restore: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("expected active run to be cancelled")
+	}
+	if len(service.runs) != 0 || len(service.turns) != 0 {
+		t.Fatalf("expected in-memory state cleared, got runs=%d turns=%d", len(service.runs), len(service.turns))
+	}
+	if !service.restoring {
+		t.Fatal("expected restoring gate to be set after quiesce")
+	}
+}
+
+func TestQuiesceForRestoreWithoutActiveRuns(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		cancels:  map[uuid.UUID]context.CancelFunc{},
+		finishes: map[uuid.UUID]chan struct{}{},
+		turns:    map[uuid.UUID]*sync.Mutex{},
+		runs:     map[uuid.UUID]store.PlaygroundRun{},
+	}
+	if err := service.QuiesceForRestore(context.Background()); err != nil {
+		t.Fatalf("quiesce without runs: %v", err)
+	}
+}
+
+func TestStartTurnRejectedWhileRestoring(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{restoring: true}
+	if _, err := service.StartTurn(context.Background(), uuid.New(), uuid.New(), TurnRequest{Mode: ModeChat}); !errors.Is(err, ErrPlaygroundRestoring) {
+		t.Fatalf("expected restoring error, got %v", err)
+	}
+}
+
+func TestQuiesceForRestoreRejectsConcurrentRestore(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		restoring: true,
+		cancels:   map[uuid.UUID]context.CancelFunc{},
+		finishes:  map[uuid.UUID]chan struct{}{},
+		turns:     map[uuid.UUID]*sync.Mutex{},
+		runs:      map[uuid.UUID]store.PlaygroundRun{},
+	}
+	if err := service.QuiesceForRestore(context.Background()); !errors.Is(err, ErrPlaygroundRestoring) {
+		t.Fatalf("expected restoring error, got %v", err)
+	}
+}

--- a/server/internal/playground/service.go
+++ b/server/internal/playground/service.go
@@ -21,18 +21,21 @@ import (
 )
 
 type Service struct {
-	logger   *slog.Logger
-	db       *store.Store
-	repo     store.PlaygroundRepository
-	rollout  *RolloutStore
-	assets   *AssetStore
-	gateway  gateway.Handler
-	mu       sync.Mutex
-	cancels  map[uuid.UUID]context.CancelFunc
-	finishes map[uuid.UUID]chan struct{}
-	turns    map[uuid.UUID]*sync.Mutex
-	runs     map[uuid.UUID]store.PlaygroundRun
+	logger    *slog.Logger
+	db        *store.Store
+	repo      store.PlaygroundRepository
+	rollout   *RolloutStore
+	assets    *AssetStore
+	gateway   gateway.Handler
+	mu        sync.Mutex
+	cancels   map[uuid.UUID]context.CancelFunc
+	finishes  map[uuid.UUID]chan struct{}
+	turns     map[uuid.UUID]*sync.Mutex
+	runs      map[uuid.UUID]store.PlaygroundRun
+	restoring bool
 }
+
+var ErrPlaygroundRestoring = errors.New("playground is restoring from a backup")
 
 func NewService(logger *slog.Logger, db *store.Store, gatewayHandler gateway.Handler, root string) *Service {
 	if db == nil {
@@ -175,6 +178,70 @@ func (s *Service) recoverActiveRuns() {
 	}
 }
 
+func (s *Service) QuiesceForRestore(ctx context.Context) error {
+	s.mu.Lock()
+	if s.restoring {
+		s.mu.Unlock()
+		return ErrPlaygroundRestoring
+	}
+	s.restoring = true
+	cancels := make([]context.CancelFunc, 0, len(s.cancels))
+	for _, cancel := range s.cancels {
+		cancels = append(cancels, cancel)
+	}
+	s.mu.Unlock()
+
+	finished := false
+	defer func() {
+		if !finished {
+			s.mu.Lock()
+			s.restoring = false
+			s.mu.Unlock()
+		}
+	}()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+
+	s.mu.Lock()
+	finishes := make([]chan struct{}, 0, len(s.finishes))
+	for _, done := range s.finishes {
+		finishes = append(finishes, done)
+	}
+	s.mu.Unlock()
+	deadline := time.After(30 * time.Second)
+	for _, done := range finishes {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for playground runs to stop")
+		}
+	}
+
+	s.resetRunState()
+	finished = true
+	return nil
+}
+
+func (s *Service) RecoverAfterRestore(_ context.Context) error {
+	s.mu.Lock()
+	s.restoring = false
+	s.mu.Unlock()
+	s.resetRunState()
+	s.recoverActiveRuns()
+	return nil
+}
+
+func (s *Service) resetRunState() {
+	s.mu.Lock()
+	s.runs = map[uuid.UUID]store.PlaygroundRun{}
+	s.turns = map[uuid.UUID]*sync.Mutex{}
+	s.mu.Unlock()
+}
+
 func (s *Service) List(ctx context.Context, adminID uuid.UUID, mode string) ([]ConversationView, error) {
 	items, err := s.repo.ListConversations(ctx, adminID, mode, 50)
 	if err != nil {
@@ -235,6 +302,12 @@ func (s *Service) Events(ctx context.Context, adminID uuid.UUID, id uuid.UUID, o
 }
 
 func (s *Service) StartTurn(ctx context.Context, adminID uuid.UUID, conversationID uuid.UUID, input TurnRequest) (ConversationView, error) {
+	s.mu.Lock()
+	restoring := s.restoring
+	s.mu.Unlock()
+	if restoring {
+		return ConversationView{}, ErrPlaygroundRestoring
+	}
 	if input.Mode != ModeChat && input.Mode != ModeImage {
 		return ConversationView{}, fmt.Errorf("unsupported playground mode")
 	}

--- a/server/internal/settings/handler.go
+++ b/server/internal/settings/handler.go
@@ -51,10 +51,10 @@ func NewHandler(logger *slog.Logger, confFile *config.ConfigFile, stores ...*sto
 	return handler
 }
 
-func NewHandlerWithBackup(logger *slog.Logger, confFile *config.ConfigFile, db *store.Store, masterKey string, downloadService *downloads.Service, timeZones ...config.TimeZone) Handler {
+func NewHandlerWithBackup(logger *slog.Logger, confFile *config.ConfigFile, db *store.Store, masterKey string, downloadService *downloads.Service, playgroundRoot string, preRestore func(context.Context) error, postRestore func(context.Context) error, timeZones ...config.TimeZone) Handler {
 	timeZone := config.TimeZoneOrDefault(timeZones...)
 	handler := NewHandler(logger, confFile, db)
-	handler.backups = backup.NewService(db, confFile, masterKey, timeZone)
+	handler.backups = backup.NewService(db, confFile, masterKey, playgroundRoot, timeZone).WithRestoreHooks(preRestore, postRestore)
 	handler.autoBackups = backup.NewAutomaticService(handler.backups, masterKey)
 	handler.downloads = downloadService
 	return handler

--- a/server/internal/settings/handler_backup.go
+++ b/server/internal/settings/handler_backup.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
+
+	"xlyra/server/internal/auth"
 	"xlyra/server/internal/backup"
 	"xlyra/server/internal/downloads"
 	"xlyra/server/internal/httpx"
@@ -78,7 +81,7 @@ func (h Handler) ImportBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	summary, err := h.backups.Import(r.Context(), passphrase, data)
+	summary, err := h.backups.Import(r.Context(), passphrase, data, backup.ImportOptions{AdminID: adminIDFromRequest(r)})
 	if err != nil {
 		h.writeBackupError(w, r, err)
 		return
@@ -88,8 +91,13 @@ func (h Handler) ImportBackup(w http.ResponseWriter, r *http.Request) {
 
 func (h Handler) importBackupSSE(w http.ResponseWriter, r *http.Request, passphrase string, data []byte) {
 	streamBackupRestore(w, r, "decrypt", func(ctx context.Context, progress backup.ProgressFunc) (backup.ImportSummary, error) {
-		return h.backups.Import(ctx, passphrase, data, progress)
+		return h.backups.Import(ctx, passphrase, data, backup.ImportOptions{AdminID: adminIDFromRequest(r)}, progress)
 	})
+}
+
+func adminIDFromRequest(r *http.Request) uuid.UUID {
+	adminID, _ := auth.AdminIDFromContext(r.Context())
+	return adminID
 }
 
 func streamBackupRestore(w http.ResponseWriter, r *http.Request, initialStep string, run func(context.Context, backup.ProgressFunc) (backup.ImportSummary, error)) {

--- a/server/internal/settings/handler_backup_automatic.go
+++ b/server/internal/settings/handler_backup_automatic.go
@@ -95,7 +95,7 @@ func (h Handler) RestoreAutomaticBackupFile(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	summary, err := h.autoBackups.Restore(r.Context(), req.Key)
+	summary, err := h.autoBackups.Restore(r.Context(), req.Key, backup.ImportOptions{AdminID: adminIDFromRequest(r)})
 	if err != nil {
 		h.writeAutomaticBackupError(w, r, err)
 		return
@@ -105,7 +105,7 @@ func (h Handler) RestoreAutomaticBackupFile(w http.ResponseWriter, r *http.Reque
 
 func (h Handler) restoreAutomaticBackupFileSSE(w http.ResponseWriter, r *http.Request, key string) {
 	streamBackupRestore(w, r, "download", func(ctx context.Context, progress backup.ProgressFunc) (backup.ImportSummary, error) {
-		return h.autoBackups.RestoreWithProgress(ctx, key, progress)
+		return h.autoBackups.RestoreWithProgress(ctx, key, backup.ImportOptions{AdminID: adminIDFromRequest(r)}, progress)
 	})
 }
 

--- a/server/internal/settings/handler_http_test_helpers_test.go
+++ b/server/internal/settings/handler_http_test_helpers_test.go
@@ -124,5 +124,5 @@ func settingsHandlerWithStore() Handler {
 }
 
 func settingsBackupHandler(confFile *config.ConfigFile, downloadService *downloads.Service) Handler {
-	return NewHandlerWithBackup(slog.Default(), confFile, &store.Store{}, settingsTestMasterKey, downloadService)
+	return NewHandlerWithBackup(slog.Default(), confFile, &store.Store{}, settingsTestMasterKey, downloadService, "", nil, nil)
 }

--- a/web/src/features/settings/api/settings.ts
+++ b/web/src/features/settings/api/settings.ts
@@ -130,6 +130,8 @@ export type BackupImportSummary = {
   rows: number
   config_keys: number
   format_version: number
+  files?: number
+  file_bytes?: number
 }
 
 export type AutomaticBackupConfig = {
@@ -230,7 +232,7 @@ export async function runAutomaticBackup() {
 }
 
 export type RestoreProgressEvent = {
-  step: 'download' | 'decrypt' | 'parse' | 'import' | 'complete'
+  step: 'download' | 'decrypt' | 'parse' | 'import' | 'files' | 'complete'
   status: 'in_progress' | 'complete' | 'error'
   rows?: number
   total_rows?: number

--- a/web/src/features/settings/components/backup/restore-progress-dialog.tsx
+++ b/web/src/features/settings/components/backup/restore-progress-dialog.tsx
@@ -19,7 +19,7 @@ import {
   type BackupImportSummary,
 } from '@/features/settings/api/settings'
 
-type StepId = 'download' | 'decrypt' | 'parse' | 'import'
+type StepId = 'download' | 'decrypt' | 'parse' | 'import' | 'files'
 type StepState = 'pending' | 'in_progress' | 'complete' | 'error'
 type Outcome = 'running' | 'success' | 'error'
 
@@ -32,6 +32,7 @@ const STEPS: { id: StepId; tKey: string }[] = [
   { id: 'decrypt', tKey: 'backup.automatic.restoreProgress.stepDecrypt' },
   { id: 'parse', tKey: 'backup.automatic.restoreProgress.stepParse' },
   { id: 'import', tKey: 'backup.automatic.restoreProgress.stepImport' },
+  { id: 'files', tKey: 'backup.automatic.restoreProgress.stepFiles' },
 ]
 
 type RestoreProgressDialogProps = {
@@ -51,6 +52,7 @@ function initialSteps(task: RestoreTask): Record<StepId, StepState> {
     decrypt: 'pending',
     parse: 'pending',
     import: 'pending',
+    files: 'pending',
   }
 }
 

--- a/web/src/locales/en/settings.json
+++ b/web/src/locales/en/settings.json
@@ -303,6 +303,7 @@
         "stepDecrypt": "Decrypt backup file",
         "stepParse": "Validate backup contents",
         "stepImport": "Write backup data",
+        "stepFiles": "Write session files",
         "status": {
           "pending": "Waiting",
           "in_progress": "In progress",

--- a/web/src/locales/jp/settings.json
+++ b/web/src/locales/jp/settings.json
@@ -303,6 +303,7 @@
         "stepDecrypt": "バックアップファイルを復号",
         "stepParse": "バックアップ内容を検証",
         "stepImport": "バックアップデータを書き込み",
+        "stepFiles": "セッションファイルを書き込み",
         "status": {
           "pending": "待機中",
           "in_progress": "進行中",

--- a/web/src/locales/zh/settings.json
+++ b/web/src/locales/zh/settings.json
@@ -303,6 +303,7 @@
         "stepDecrypt": "解密备份文件",
         "stepParse": "校验备份内容",
         "stepImport": "写入备份数据",
+        "stepFiles": "写入会话文件",
         "status": {
           "pending": "等待中",
           "in_progress": "进行中",


### PR DESCRIPTION
## 背景

#29 将模型体验会话持久化到服务端（4 张数据库表 + `<workdir>/playground/` 下的 JSONL 会话日志与图片/附件文件），但备份与恢复仍只覆盖旧的 22 张表，不包含这块新增数据。本 PR 把会话持久化数据完整接入备份/恢复，并按审查意见修复了一致性与健壮性问题。

> 本 PR 堆叠在 #29 之上，base 为 `codex/playground-server-persistence`，#29 合并后 GitHub 会自动改指 main。

## 用户可见行为

| 场景 | 行为 |
|---|---|
| 手动/自动备份 | 包含模型体验会话索引、运行状态、会话正文（JSONL）与生成图片/附件文件 |
| 恢复备份 | 会话跨实例完整还原；归属归并到执行恢复的管理员；恢复期间新任务返回 409；恢复后未完成的任务按中断收敛 |
| 导入旧版本备份 | 宽容解析：备份缺少新表时按空表处理，不再报"表清单不匹配" |
| 当前版本备份损坏 | 严格校验：manifest 表清单与条目缺失即判定损坏，恢复前报错，不会静默清空数据 |
| 备份体积超过可恢复上限（2 GiB） | 导出直接失败，杜绝"备份成功但永远无法恢复" |
| 恢复过程 | 进度对话框新增"写入会话文件"步骤 |

## 备份格式

- 格式版本升至 **3**（新增 4 张 playground 表 + `playground/` 文件区），恢复兼容 2/3：旧版本宽容（缺表=空表），当前版本严格（防截断/损坏备份静默清库）
- JSONL 按数据库快照中的事件游标**截断拷贝**，与表数据严格一致，且不受备份期间正在进行的生成任务影响
- 图片资产为已压缩格式，zip 内直接存储（`zip.Store`）不再无效压缩
- 加密备份上限由 512 MiB 上调至 **2 GiB**（注意：上传与 S3 恢复会将加密报文读入内存，峰值内存随之上浮）

## 一致性设计

- 导出：表数据在可重复读快照事务内导出，文件字节在事务提交后按快照元数据拷贝；引用文件缺失时复核行是否仍在，区分并发删除（跳过）与数据损坏（报错）
- 恢复顺序：quiesce（取消活动任务并拒绝新任务）→ 单事务替换数据库 → 文件解压到暂存目录后按顶层目录两阶段交换（失败整体回滚）→ 收敛钩子；失败路径同样执行收敛，不留僵尸任务
- 恢复进度事件按 4 MiB 增量节流，与下载步骤一致

## 验证

- `cd server && go test ./...` ✅
- `cd server && go test -race ./internal/backup ./internal/playground` ✅
- `cd server && govulncheck ./...` ✅（0 个受影响漏洞）
- `cd web && npm run typecheck && npm run lint && npm run build` ✅
- 新增测试：v3 严格拒绝缺表、v2 宽容解析、游标截断导出、目录替换/清空/回滚、路径穿越拒绝、管理员归属重映射、恢复闸门与 quiesce 行为、压缩方法选择
- 另经过一轮多角度的独立代码审查（8 个查找角度 + 逐项验证），所有确认问题已修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)