### PR TITLE
fix: 🐛 修复弹窗面板内下拉列表无法滚动导致选项显示不全的问题

### DIFF
--- a/web/src/components/ui/date-time-picker.tsx
+++ b/web/src/components/ui/date-time-picker.tsx
@@ -282,6 +282,9 @@ export function DateTimePicker(props: DateTimePickerProps) {
         <PopoverPrimitive.Content
           align="start"
           sideOffset={8}
+          // 阻止滚轮/触摸事件冒泡到 document，否则弹层在 Dialog/Sheet 内打开时滚动会被其滚动锁拦截
+          onWheel={(event) => event.stopPropagation()}
+          onTouchMove={(event) => event.stopPropagation()}
           className="glass-panel-strong z-[120] w-[min(644px,calc(100vw-2rem))] rounded-xl p-3"
         >
           <div className="grid gap-4 min-[620px]:grid-cols-[320px_1fr]">

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -146,6 +146,9 @@ export function MultiSelect({
           sideOffset={8}
           collisionPadding={16}
           onOpenAutoFocus={(event) => event.preventDefault()}
+          // 阻止滚轮/触摸事件冒泡到 document，否则弹层在 Dialog/Sheet 内打开时滚动会被其滚动锁拦截
+          onWheel={(event) => event.stopPropagation()}
+          onTouchMove={(event) => event.stopPropagation()}
           className={cn(
             'glass-panel-strong z-[120] flex max-h-[min(var(--radix-popover-content-available-height),32rem)] flex-col overflow-hidden rounded-xl shadow-xl',
             useContentWidth

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -76,6 +76,9 @@ const SelectContent = React.forwardRef<
           position={position}
           sideOffset={8}
           onCloseAutoFocus={() => setSearch('')}
+          // 阻止滚轮/触摸事件冒泡到 document，否则弹层在 Dialog/Sheet 内打开时滚动会被其滚动锁拦截
+          onWheel={(event) => event.stopPropagation()}
+          onTouchMove={(event) => event.stopPropagation()}
           className={cn(
             'glass-panel-strong relative z-[120] max-h-[min(var(--radix-select-content-available-height),32rem)] overflow-hidden rounded-xl',
             position === 'popper' && 'translate-y-1',

--- a/web/src/components/ui/time-picker.tsx
+++ b/web/src/components/ui/time-picker.tsx
@@ -178,6 +178,9 @@ export function TimePicker({
         <PopoverPrimitive.Content
           align="start"
           sideOffset={8}
+          // 阻止滚轮/触摸事件冒泡到 document，否则弹层在 Dialog/Sheet 内打开时滚动会被其滚动锁拦截
+          onWheel={(event) => event.stopPropagation()}
+          onTouchMove={(event) => event.stopPropagation()}
           className="glass-panel-strong z-[120] w-[280px] rounded-xl p-3"
         >
           <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## 改动内容

在 4 个共享下拉组件的浮层内容上添加 `onWheel` / `onTouchMove` 的 `stopPropagation`，阻止滚动事件冒泡到 document：

- `multi-select.tsx`：多选下拉（站点/OAuth 账号的「所属分组」、API Key 的「选择分组」等）
- `select.tsx`：单选下拉（含嵌套在日期时间选择器内的下拉）
- `time-picker.tsx`：时间选择器的小时/分钟滚动列
- `date-time-picker.tsx`：日期时间面板的滚动列表

各组件附带一行注释说明该处理的原因。

## 问题说明

站点/OAuth 账号等编辑面板基于 Radix Dialog（modal）实现，打开时会挂载 `RemoveScroll` 滚动锁，在 document 上监听 `wheel`/`touchmove` 并拦截「Dialog 内容区之外」的滚动事件。下拉浮层通过 Portal 渲染到 `body`，不在 Dialog 内容区内，导致浮层内的滚轮/触摸滚动被 `preventDefault`，分组较多时下拉列表无法滚动、选项显示不全。

浮层内容阻止事件冒泡后，document 层的滚动锁不再拦截，浮层内滚动恢复正常；浮层外的背景滚动锁行为不变。

## 验证

- `npm run typecheck`、`npm run lint`、`npm run build` 均通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)