### PR TITLE
fix: 🐛 优化 Playground 操作布局并完善代码复制与生图结果信息展示

### DIFF
--- a/web/src/features/playground/components/chat-view.tsx
+++ b/web/src/features/playground/components/chat-view.tsx
@@ -435,7 +435,7 @@ export function ChatView({
               disabled={!apiKeyId}
             />
           </div>
-          <div className="min-w-0 md:hidden">
+          <div className="md:hidden">
             <ModelReasoningPicker
               apiKeys={apiKeys}
               apiKeyId={apiKeyId}
@@ -446,7 +446,7 @@ export function ChatView({
               effort={effort}
               onEffortChange={onEffortChange}
               disabled={apiKeys.length === 0}
-              triggerClassName="h-11 min-w-0 w-[min(13.5rem,calc(100vw-7rem))] max-w-full"
+              triggerClassName="h-11"
             />
           </div>
         </>

--- a/web/src/features/playground/components/image-view.tsx
+++ b/web/src/features/playground/components/image-view.tsx
@@ -515,7 +515,7 @@ export function ImageView({
           disabled={!apiKeyId}
         />
       </div>
-      <div className="min-w-0 md:hidden">
+      <div className="md:hidden">
         <ModelParameterPicker
           apiKeys={apiKeys}
           apiKeyId={apiKeyId}
@@ -528,7 +528,7 @@ export function ImageView({
           parameterOptions={sizeOptions}
           onParameterChange={setSize}
           disabled={apiKeys.length === 0}
-          triggerClassName="h-11 min-w-0 w-[min(13.5rem,calc(100vw-7rem))] max-w-full"
+          triggerClassName="h-11"
         />
       </div>
     </>
@@ -721,6 +721,8 @@ export function ImageView({
                       ownedBy={entryModel?.ownedBy}
                     />
                     <span className="truncate">{entry.model}</span>
+                    {entry.siteName ? <span>|</span> : null}
+                    {entry.siteName ? <span className="truncate">{entry.siteName}</span> : null}
                     {displayedDuration ? <span>·</span> : null}
                     {displayedDuration ? (
                       <span className="whitespace-nowrap tabular-nums">
@@ -729,8 +731,6 @@ export function ImageView({
                         })}
                       </span>
                     ) : null}
-                    {entry.siteName ? <span>|</span> : null}
-                    {entry.siteName ? <span className="truncate">{entry.siteName}</span> : null}
                     {entry.size && entry.size !== 'auto' ? <span>· {entry.size}</span> : null}
                   </div>
                 </div>

--- a/web/src/features/playground/components/markdown-message.tsx
+++ b/web/src/features/playground/components/markdown-message.tsx
@@ -1,17 +1,49 @@
-import { memo } from 'react'
+import { isValidElement, memo, type ComponentPropsWithoutRef, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Copy } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { cn } from '@/lib/utils'
+import { copyToClipboard } from '@/components/common/copy-to-clipboard'
 
 type MarkdownMessageProps = {
   content: string
   className?: string
 }
 
+function reactNodeText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(reactNodeText).join('')
+  if (isValidElement<{ children?: ReactNode }>(node)) return reactNodeText(node.props.children)
+  return ''
+}
+
+function MarkdownCodeBlock({ children }: ComponentPropsWithoutRef<'pre'>) {
+  const { t } = useTranslation('playground')
+  const code = reactNodeText(children)
+
+  return (
+    <div className="playground-code-block">
+      <button
+        type="button"
+        onClick={() => void copyToClipboard(code, t('actions.copied'), t('actions.copyFailed'))}
+        className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-[hsl(var(--glass-border))] bg-[hsl(var(--surface-base))]/90 text-muted-soft shadow-sm backdrop-blur-sm transition-colors hover:text-foreground"
+        aria-label={t('actions.copy')}
+        title={t('actions.copy')}
+      >
+        <Copy className="h-3.5 w-3.5" />
+      </button>
+      <pre>{children}</pre>
+    </div>
+  )
+}
+
 function MarkdownMessageImpl({ content, className }: MarkdownMessageProps) {
   return (
     <div className={cn('playground-markdown text-sm leading-6 text-foreground', className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: MarkdownCodeBlock }}>
+        {content}
+      </ReactMarkdown>
     </div>
   )
 }

--- a/web/src/features/playground/components/model-parameter-picker.tsx
+++ b/web/src/features/playground/components/model-parameter-picker.tsx
@@ -178,7 +178,7 @@ export function ModelParameterPicker<T extends string>({
           type="button"
           disabled={disabled}
           className={cn(
-            'inline-flex h-8 w-[15rem] max-w-[15rem] items-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-soft outline-none transition-colors hover:bg-[hsl(var(--surface-subtle))] hover:text-foreground focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring-soft))] disabled:opacity-50',
+            'inline-flex h-8 w-max max-w-none items-center justify-end gap-1 rounded-full px-2.5 text-xs font-medium text-muted-soft outline-none transition-colors hover:bg-[hsl(var(--surface-subtle))] hover:text-foreground focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring-soft))] disabled:opacity-50',
             triggerClassName,
           )}
         >
@@ -189,7 +189,7 @@ export function ModelParameterPicker<T extends string>({
               ownedBy={selectedModel.ownedBy}
             />
           ) : null}
-          <span className="min-w-0 truncate text-foreground">{modelLabel}</span>
+          <span className="shrink-0 whitespace-nowrap text-foreground">{modelLabel}</span>
           <span className="shrink-0 opacity-60">· {selectedParameter?.label ?? parameterValue}</span>
           <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
         </button>
@@ -197,7 +197,7 @@ export function ModelParameterPicker<T extends string>({
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
           side="top"
-          align="start"
+          align="end"
           sideOffset={8}
           collisionPadding={12}
           onClick={(event) => event.stopPropagation()}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1340,6 +1340,14 @@ html.dark .slash-tabs-trigger[data-state="active"] {
   padding: 0.75rem;
   font-size: 0.85em;
 }
+.playground-markdown .playground-code-block {
+  position: relative;
+  margin: 0.5rem 0;
+}
+.playground-markdown .playground-code-block pre {
+  margin: 0;
+  padding-right: 2.75rem;
+}
 .playground-markdown blockquote {
   border-left: 2px solid hsl(var(--glass-border-strong));
   padding-left: 0.75rem;


### PR DESCRIPTION
## 改动内容

### 1. 模型 / 参数选择器布局优化(移动端)

对话页与生图页的模型、推理、参数选择器此前使用固定宽度(桌面端 `15rem`、移动端 `min(13.5rem, calc(100vw-7rem))`),长模型名会被截断成省略号,且宽度写死导致排布僵硬。

- 触发器改为**按内容自适应宽度**(`w-max`、取消 `max-w` 限制),标签设为不换行、不截断,模型名完整展示
- 移除移动端容器上冗余的 `min-w-0` 与固定宽度类
- 弹层对齐方式由左对齐(`align="start"`)改为**右对齐**(`align="end"`),与触发器右端对齐,小屏下不会溢出屏幕左侧
- 触发器内容改为右对齐(`justify-end`),视觉上与弹层锚点一致

### 2. Markdown 代码块一键复制

Playground 消息中的代码块此前只能手动框选复制,现在右上角新增复制按钮。

- 新增 `MarkdownCodeBlock` 组件接管 `pre` 渲染,通过 `reactNodeText` 递归提取 ReactNode 中的纯文本作为复制内容
- 调用统一的 `copyToClipboard`,复制成功 / 失败均有国际化提示(复用 playground 命名空间 `actions.*` 文案)
- 按钮带 `aria-label` 与 `title`,悬停高亮;代码块内容右侧预留 `2.75rem` 内边距,避免长行代码与按钮重叠
- 按钮使用毛玻璃质感(半透明背景 + backdrop-blur),适配浅色 / 深色主题

### 3. 生图结果信息排布调整

生图历史条目的元信息展示顺序由「模型 · 耗时 | 站点 · 尺寸」调整为「模型 | 站点 · 耗时 · 尺寸」——站点名称紧跟模型名,与模型的归属关系更直观。

## 验证

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)