### PR TITLE
feat: 🎸 API 密钥轮换与分钟级到期

### DIFF
--- a/server/internal/admin/handler_api_keys.go
+++ b/server/internal/admin/handler_api_keys.go
@@ -132,6 +132,37 @@ func (h Handler) RevealAPIKey(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// RotateAPIKey generates a fresh credential for an existing key while keeping
+// every piece of configuration (sites, models, quota, expiry) intact. The old
+// secret stops working as soon as the hash is replaced; the new plaintext is
+// returned exactly once in this response.
+func (h Handler) RotateAPIKey(w http.ResponseWriter, r *http.Request) {
+	apiKey, ok := h.apiKeyByParam(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.auth.RotateAPIKey(r.Context(), apiKey.ID)
+	if err != nil {
+		h.writeError(w, r, http.StatusBadRequest, "api_key_rotate_failed", err.Error())
+		return
+	}
+
+	actor, _ := auth.AdminActorFromContext(r.Context())
+	h.recordAudit(r, actor, "api_key.rotate", "api_key", apiKey.ID.String(), true, "", map[string]any{"name": apiKey.Name})
+	h.logInfo("api key rotated", "api_key_id", apiKey.ID, "name", apiKey.Name)
+	h.invalidateGatewayModelsCacheForAPIKey(result.APIKey.ID)
+	h.prewarmGatewayModelsCacheForAPIKey(result.APIKey)
+	models, _ := h.auth.APIKeyEffectiveSiteModels(r.Context(), result.APIKey)
+	sites, _ := h.auth.APIKeySites(r.Context(), result.APIKey.ID)
+	groups, _ := h.auth.APIKeySiteGroups(r.Context(), result.APIKey.ID)
+	h.writePayload(w, http.StatusOK, map[string]any{
+		"key":        result.Key,
+		"key_prefix": result.KeyPrefix,
+		"api_key":    h.apiKeyPayload(r.Context(), result.APIKey, models, sites, groups, false),
+	})
+}
+
 func (h Handler) UpdateAPIKey(w http.ResponseWriter, r *http.Request) {
 	apiKey, ok := h.apiKeyByParam(w, r)
 	if !ok {

--- a/server/internal/app/router.go
+++ b/server/internal/app/router.go
@@ -190,6 +190,7 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 				protected.Post("/api-keys", adminHandler.CreateAPIKey)
 				protected.Get("/api-keys/{apiKeyID}", adminHandler.GetAPIKey)
 				protected.Get("/api-keys/{apiKeyID}/reveal", adminHandler.RevealAPIKey)
+				protected.Post("/api-keys/{apiKeyID}/rotate", adminHandler.RotateAPIKey)
 				protected.Put("/api-keys/{apiKeyID}", adminHandler.UpdateAPIKey)
 				protected.Post("/api-keys/{apiKeyID}/quota/increase", adminHandler.IncreaseAPIKeyQuota)
 				protected.Post("/api-keys/{apiKeyID}/quota/reset", adminHandler.ResetAPIKeyQuota)

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -762,11 +762,20 @@ func (s *Service) createGatewayAPIKeyValue(ctx context.Context, customKey string
 	return "", "", fmt.Errorf("generate unique api key: too many collisions")
 }
 
+// disableExpiredAPIKeys persists the disabled status for keys whose expiry
+// has passed, so the admin console shows the toggle as off. Best-effort: read
+// paths must not fail because of this sweep.
+func (s *Service) disableExpiredAPIKeys(ctx context.Context) {
+	_, _ = s.apiKeys.DisableExpiredAPIKeys(ctx, time.Now())
+}
+
 func (s *Service) ListAPIKeys(ctx context.Context) ([]store.APIKey, error) {
+	s.disableExpiredAPIKeys(ctx)
 	return s.apiKeys.List(ctx)
 }
 
 func (s *Service) ListAPIKeyDetails(ctx context.Context) ([]APIKeyDetails, error) {
+	s.disableExpiredAPIKeys(ctx)
 	apiKeys, err := s.apiKeys.List(ctx)
 	if err != nil {
 		return nil, err
@@ -870,6 +879,7 @@ func (s *Service) ListAPIKeyDetails(ctx context.Context) ([]APIKeyDetails, error
 }
 
 func (s *Service) GetAPIKey(ctx context.Context, id uuid.UUID) (store.APIKey, error) {
+	s.disableExpiredAPIKeys(ctx)
 	return s.apiKeys.GetByID(ctx, id)
 }
 
@@ -916,6 +926,17 @@ func (s *Service) UpdateAPIKey(ctx context.Context, id uuid.UUID, input UpdateAP
 	status := strings.TrimSpace(input.Status)
 	if status == "" {
 		status = current.Status
+	}
+	// Re-enabling is only meaningful while the key is within its validity
+	// window; an expired key must have its expiration extended first.
+	if status == "active" && current.Status != "active" {
+		effectiveExpiresAt := input.ExpiresAt
+		if effectiveExpiresAt == nil {
+			effectiveExpiresAt = current.ExpiresAt
+		}
+		if effectiveExpiresAt != nil && !effectiveExpiresAt.After(time.Now()) {
+			return store.APIKey{}, fmt.Errorf("cannot enable an expired api key; extend the expiration time first")
+		}
 	}
 	modelPolicy := normalizeModelPolicy(input.ModelPolicy)
 	if input.ModelPolicy == "" {

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -1009,6 +1009,49 @@ func (s *Service) UpdateAPIKey(ctx context.Context, id uuid.UUID, input UpdateAP
 	return updated, err
 }
 
+// RotateAPIKey replaces the credential of an existing key with a freshly
+// generated one. All configuration and usage counters stay attached to the
+// same row; only the secret material changes. Custom keys are rejected
+// because their value is user-chosen rather than generated.
+func (s *Service) RotateAPIKey(ctx context.Context, id uuid.UUID) (CreateAPIKeyResult, error) {
+	current, err := s.apiKeys.GetByID(ctx, id)
+	if err != nil {
+		return CreateAPIKeyResult{}, err
+	}
+	if current.KeyKind == apiKeyCustomKind {
+		return CreateAPIKeyResult{}, fmt.Errorf("custom api keys do not support rotation")
+	}
+
+	key, keyKind, err := s.createGatewayAPIKeyValue(ctx, "")
+	if err != nil {
+		return CreateAPIKeyResult{}, err
+	}
+
+	encrypted, masked, err := s.credentials.Encrypt(key)
+	if err != nil {
+		return CreateAPIKeyResult{}, err
+	}
+
+	keyPrefix := apiKeyStoragePrefix(key, keyKind)
+	updated, err := s.apiKeys.RotateSecret(ctx, store.RotateAPIKeySecretParams{
+		ID:              id,
+		KeyPrefix:       keyPrefix,
+		KeyHash:         hashToken(key),
+		EncryptedSecret: encrypted,
+		MaskedKey:       masked,
+		KeyKind:         keyKind,
+	})
+	if err != nil {
+		return CreateAPIKeyResult{}, err
+	}
+
+	return CreateAPIKeyResult{
+		Key:       key,
+		KeyPrefix: keyPrefix,
+		APIKey:    updated,
+	}, nil
+}
+
 func (s *Service) DeleteAPIKey(ctx context.Context, id uuid.UUID) error {
 	return s.apiKeys.Delete(ctx, id)
 }

--- a/server/internal/store/api_key_repository.go
+++ b/server/internal/store/api_key_repository.go
@@ -245,6 +245,9 @@ func (r APIKeyRepository) lookupActive(ctx context.Context, keyHash string, now 
 		return APIKey{}, gorm.ErrRecordNotFound
 	}
 	if apiKey.ExpiresAt != nil && !apiKey.ExpiresAt.After(now) {
+		// Best-effort: persist the disabled status so admin views reflect the
+		// expired state; the key is rejected as not found either way.
+		_, _ = r.DisableExpiredAPIKeys(ctx, now)
 		return APIKey{}, gorm.ErrRecordNotFound
 	}
 	if opts.RequireQuota {
@@ -261,6 +264,21 @@ func (r APIKeyRepository) lookupActive(ctx context.Context, keyHash string, now 
 		apiKey.LastUsedAt = &now
 	}
 	return apiKey, nil
+}
+
+// DisableExpiredAPIKeys flips still-active keys whose expiry has passed to
+// disabled, so the persisted status matches the request-time enforcement and
+// admin views show the switch as off. Rows with a NULL expires_at never
+// satisfy the <= comparison and are left untouched.
+func (r APIKeyRepository) DisableExpiredAPIKeys(ctx context.Context, now time.Time) (int64, error) {
+	result := r.db.WithContext(ctx).Model(&APIKey{}).
+		Where(clause.Eq{Column: "status", Value: "active"}).
+		Where(clause.Lte{Column: "expires_at", Value: now}).
+		Update("status", "disabled")
+	if result.Error != nil {
+		return 0, fmt.Errorf("disable expired api keys: %w", result.Error)
+	}
+	return result.RowsAffected, nil
 }
 
 func (r APIKeyRepository) ExistsByHash(ctx context.Context, keyHash string) (bool, error) {

--- a/server/internal/store/api_key_repository.go
+++ b/server/internal/store/api_key_repository.go
@@ -351,6 +351,35 @@ func (r APIKeyRepository) Update(ctx context.Context, params UpdateAPIKeyParams)
 	return updated, nil
 }
 
+type RotateAPIKeySecretParams struct {
+	ID              uuid.UUID
+	KeyPrefix       string
+	KeyHash         string
+	EncryptedSecret any
+	MaskedKey       string
+	KeyKind         string
+}
+
+// RotateSecret replaces only the credential material of an existing key,
+// leaving all configuration (permissions, quota, expiry) untouched.
+func (r APIKeyRepository) RotateSecret(ctx context.Context, params RotateAPIKeySecretParams) (APIKey, error) {
+	updates := map[string]any{
+		"key_prefix":       params.KeyPrefix,
+		"key_hash":         params.KeyHash,
+		"encrypted_secret": nullStringFromAny(params.EncryptedSecret),
+		"masked_key":       params.MaskedKey,
+		"key_kind":         params.KeyKind,
+	}
+	if err := r.db.WithContext(ctx).Model(&APIKey{ID: params.ID}).Updates(updates).Error; err != nil {
+		return APIKey{}, fmt.Errorf("rotate api key secret: %w", err)
+	}
+	updated, err := r.GetByID(ctx, params.ID)
+	if err != nil {
+		return APIKey{}, fmt.Errorf("load rotated api key: %w", err)
+	}
+	return updated, nil
+}
+
 func (r APIKeyRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	result := r.db.WithContext(ctx).Where(&APIKey{ID: id}).Delete(&APIKey{})
 	if result.Error != nil {

--- a/server/internal/store/repository_access_edges_test.go
+++ b/server/internal/store/repository_access_edges_test.go
@@ -64,14 +64,20 @@ func TestAPIKeyRepositoryGetActiveByHashRejectsInactiveExpiredAndTouchesGenerate
 		tx.Statement.RowsAffected = 1
 	})
 	storeReplaceUpdateCallback(t, db, func(tx *gorm.DB) {
-		saveCalls++
 		updates, ok := tx.Statement.Dest.(map[string]any)
 		if !ok {
 			tx.AddError(errors.New("unexpected api key update destination"))
 			return
 		}
 		ts, ok := updates["last_used_at"].(time.Time)
-		if !ok || !ts.Equal(now) {
+		if !ok {
+			// Expired keys trigger a status write-back sweep instead of a
+			// last-used touch; it is not what this test counts.
+			tx.Statement.RowsAffected = 1
+			return
+		}
+		saveCalls++
+		if !ts.Equal(now) {
 			tx.AddError(errors.New("last used timestamp was not updated"))
 			return
 		}

--- a/web/src/features/api-keys/api/api-keys.ts
+++ b/web/src/features/api-keys/api/api-keys.ts
@@ -148,6 +148,19 @@ export async function createDownstreamAPIKey(input: APIKeyUpsertInput) {
   })
 }
 
+// Rotates the credential in place: the old secret stops working immediately,
+// all configuration and usage counters are preserved. The new plaintext is
+// returned exactly once in this response. Custom keys are rejected server-side.
+export async function rotateDownstreamAPIKey(apiKeyId: string) {
+  return apiFetch<{
+    key: string
+    key_prefix: string
+    api_key: DownstreamAPIKey
+  }>(`/api/v1/api-keys/${apiKeyId}/rotate`, {
+    method: 'POST',
+  })
+}
+
 export async function updateDownstreamAPIKey(apiKeyId: string, input: APIKeyUpsertInput) {
   return apiFetch<{ api_key: DownstreamAPIKey }>(`/api/v1/api-keys/${apiKeyId}`, {
     method: 'PUT',

--- a/web/src/features/api-keys/components/api-key-actions-menu.tsx
+++ b/web/src/features/api-keys/components/api-key-actions-menu.tsx
@@ -1,19 +1,23 @@
 import { useState, type ComponentType } from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
-import { Ellipsis, LoaderCircle, PencilLine, RotateCcw, Trash2 } from 'lucide-react'
+import { Ellipsis, LoaderCircle, PencilLine, RefreshCw, RotateCcw, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 
 export function APIKeyActionsMenu({
   busy,
   resetDisabled,
+  rotateDisabled,
   onEdit,
+  onRotate,
   onReset,
   onDelete,
 }: {
   busy?: boolean
   resetDisabled?: boolean
+  rotateDisabled?: boolean
   onEdit: () => void
+  onRotate: () => void
   onReset: () => void
   onDelete: () => void
 }) {
@@ -46,6 +50,13 @@ export function APIKeyActionsMenu({
         >
           <ActionItem icon={PencilLine} label={t('table.edit')} onClick={() => run(onEdit)} />
           <ActionItem
+            icon={RefreshCw}
+            label={t('table.rotate')}
+            disabled={rotateDisabled}
+            title={rotateDisabled ? t('table.rotateCustomDisabled') : undefined}
+            onClick={() => run(onRotate)}
+          />
+          <ActionItem
             icon={RotateCcw}
             label={t('table.resetQuota')}
             disabled={resetDisabled}
@@ -63,18 +74,21 @@ function ActionItem({
   label,
   disabled,
   destructive,
+  title,
   onClick,
 }: {
   icon: ComponentType<{ className?: string }>
   label: string
   disabled?: boolean
   destructive?: boolean
+  title?: string
   onClick: () => void
 }) {
   return (
     <button
       type="button"
       disabled={disabled}
+      title={title}
       onClick={onClick}
       className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm font-medium transition-colors hover:bg-[hsl(var(--surface-subtle))] disabled:cursor-not-allowed disabled:opacity-40 ${destructive ? 'text-destructive' : 'text-foreground'}`}
     >

--- a/web/src/features/api-keys/components/api-key-form-draw.tsx
+++ b/web/src/features/api-keys/components/api-key-form-draw.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, LoaderCircle, Plus, Search, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { DatePicker } from '@/components/ui/date-picker'
+import { DateTimePicker } from '@/components/ui/date-time-picker'
 import { Draw, DrawBody, DrawContent, DrawFooter, DrawHeader, DrawTitle } from '@/components/ui/draw'
 import { FormField } from '@/components/ui/form-field'
 import { Input } from '@/components/ui/input'
@@ -16,7 +16,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/lib/toast'
 import type { APIKeyUpsertInput, DownstreamAPIKey, ModelRule } from '@/features/api-keys/api/api-keys'
 import {
-  dateToEndOfDayRFC3339,
+  dateToRFC3339,
   buildMappingModelKeys,
   formValuesFromAPIKey,
   formatSiteTypeLabel,
@@ -434,7 +434,7 @@ export function APIKeyFormDraw({
       return
     }
 
-    const expiresAt = values.expiresPermanent ? null : dateToEndOfDayRFC3339(values.expiresAt)
+    const expiresAt = values.expiresPermanent ? null : dateToRFC3339(values.expiresAt)
     if (!values.expiresPermanent && !expiresAt) {
       toast.error(t('form.validation.expiresRequired'))
       return
@@ -810,11 +810,21 @@ export function APIKeyFormDraw({
 
             {!values.expiresPermanent ? (
               <FormField label={t('form.fields.expiresDate')} required>
-                <DatePicker
+                <DateTimePicker
                   value={values.expiresAt}
-                  onValueChange={(date) => setValues((current) => ({ ...current, expiresAt: date }))}
+                  onValueChange={(date) => setValues((current) => {
+                    // First day selection starts at 00:00; keep the previous
+                    // end-of-day default so picking only a date behaves as before.
+                    if (date && !current.expiresAt && date.getHours() === 0 && date.getMinutes() === 0) {
+                      const endOfDay = new Date(date)
+                      endOfDay.setHours(23, 59, 0, 0)
+                      return { ...current, expiresAt: endOfDay }
+                    }
+                    return { ...current, expiresAt: date }
+                  })}
                   placeholder={t('form.fields.pickDate')}
                   disablePastDates
+                  minuteStep={1}
                 />
               </FormField>
             ) : null}

--- a/web/src/features/api-keys/components/downstream-api-keys-table.tsx
+++ b/web/src/features/api-keys/components/downstream-api-keys-table.tsx
@@ -16,6 +16,7 @@ import {
   formatSitePolicy,
   hasResettableQuota,
   isAPIKeyActive,
+  isAPIKeyExpired,
 } from '@/features/api-keys/lib/api-key-utils'
 import type { TimeDisplayMode } from '@/features/api-keys/lib/types'
 
@@ -137,11 +138,17 @@ export function DownstreamAPIKeysTable({
       {
         id: 'expires_at',
         header: t('table.headers.expiresAt'),
-        cell: ({ row }) => (
-          <span className="text-muted-soft text-sm">
-            {row.original.expires_at ? formatDateTime(row.original.expires_at) : t('table.permanent')}
-          </span>
-        ),
+        cell: ({ row }) => {
+          const expired = isAPIKeyExpired(row.original)
+          return (
+            <span
+              className={expired ? 'text-sm text-[hsl(var(--destructive))]' : 'text-muted-soft text-sm'}
+              title={expired ? t('table.expired') : undefined}
+            >
+              {row.original.expires_at ? formatDateTime(row.original.expires_at) : t('table.permanent')}
+            </span>
+          )
+        },
         meta: {
           className: 'w-[12%]',
           align: 'center',
@@ -152,11 +159,13 @@ export function DownstreamAPIKeysTable({
         header: t('table.headers.status'),
         cell: ({ row }) => {
           const active = isAPIKeyActive(row.original)
+          const expired = isAPIKeyExpired(row.original)
           const toggling = togglingKeyId === row.original.id
           return (
             <Switch
               checked={active}
-              disabled={toggling}
+              disabled={toggling || expired}
+              title={expired ? t('table.expiredToggleHint') : undefined}
               onCheckedChange={() => onToggleKey(row.original)}
             />
           )

--- a/web/src/features/api-keys/components/downstream-api-keys-table.tsx
+++ b/web/src/features/api-keys/components/downstream-api-keys-table.tsx
@@ -28,6 +28,7 @@ export function DownstreamAPIKeysTable({
   onToggleKey,
   onEditKey,
   onDeleteKey,
+  onRotateKey,
   onResetQuota,
   onShowModels,
   onToggleLastUsedMode,
@@ -40,6 +41,7 @@ export function DownstreamAPIKeysTable({
   onToggleKey: (apiKey: DownstreamAPIKey) => void
   onEditKey: (apiKey: DownstreamAPIKey) => void
   onDeleteKey: (apiKey: DownstreamAPIKey) => void
+  onRotateKey: (apiKey: DownstreamAPIKey) => void
   onResetQuota: (apiKey: DownstreamAPIKey) => void
   onShowModels: (apiKey: DownstreamAPIKey) => void
   onToggleLastUsedMode: () => void
@@ -174,7 +176,9 @@ export function DownstreamAPIKeysTable({
             <APIKeyActionsMenu
               busy={deleting}
               resetDisabled={!hasResettableQuota(row.original)}
+              rotateDisabled={row.original.key_kind === 'custom'}
               onEdit={() => onEditKey(row.original)}
+              onRotate={() => onRotateKey(row.original)}
               onReset={() => onResetQuota(row.original)}
               onDelete={() => onDeleteKey(row.original)}
             />
@@ -185,7 +189,7 @@ export function DownstreamAPIKeysTable({
         },
       },
     ],
-    [t, i18n.language, deletingKeyId, lastUsedMode, now, onDeleteKey, onEditKey, onResetQuota, onShowModels, onToggleKey, onToggleLastUsedMode, togglingKeyId],
+    [t, i18n.language, deletingKeyId, lastUsedMode, now, onDeleteKey, onEditKey, onResetQuota, onRotateKey, onShowModels, onToggleKey, onToggleLastUsedMode, togglingKeyId],
   )
 
   return (

--- a/web/src/features/api-keys/components/downstream-api-keys-workspace.tsx
+++ b/web/src/features/api-keys/components/downstream-api-keys-workspace.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Copy, Link, LoaderCircle, Plus, RotateCcw, Search } from 'lucide-react'
+import { Copy, Link, LoaderCircle, Plus, RefreshCw, RotateCcw, Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '@/components/common/copy-to-clipboard'
 import { EmptyState } from '@/components/common/empty-state'
@@ -32,6 +32,7 @@ import {
   downstreamAPIKeyQueryKeys,
   listDownstreamAPIKeys,
   resetDownstreamAPIKeyQuota,
+  rotateDownstreamAPIKey,
   updateDownstreamAPIKey,
   type APIKeyUpsertInput,
   type DownstreamAPIKey,
@@ -77,6 +78,8 @@ export function DownstreamAPIKeysWorkspace() {
   const [editingKey, setEditingKey] = useState<DownstreamAPIKey | null>(null)
   const [modelsKey, setModelsKey] = useState<DownstreamAPIKey | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<DownstreamAPIKey | null>(null)
+  const [rotateTarget, setRotateTarget] = useState<DownstreamAPIKey | null>(null)
+  const [rotatedKey, setRotatedKey] = useState<{ name: string; key: string } | null>(null)
   const [resetTarget, setResetTarget] = useState<DownstreamAPIKey | null>(null)
   const [resetScopes, setResetScopes] = useState<QuotaResetScope[]>([])
   const [lastUsedMode, setLastUsedMode] = useState<TimeDisplayMode>(readLastUsedMode)
@@ -195,6 +198,19 @@ export function DownstreamAPIKeysWorkspace() {
     },
   })
 
+  const rotateMutation = useMutation({
+    mutationFn: (apiKeyId: string) => rotateDownstreamAPIKey(apiKeyId),
+    onSuccess: async (result) => {
+      setRotateTarget(null)
+      setRotatedKey({ name: result.api_key.name, key: result.key })
+      await queryClient.invalidateQueries({ queryKey: downstreamAPIKeyQueryKeys.list() })
+      toast.success(t('workspace.toast.keyRotated'))
+    },
+    onError: (error) => {
+      toast.error(t('workspace.toast.rotateFailed'), { description: error.message })
+    },
+  })
+
   if (apiKeysQuery.isLoading) {
     return <APIKeysSkeleton />
   }
@@ -239,6 +255,7 @@ export function DownstreamAPIKeysWorkspace() {
     onToggleKey: (apiKey: DownstreamAPIKey) => toggleMutation.mutate(apiKey),
     onEditKey: openEditKey,
     onDeleteKey: setDeleteTarget,
+    onRotateKey: setRotateTarget,
     onResetQuota: openResetQuota,
     onShowModels: setModelsKey,
     onToggleLastUsedMode: () => setLastUsedMode((current) => (current === 'absolute' ? 'relative' : 'absolute')),
@@ -350,6 +367,88 @@ export function DownstreamAPIKeysWorkspace() {
             >
               {resetQuotaMutation.isPending ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
               {t('workspace.resetQuotaDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(rotateTarget)}
+        onOpenChange={(open) => {
+          if (!open && !rotateMutation.isPending) {
+            setRotateTarget(null)
+          }
+        }}
+      >
+        <DialogContent className="w-[min(92vw,520px)] overflow-hidden">
+          <DialogHeader className="border-b-0 pb-2">
+            <DialogTitle>{t('workspace.rotateDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="pt-0">
+            <DialogDescription className="mt-0">
+              {rotateTarget ? t('workspace.rotateDialog.description', { name: rotateTarget.name }) : null}
+            </DialogDescription>
+          </DialogBody>
+          <DialogFooter className="border-t-0 pt-2">
+            <Button
+              variant="outline"
+              onClick={() => setRotateTarget(null)}
+              disabled={rotateMutation.isPending}
+            >
+              {t('workspace.rotateDialog.cancel')}
+            </Button>
+            <Button
+              onClick={() => {
+                if (rotateTarget) {
+                  rotateMutation.mutate(rotateTarget.id)
+                }
+              }}
+              disabled={rotateMutation.isPending}
+            >
+              {rotateMutation.isPending ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+              {t('workspace.rotateDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(rotatedKey)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRotatedKey(null)
+          }
+        }}
+      >
+        <DialogContent className="w-[min(92vw,520px)] overflow-hidden">
+          <DialogHeader className="border-b-0 pb-2">
+            <DialogTitle>{t('workspace.rotateResultDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="min-w-0 space-y-4 pt-0">
+            <DialogDescription className="mt-0">
+              {rotatedKey ? t('workspace.rotateResultDialog.description', { name: rotatedKey.name }) : null}
+            </DialogDescription>
+            <div className="flex items-start gap-2 rounded-lg border border-[hsl(var(--glass-border))] bg-[hsl(var(--surface-subtle))] px-3 py-2.5">
+              <code className="min-w-0 flex-1 break-all font-mono text-sm leading-6 text-foreground">{rotatedKey?.key}</code>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8 shrink-0"
+                aria-label={t('workspace.rotateResultDialog.copy')}
+                title={t('workspace.rotateResultDialog.copy')}
+                onClick={() => {
+                  if (rotatedKey) {
+                    void copyToClipboard(rotatedKey.key, t('table.copySuccess'), t('table.copyFailed'))
+                  }
+                }}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </DialogBody>
+          <DialogFooter className="border-t-0 pt-2">
+            <Button onClick={() => setRotatedKey(null)}>
+              {t('workspace.rotateResultDialog.close')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/features/api-keys/components/mobile-api-keys-list.tsx
+++ b/web/src/features/api-keys/components/mobile-api-keys-list.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle, PencilLine, RotateCcw, Trash2 } from 'lucide-react'
+import { LoaderCircle, PencilLine, RefreshCw, RotateCcw, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -27,6 +27,7 @@ export function MobileAPIKeysList({
   onToggleKey,
   onEditKey,
   onDeleteKey,
+  onRotateKey,
   onResetQuota,
   onShowModels,
   onToggleLastUsedMode,
@@ -40,6 +41,7 @@ export function MobileAPIKeysList({
   onToggleKey: (apiKey: DownstreamAPIKey) => void
   onEditKey: (apiKey: DownstreamAPIKey) => void
   onDeleteKey: (apiKey: DownstreamAPIKey) => void
+  onRotateKey: (apiKey: DownstreamAPIKey) => void
   onResetQuota: (apiKey: DownstreamAPIKey) => void
   onShowModels: (apiKey: DownstreamAPIKey) => void
   onToggleLastUsedMode: () => void
@@ -58,6 +60,7 @@ export function MobileAPIKeysList({
           onToggleKey={onToggleKey}
           onEditKey={onEditKey}
           onDeleteKey={onDeleteKey}
+          onRotateKey={onRotateKey}
           onResetQuota={onResetQuota}
           onShowModels={onShowModels}
           onToggleLastUsedMode={onToggleLastUsedMode}
@@ -76,6 +79,7 @@ function MobileAPIKeyCard({
   onToggleKey,
   onEditKey,
   onDeleteKey,
+  onRotateKey,
   onResetQuota,
   onShowModels,
   onToggleLastUsedMode,
@@ -88,6 +92,7 @@ function MobileAPIKeyCard({
   onToggleKey: (apiKey: DownstreamAPIKey) => void
   onEditKey: (apiKey: DownstreamAPIKey) => void
   onDeleteKey: (apiKey: DownstreamAPIKey) => void
+  onRotateKey: (apiKey: DownstreamAPIKey) => void
   onResetQuota: (apiKey: DownstreamAPIKey) => void
   onShowModels: (apiKey: DownstreamAPIKey) => void
   onToggleLastUsedMode: () => void
@@ -157,6 +162,17 @@ function MobileAPIKeyCard({
           title={t('table.edit')}
         >
           <PencilLine className="h-4 w-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8 text-foreground/60 hover:text-foreground"
+          disabled={isDeleting || apiKey.key_kind === 'custom'}
+          onClick={() => onRotateKey(apiKey)}
+          aria-label={t('table.rotate')}
+          title={apiKey.key_kind === 'custom' ? t('table.rotateCustomDisabled') : t('table.rotate')}
+        >
+          <RefreshCw className="h-4 w-4" />
         </Button>
         <Button
           size="icon"

--- a/web/src/features/api-keys/components/mobile-api-keys-list.tsx
+++ b/web/src/features/api-keys/components/mobile-api-keys-list.tsx
@@ -15,6 +15,7 @@ import {
   formatSitePolicy,
   hasResettableQuota,
   isAPIKeyActive,
+  isAPIKeyExpired,
 } from '@/features/api-keys/lib/api-key-utils'
 import type { TimeDisplayMode } from '@/features/api-keys/lib/types'
 
@@ -99,6 +100,7 @@ function MobileAPIKeyCard({
 }) {
   const { t, i18n } = useTranslation('api-keys')
   const active = isAPIKeyActive(apiKey)
+  const expired = isAPIKeyExpired(apiKey)
   const lastUsedLabel = apiKey.last_used_at
     ? lastUsedMode === 'absolute'
       ? formatDateTime(apiKey.last_used_at)
@@ -122,7 +124,8 @@ function MobileAPIKeyCard({
         </div>
         <Switch
           checked={active}
-          disabled={isToggling}
+          disabled={isToggling || expired}
+          title={expired ? t('table.expiredToggleHint') : undefined}
           onCheckedChange={() => onToggleKey(apiKey)}
           aria-label={t('table.headers.status')}
         />
@@ -148,6 +151,8 @@ function MobileAPIKeyCard({
         <MobileMetric
           label={t('table.headers.expiresAt')}
           value={apiKey.expires_at ? formatDateTime(apiKey.expires_at) : t('table.permanent')}
+          valueClassName={expired ? 'text-[hsl(var(--destructive))]' : undefined}
+          valueTitle={expired ? t('table.expired') : undefined}
         />
       </div>
 
@@ -202,11 +207,13 @@ function MobileAPIKeyCard({
 }
 
 
-function MobileMetric({ label, value }: { label: string; value: string }) {
+function MobileMetric({ label, value, valueClassName, valueTitle }: { label: string; value: string; valueClassName?: string; valueTitle?: string }) {
   return (
     <div className="min-w-0 px-2 py-2">
       <span className="block text-[11px] text-muted-soft">{label}</span>
-      <span className="mt-1 block truncate font-medium text-foreground tabular-nums" title={value}>{value}</span>
+      <span className={cn('mt-1 block truncate font-medium text-foreground tabular-nums', valueClassName)} title={valueTitle ?? value}>
+        {value}
+      </span>
     </div>
   )
 }

--- a/web/src/features/api-keys/lib/api-key-utils.ts
+++ b/web/src/features/api-keys/lib/api-key-utils.ts
@@ -434,13 +434,17 @@ function parseAPIKeyExpiresAt(value?: string | null) {
   return date
 }
 
-export function dateToEndOfDayRFC3339(value?: Date) {
+export function dateToRFC3339(value?: Date) {
   if (!value) return null
   if (Number.isNaN(value.getTime())) return null
 
-  const date = new Date(value)
-  date.setHours(23, 59, 59, 999)
-  return date.toISOString()
+  return value.toISOString()
+}
+
+export function isAPIKeyExpired(apiKey: DownstreamAPIKey) {
+  if (!apiKey.expires_at) return false
+  const time = new Date(apiKey.expires_at).getTime()
+  return !Number.isNaN(time) && time <= Date.now()
 }
 
 export function sortCanonicalModels(items: CanonicalModelItem[]) {

--- a/web/src/locales/en/api-keys.json
+++ b/web/src/locales/en/api-keys.json
@@ -60,7 +60,9 @@
       "description": "Create a key to start calling the unified gateway."
     },
     "rotate": "Rotate key",
-    "rotateCustomDisabled": "Custom keys cannot be rotated"
+    "rotateCustomDisabled": "Custom keys cannot be rotated",
+    "expired": "Expired",
+    "expiredToggleHint": "Expired — extend the expiration time first"
   },
   "workspace": {
     "loadFailed": "Failed to load API keys",
@@ -177,8 +179,8 @@
       "brandAll": "All brands",
       "noModels": "No models",
       "neverExpire": "Never expire",
-      "expiresDate": "Expires date",
-      "pickDate": "Pick a date",
+      "expiresDate": "Expires at",
+      "pickDate": "Pick expiration date and time",
       "quotaLimit": "Total quota",
       "quotaDesc": "Unit: USD ($) · Empty or 0 means unlimited · Used ${{used}} since the last manual reset",
       "quotaDailyLimit": "Daily quota limit",

--- a/web/src/locales/en/api-keys.json
+++ b/web/src/locales/en/api-keys.json
@@ -58,7 +58,9 @@
     "empty": {
       "title": "No API keys",
       "description": "Create a key to start calling the unified gateway."
-    }
+    },
+    "rotate": "Rotate key",
+    "rotateCustomDisabled": "Custom keys cannot be rotated"
   },
   "workspace": {
     "loadFailed": "Failed to load API keys",
@@ -93,6 +95,18 @@
       "cancel": "Cancel",
       "confirm": "Reset quota"
     },
+    "rotateDialog": {
+      "title": "Rotate key",
+      "description": "Generate a new secret for \"{{name}}\"? The current key stops working immediately; all configuration such as sites, models, and usage stays unchanged.",
+      "cancel": "Cancel",
+      "confirm": "Rotate"
+    },
+    "rotateResultDialog": {
+      "title": "Key rotated",
+      "description": "A new secret for \"{{name}}\" has been generated and the old one is now invalid. Copy and store the new key right away.",
+      "copy": "Copy new key",
+      "close": "Done"
+    },
     "deleteDialog": {
       "title": "Delete key",
       "confirm": "Delete「{{name}}」? This action cannot be undone.",
@@ -108,7 +122,9 @@
       "keyDeleted": "Key deleted",
       "deleteFailed": "Delete failed",
       "quotaReset": "Quota reset",
-      "quotaResetFailed": "Failed to reset quota"
+      "quotaResetFailed": "Failed to reset quota",
+      "keyRotated": "Key rotated",
+      "rotateFailed": "Rotation failed"
     }
   },
   "form": {

--- a/web/src/locales/jp/api-keys.json
+++ b/web/src/locales/jp/api-keys.json
@@ -58,7 +58,9 @@
     "empty": {
       "title": "API キーがありません",
       "description": "統合ゲートウェイを呼び出すにはキーを作成してください。"
-    }
+    },
+    "rotate": "キーをローテーション",
+    "rotateCustomDisabled": "カスタムキーはローテーションできません"
   },
   "workspace": {
     "loadFailed": "API キーの読み込みに失敗しました",
@@ -93,6 +95,18 @@
       "cancel": "キャンセル",
       "confirm": "リセット"
     },
+    "rotateDialog": {
+      "title": "キーをローテーション",
+      "description": "「{{name}}」の新しいキーを生成しますか？現在のキーは直ちに無効になります。サイト・モデル・使用量などの設定はすべて維持されます。",
+      "cancel": "キャンセル",
+      "confirm": "ローテーション"
+    },
+    "rotateResultDialog": {
+      "title": "ローテーション完了",
+      "description": "「{{name}}」の新しいキーが生成され、古いキーは無効になりました。新しいキーを今すぐコピーして安全に保管してください。",
+      "copy": "新しいキーをコピー",
+      "close": "完了"
+    },
     "deleteDialog": {
       "title": "キーを削除",
       "confirm": "「{{name}}」を削除しますか？この操作は元に戻せません。",
@@ -108,7 +122,9 @@
       "keyDeleted": "キーを削除しました",
       "deleteFailed": "削除に失敗しました",
       "quotaReset": "クォータをリセットしました",
-      "quotaResetFailed": "クォータのリセットに失敗しました"
+      "quotaResetFailed": "クォータのリセットに失敗しました",
+      "keyRotated": "キーをローテーションしました",
+      "rotateFailed": "ローテーションに失敗しました"
     }
   },
   "form": {

--- a/web/src/locales/jp/api-keys.json
+++ b/web/src/locales/jp/api-keys.json
@@ -60,7 +60,9 @@
       "description": "統合ゲートウェイを呼び出すにはキーを作成してください。"
     },
     "rotate": "キーをローテーション",
-    "rotateCustomDisabled": "カスタムキーはローテーションできません"
+    "rotateCustomDisabled": "カスタムキーはローテーションできません",
+    "expired": "期限切れ",
+    "expiredToggleHint": "期限切れです。先に有効期限を延長してください"
   },
   "workspace": {
     "loadFailed": "API キーの読み込みに失敗しました",
@@ -177,8 +179,8 @@
       "brandAll": "すべてのブランド",
       "noModels": "モデルがありません",
       "neverExpire": "期限なし",
-      "expiresDate": "有効期限日",
-      "pickDate": "日付を選択",
+      "expiresDate": "有効期限",
+      "pickDate": "有効期限を選択（分単位）",
       "quotaLimit": "合計クォータ上限",
       "quotaDesc": "単位: USD ($) · 空欄または 0 は無制限 · 前回の手動リセット以降に ${{used}} 使用済み",
       "quotaDailyLimit": "日次クォータ上限",

--- a/web/src/locales/zh/api-keys.json
+++ b/web/src/locales/zh/api-keys.json
@@ -58,7 +58,9 @@
     "empty": {
       "title": "暂无 API 密钥",
       "description": "创建一个密钥以开始调用统一网关。"
-    }
+    },
+    "rotate": "轮换密钥",
+    "rotateCustomDisabled": "自定义密钥不支持轮换"
   },
   "workspace": {
     "loadFailed": "加载 API 密钥失败",
@@ -93,6 +95,18 @@
       "cancel": "取消",
       "confirm": "确认重置"
     },
+    "rotateDialog": {
+      "title": "轮换密钥",
+      "description": "为「{{name}}」生成一个新密钥？原密钥将立即失效，站点、模型、用量等所有配置保持不变。",
+      "cancel": "取消",
+      "confirm": "确认轮换"
+    },
+    "rotateResultDialog": {
+      "title": "轮换成功",
+      "description": "「{{name}}」的新密钥已生成，原密钥已失效。请立即复制并妥善保存新密钥。",
+      "copy": "复制新密钥",
+      "close": "完成"
+    },
     "deleteDialog": {
       "title": "删除密钥",
       "confirm": "确定删除「{{name}}」？此操作不可撤销。",
@@ -108,7 +122,9 @@
       "keyDeleted": "密钥已删除",
       "deleteFailed": "删除失败",
       "quotaReset": "限额已重置",
-      "quotaResetFailed": "重置限额失败"
+      "quotaResetFailed": "重置限额失败",
+      "keyRotated": "密钥已轮换",
+      "rotateFailed": "轮换失败"
     }
   },
   "form": {

--- a/web/src/locales/zh/api-keys.json
+++ b/web/src/locales/zh/api-keys.json
@@ -60,7 +60,9 @@
       "description": "创建一个密钥以开始调用统一网关。"
     },
     "rotate": "轮换密钥",
-    "rotateCustomDisabled": "自定义密钥不支持轮换"
+    "rotateCustomDisabled": "自定义密钥不支持轮换",
+    "expired": "已过期",
+    "expiredToggleHint": "已到期，请先修改到期时间"
   },
   "workspace": {
     "loadFailed": "加载 API 密钥失败",
@@ -177,8 +179,8 @@
       "brandAll": "全部品牌",
       "noModels": "暂无模型",
       "neverExpire": "永不过期",
-      "expiresDate": "到期日期",
-      "pickDate": "选择日期",
+      "expiresDate": "到期时间",
+      "pickDate": "选择到期时间（精确到分钟）",
       "quotaLimit": "总额度",
       "quotaDesc": "单位：美元 ($) · 空或 0 表示不限 · 自上次手动重置以来已用 ${{used}}",
       "quotaDailyLimit": "日额度上限",


### PR DESCRIPTION
## 改动内容

### 1. API 密钥轮换（feat: 🎸 支持轮换 API 密钥，一键更换密钥并保留站点模型用量等全部配置）

- 新增 `POST /api-keys/{apiKeyID}/rotate` 端点：生成全新密钥并原地替换凭证字段（`key_hash` / `key_prefix` / `encrypted_secret` / `masked_key` / `key_kind`），其余配置（站点/分组/模型权限、模型映射、图像桥接、配额与用量、限速、到期时间）全部保留
- 旧密钥因 hash 替换立即失效，新密钥立即生效（网关校验按 hash 实时查库，无缓存残留）；响应一次性返回新明文密钥
- 自定义密钥（`key_kind=custom`）不支持轮换：服务端入口直接校验拒绝，前端轮换按钮置灰并提示
- 轮换动作记录 `api_key.rotate` 审计日志，并照常失效/预热网关模型列表缓存
- 前端：桌面操作菜单与移动端图标按钮新增「轮换密钥」入口 → 确认弹窗（说明旧 Key 立即失效）→ 成功弹窗完整展示新明文密钥（`break-all` 换行，避免长串撑宽弹窗）并支持一键复制
- 三语（zh/en/jp）文案已补齐

### 2. 分钟级到期 + 到期自动停用（fix: 🐛 密钥到期时间支持精确到分钟，到期后自动置为停用状态）

- 前端到期配置从纯日期选择器换成 `DateTimePicker`（`minuteStep=1`），提交用户选定的精确时分，不再钳制到当天 23:59:59；首次只选日期时默认 23:59，保持原有「选哪天到期」的操作习惯
- 新增 `DisableExpiredAPIKeys` 仓储方法（GORM clause，`status='active' AND expires_at <= now` → `disabled`，NULL 到期时间天然不参与比较），在两个入口触发：
  - 管理端列表/详情读取前批量归一化，后台展示的状态始终为最新
  - 网关校验命中过期 Key 时顺手回写，覆盖「过期后无人再打开后台」的场景
- `UpdateAPIKey` 新增校验：到期时间在过去时不允许把状态从停用切回启用（先延长到期时间再启用）
- 前端：过期 Key 的状态开关禁用（悬停提示「已到期，请先修改到期时间」），到期时间以红色 `text-[hsl(var(--destructive))]` 标注并附悬停提示；移动端同步

## 检查

- `go test ./...` ✅（适配了一处统计写次数的仓储测试：到期回写会新增一次 UPDATE，属预期行为变化）
- `govulncheck ./...` ✅（0 个受影响漏洞）
- `npm run typecheck` / `lint` / `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)