### PR TITLE
feat: reset downstream API key quota on OAuth weekly reset

### DIFF
--- a/server/internal/admin/handler_api_keys.go
+++ b/server/internal/admin/handler_api_keys.go
@@ -461,24 +461,25 @@ func (h Handler) CheckAPIKeyModel(w http.ResponseWriter, r *http.Request) {
 }
 
 type apiKeyRequest struct {
-	Name                 string                  `json:"name"`
-	CustomKey            string                  `json:"custom_key"`
-	Status               string                  `json:"status"`
-	ModelPolicy          string                  `json:"model_policy"`
-	SiteModelIDs         []string                `json:"site_model_ids"`
-	SitePolicy           string                  `json:"site_policy"`
-	SiteIDs              []string                `json:"site_ids"`
-	SiteGroupIDs         []string                `json:"site_group_ids"`
-	ModelMappings        []modelRuleRequest      `json:"model_mappings"`
-	ImageToolBridge      *imageToolBridgeRequest `json:"image_tool_bridge"`
-	QuotaLimit           *float64                `json:"quota_limit"`
-	QuotaUnlimited       *bool                   `json:"quota_unlimited"`
-	QuotaDailyLimit      *float64                `json:"quota_daily_limit"`
-	QuotaDailyUnlimited  *bool                   `json:"quota_daily_unlimited"`
-	QuotaWeeklyLimit     *float64                `json:"quota_weekly_limit"`
-	QuotaWeeklyUnlimited *bool                   `json:"quota_weekly_unlimited"`
-	ExpiresAt            json.RawMessage         `json:"expires_at"`
-	RateLimit            *rateLimitRequest       `json:"rate_limit"`
+	Name                       string                  `json:"name"`
+	CustomKey                  string                  `json:"custom_key"`
+	Status                     string                  `json:"status"`
+	ModelPolicy                string                  `json:"model_policy"`
+	SiteModelIDs               []string                `json:"site_model_ids"`
+	SitePolicy                 string                  `json:"site_policy"`
+	SiteIDs                    []string                `json:"site_ids"`
+	SiteGroupIDs               []string                `json:"site_group_ids"`
+	ModelMappings              []modelRuleRequest      `json:"model_mappings"`
+	ImageToolBridge            *imageToolBridgeRequest `json:"image_tool_bridge"`
+	QuotaLimit                 *float64                `json:"quota_limit"`
+	QuotaUnlimited             *bool                   `json:"quota_unlimited"`
+	QuotaDailyLimit            *float64                `json:"quota_daily_limit"`
+	QuotaDailyUnlimited        *bool                   `json:"quota_daily_unlimited"`
+	QuotaWeeklyLimit           *float64                `json:"quota_weekly_limit"`
+	QuotaWeeklyUnlimited       *bool                   `json:"quota_weekly_unlimited"`
+	AutoResetOAuthConnectionID json.RawMessage         `json:"auto_reset_oauth_connection_id"`
+	ExpiresAt                  json.RawMessage         `json:"expires_at"`
+	RateLimit                  *rateLimitRequest       `json:"rate_limit"`
 }
 
 type modelRuleRequest struct {
@@ -562,6 +563,10 @@ func apiKeyInputFromRequest(w http.ResponseWriter, r *http.Request, payload apiK
 	if payload.QuotaWeeklyUnlimited != nil {
 		weeklyUnlimited = *payload.QuotaWeeklyUnlimited
 	}
+	autoResetOAuthConnectionID, _, ok := parseOptionalUUID(w, r, payload.AutoResetOAuthConnectionID, "auto_reset_oauth_connection_id")
+	if !ok {
+		return auth.CreateAPIKeyInput{}, false
+	}
 
 	siteIDs, ok := parseSiteIDs(w, r, payload.SiteIDs)
 	if !ok {
@@ -581,23 +586,24 @@ func apiKeyInputFromRequest(w http.ResponseWriter, r *http.Request, payload apiK
 	}
 
 	return auth.CreateAPIKeyInput{
-		Name:                 payload.Name,
-		CustomKey:            payload.CustomKey,
-		ModelPolicy:          payload.ModelPolicy,
-		SiteModelIDs:         siteModelIDs,
-		SitePolicy:           payload.SitePolicy,
-		SiteIDs:              siteIDs,
-		SiteGroupIDs:         siteGroupIDs,
-		ModelRules:           authModelRules(payload.ModelMappings),
-		ImageToolBridge:      imageToolBridge,
-		QuotaLimit:           payload.QuotaLimit,
-		QuotaUnlimited:       quotaUnlimited,
-		QuotaDailyLimit:      payload.QuotaDailyLimit,
-		QuotaDailyUnlimited:  &dailyUnlimited,
-		QuotaWeeklyLimit:     payload.QuotaWeeklyLimit,
-		QuotaWeeklyUnlimited: &weeklyUnlimited,
-		ExpiresAt:            expiresAt,
-		RateLimit:            authRateLimitInput(payload.RateLimit),
+		Name:                       payload.Name,
+		CustomKey:                  payload.CustomKey,
+		ModelPolicy:                payload.ModelPolicy,
+		SiteModelIDs:               siteModelIDs,
+		SitePolicy:                 payload.SitePolicy,
+		SiteIDs:                    siteIDs,
+		SiteGroupIDs:               siteGroupIDs,
+		ModelRules:                 authModelRules(payload.ModelMappings),
+		ImageToolBridge:            imageToolBridge,
+		QuotaLimit:                 payload.QuotaLimit,
+		QuotaUnlimited:             quotaUnlimited,
+		QuotaDailyLimit:            payload.QuotaDailyLimit,
+		QuotaDailyUnlimited:        &dailyUnlimited,
+		QuotaWeeklyLimit:           payload.QuotaWeeklyLimit,
+		QuotaWeeklyUnlimited:       &weeklyUnlimited,
+		AutoResetOAuthConnectionID: autoResetOAuthConnectionID,
+		ExpiresAt:                  expiresAt,
+		RateLimit:                  authRateLimitInput(payload.RateLimit),
 	}, true
 }
 
@@ -638,6 +644,13 @@ func apiKeyUpdateInputFromRequest(w http.ResponseWriter, r *http.Request, payloa
 	if payload.QuotaWeeklyUnlimited != nil {
 		weeklyUnlimited = *payload.QuotaWeeklyUnlimited
 	}
+	autoResetOAuthConnectionID, autoResetProvided, ok := parseOptionalUUID(w, r, payload.AutoResetOAuthConnectionID, "auto_reset_oauth_connection_id")
+	if !ok {
+		return auth.UpdateAPIKeyInput{}, false
+	}
+	if !autoResetProvided {
+		autoResetOAuthConnectionID = current.AutoResetOAuthConnectionID
+	}
 
 	var siteIDs []uuid.UUID
 	if payload.SiteIDs != nil {
@@ -667,23 +680,24 @@ func apiKeyUpdateInputFromRequest(w http.ResponseWriter, r *http.Request, payloa
 	}
 
 	return auth.UpdateAPIKeyInput{
-		Name:                 payload.Name,
-		Status:               payload.Status,
-		ModelPolicy:          payload.ModelPolicy,
-		SiteModelIDs:         siteModelIDs,
-		SitePolicy:           payload.SitePolicy,
-		SiteIDs:              siteIDs,
-		SiteGroupIDs:         siteGroupIDs,
-		ModelRules:           authModelRules(payload.ModelMappings),
-		ImageToolBridge:      imageToolBridge,
-		QuotaLimit:           quotaLimit,
-		QuotaUnlimited:       quotaUnlimited,
-		QuotaDailyLimit:      dailyLimit,
-		QuotaDailyUnlimited:  &dailyUnlimited,
-		QuotaWeeklyLimit:     weeklyLimit,
-		QuotaWeeklyUnlimited: &weeklyUnlimited,
-		ExpiresAt:            expiresAt,
-		RateLimit:            authRateLimitInput(payload.RateLimit),
+		Name:                       payload.Name,
+		Status:                     payload.Status,
+		ModelPolicy:                payload.ModelPolicy,
+		SiteModelIDs:               siteModelIDs,
+		SitePolicy:                 payload.SitePolicy,
+		SiteIDs:                    siteIDs,
+		SiteGroupIDs:               siteGroupIDs,
+		ModelRules:                 authModelRules(payload.ModelMappings),
+		ImageToolBridge:            imageToolBridge,
+		QuotaLimit:                 quotaLimit,
+		QuotaUnlimited:             quotaUnlimited,
+		QuotaDailyLimit:            dailyLimit,
+		QuotaDailyUnlimited:        &dailyUnlimited,
+		QuotaWeeklyLimit:           weeklyLimit,
+		QuotaWeeklyUnlimited:       &weeklyUnlimited,
+		AutoResetOAuthConnectionID: autoResetOAuthConnectionID,
+		ExpiresAt:                  expiresAt,
+		RateLimit:                  authRateLimitInput(payload.RateLimit),
 	}, true
 }
 
@@ -739,6 +753,27 @@ func parseOptionalTime(w http.ResponseWriter, r *http.Request, raw json.RawMessa
 	return &parsed, true, true
 }
 
+func parseOptionalUUID(w http.ResponseWriter, r *http.Request, raw json.RawMessage, field string) (*uuid.UUID, bool, bool) {
+	if len(raw) == 0 {
+		return nil, false, true
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, true, true
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil || strings.TrimSpace(value) == "" {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_"+field, field+" must be a UUID or null")
+		return nil, true, false
+	}
+	id, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil {
+		httpx.Error(w, r, http.StatusBadRequest, "invalid_"+field, field+" must be a UUID or null")
+		return nil, true, false
+	}
+	return &id, true, true
+}
+
 func (h Handler) apiKeyPayload(ctx context.Context, item store.APIKey, models []store.APIKeySiteModelPermissionDetail, sites []store.APIKeySitePermission, groups []store.APIKeySiteGroupPermission, includePlaintext bool) map[string]any {
 	return h.apiKeyPayloadWithRateLimit(item, models, sites, groups, includePlaintext, h.apiKeyRateLimit(ctx, item.ID))
 }
@@ -755,43 +790,47 @@ func (h Handler) apiKeyPayloadWithRateLimit(item store.APIKey, models []store.AP
 	weeklyUsed := item.EffectiveWeeklyQuotaUsed(now, h.timeZone)
 
 	return map[string]any{
-		"id":                     item.ID.String(),
-		"name":                   item.Name,
-		"key":                    plaintext,
-		"key_prefix":             item.KeyPrefix,
-		"masked_key":             item.MaskedKey,
-		"key_kind":               item.KeyKind,
-		"scope":                  item.Scope,
-		"status":                 item.Status,
-		"model_policy":           item.ModelPolicy,
-		"site_policy":            item.SitePolicy,
-		"model_mappings":         modelMappingsPayload(item.ModelMappings),
-		"image_tool_bridge":      imageToolBridgePayload(item),
-		"quota_limit":            nullFloat64Value(item.QuotaLimit),
-		"quota_used":             item.QuotaUsed,
-		"quota_total_used":       item.EffectiveTotalQuotaUsed(),
-		"quota_available":        apiKeyQuotaAvailable(item),
-		"quota_total_available":  apiKeyQuotaAvailable(item),
-		"quota_total_reset_at":   timePtrValue(item.QuotaTotalResetAt),
-		"quota_unlimited":        item.QuotaUnlimited,
-		"quota_daily_limit":      nullFloat64Value(item.QuotaDailyLimit),
-		"quota_daily_used":       dailyUsed,
-		"quota_daily_available":  quotaAvailable(item.QuotaDailyLimit, dailyUsed, item.QuotaDailyUnlimited),
-		"quota_daily_unlimited":  item.QuotaDailyUnlimited,
-		"quota_daily_reset_at":   quotaResetAt(h.timeZone.StartOfDay(now).AddDate(0, 0, 1), item.QuotaDailyUnlimited),
-		"quota_weekly_limit":     nullFloat64Value(item.QuotaWeeklyLimit),
-		"quota_weekly_used":      weeklyUsed,
-		"quota_weekly_available": quotaAvailable(item.QuotaWeeklyLimit, weeklyUsed, item.QuotaWeeklyUnlimited),
-		"quota_weekly_unlimited": item.QuotaWeeklyUnlimited,
-		"quota_weekly_reset_at":  quotaResetAt(h.timeZone.StartOfWeek(now).AddDate(0, 0, 7), item.QuotaWeeklyUnlimited),
-		"rate_limit":             apiKeyRateLimitPayload(rateLimit),
-		"expires_at":             timePtrValue(item.ExpiresAt),
-		"last_used_at":           timePtrValue(item.LastUsedAt),
-		"site_models":            apiKeySiteModelPayloads(models),
-		"sites":                  apiKeySitePayloads(sites),
-		"site_groups":            apiKeySiteGroupPayloads(groups),
-		"created_at":             timeString(item.CreatedAt),
-		"updated_at":             timeString(item.UpdatedAt),
+		"id":                             item.ID.String(),
+		"name":                           item.Name,
+		"key":                            plaintext,
+		"key_prefix":                     item.KeyPrefix,
+		"masked_key":                     item.MaskedKey,
+		"key_kind":                       item.KeyKind,
+		"scope":                          item.Scope,
+		"status":                         item.Status,
+		"model_policy":                   item.ModelPolicy,
+		"site_policy":                    item.SitePolicy,
+		"model_mappings":                 modelMappingsPayload(item.ModelMappings),
+		"image_tool_bridge":              imageToolBridgePayload(item),
+		"quota_limit":                    nullFloat64Value(item.QuotaLimit),
+		"quota_used":                     item.QuotaUsed,
+		"quota_total_used":               item.EffectiveTotalQuotaUsed(),
+		"quota_available":                apiKeyQuotaAvailable(item),
+		"quota_total_available":          apiKeyQuotaAvailable(item),
+		"quota_total_reset_at":           timePtrValue(item.QuotaTotalResetAt),
+		"quota_unlimited":                item.QuotaUnlimited,
+		"quota_daily_limit":              nullFloat64Value(item.QuotaDailyLimit),
+		"quota_daily_used":               dailyUsed,
+		"quota_daily_available":          quotaAvailable(item.QuotaDailyLimit, dailyUsed, item.QuotaDailyUnlimited),
+		"quota_daily_unlimited":          item.QuotaDailyUnlimited,
+		"quota_daily_reset_at":           quotaResetAt(h.timeZone.StartOfDay(now).AddDate(0, 0, 1), item.QuotaDailyUnlimited),
+		"quota_weekly_limit":             nullFloat64Value(item.QuotaWeeklyLimit),
+		"quota_weekly_used":              weeklyUsed,
+		"quota_weekly_available":         quotaAvailable(item.QuotaWeeklyLimit, weeklyUsed, item.QuotaWeeklyUnlimited),
+		"quota_weekly_unlimited":         item.QuotaWeeklyUnlimited,
+		"quota_weekly_reset_at":          quotaResetAt(h.timeZone.StartOfWeek(now).AddDate(0, 0, 7), item.QuotaWeeklyUnlimited),
+		"auto_reset_oauth_connection_id": pointerUUIDValue(item.AutoResetOAuthConnectionID),
+		"auto_reset_last_reset_at":       timePtrValue(item.AutoResetLastResetAt),
+		"auto_reset_window":              apiKeyAutoResetWindow(item),
+		"auto_reset_scope":               apiKeyAutoResetScope(item),
+		"rate_limit":                     apiKeyRateLimitPayload(rateLimit),
+		"expires_at":                     timePtrValue(item.ExpiresAt),
+		"last_used_at":                   timePtrValue(item.LastUsedAt),
+		"site_models":                    apiKeySiteModelPayloads(models),
+		"sites":                          apiKeySitePayloads(sites),
+		"site_groups":                    apiKeySiteGroupPayloads(groups),
+		"created_at":                     timeString(item.CreatedAt),
+		"updated_at":                     timeString(item.UpdatedAt),
 	}
 }
 
@@ -800,33 +839,51 @@ func (h Handler) apiKeySyncPayload(item store.APIKey) map[string]any {
 	dailyUsed := item.EffectiveDailyQuotaUsed(now, h.timeZone)
 	weeklyUsed := item.EffectiveWeeklyQuotaUsed(now, h.timeZone)
 	return map[string]any{
-		"id":                     item.ID.String(),
-		"name":                   item.Name,
-		"key":                    nil,
-		"key_prefix":             item.KeyPrefix,
-		"masked_key":             item.MaskedKey,
-		"key_kind":               item.KeyKind,
-		"scope":                  item.Scope,
-		"status":                 item.Status,
-		"quota_limit":            nullFloat64Value(item.QuotaLimit),
-		"quota_used":             item.QuotaUsed,
-		"quota_total_used":       item.EffectiveTotalQuotaUsed(),
-		"quota_available":        apiKeyQuotaAvailable(item),
-		"quota_total_available":  apiKeyQuotaAvailable(item),
-		"quota_total_reset_at":   timePtrValue(item.QuotaTotalResetAt),
-		"quota_unlimited":        item.QuotaUnlimited,
-		"quota_daily_limit":      nullFloat64Value(item.QuotaDailyLimit),
-		"quota_daily_used":       dailyUsed,
-		"quota_daily_available":  quotaAvailable(item.QuotaDailyLimit, dailyUsed, item.QuotaDailyUnlimited),
-		"quota_daily_unlimited":  item.QuotaDailyUnlimited,
-		"quota_weekly_limit":     nullFloat64Value(item.QuotaWeeklyLimit),
-		"quota_weekly_used":      weeklyUsed,
-		"quota_weekly_available": quotaAvailable(item.QuotaWeeklyLimit, weeklyUsed, item.QuotaWeeklyUnlimited),
-		"quota_weekly_unlimited": item.QuotaWeeklyUnlimited,
-		"expires_at":             timePtrValue(item.ExpiresAt),
-		"created_at":             timeString(item.CreatedAt),
-		"updated_at":             timeString(item.UpdatedAt),
+		"id":                             item.ID.String(),
+		"name":                           item.Name,
+		"key":                            nil,
+		"key_prefix":                     item.KeyPrefix,
+		"masked_key":                     item.MaskedKey,
+		"key_kind":                       item.KeyKind,
+		"scope":                          item.Scope,
+		"status":                         item.Status,
+		"quota_limit":                    nullFloat64Value(item.QuotaLimit),
+		"quota_used":                     item.QuotaUsed,
+		"quota_total_used":               item.EffectiveTotalQuotaUsed(),
+		"quota_available":                apiKeyQuotaAvailable(item),
+		"quota_total_available":          apiKeyQuotaAvailable(item),
+		"quota_total_reset_at":           timePtrValue(item.QuotaTotalResetAt),
+		"quota_unlimited":                item.QuotaUnlimited,
+		"quota_daily_limit":              nullFloat64Value(item.QuotaDailyLimit),
+		"quota_daily_used":               dailyUsed,
+		"quota_daily_available":          quotaAvailable(item.QuotaDailyLimit, dailyUsed, item.QuotaDailyUnlimited),
+		"quota_daily_unlimited":          item.QuotaDailyUnlimited,
+		"quota_weekly_limit":             nullFloat64Value(item.QuotaWeeklyLimit),
+		"quota_weekly_used":              weeklyUsed,
+		"quota_weekly_available":         quotaAvailable(item.QuotaWeeklyLimit, weeklyUsed, item.QuotaWeeklyUnlimited),
+		"quota_weekly_unlimited":         item.QuotaWeeklyUnlimited,
+		"auto_reset_oauth_connection_id": pointerUUIDValue(item.AutoResetOAuthConnectionID),
+		"auto_reset_last_reset_at":       timePtrValue(item.AutoResetLastResetAt),
+		"auto_reset_window":              apiKeyAutoResetWindow(item),
+		"auto_reset_scope":               apiKeyAutoResetScope(item),
+		"expires_at":                     timePtrValue(item.ExpiresAt),
+		"created_at":                     timeString(item.CreatedAt),
+		"updated_at":                     timeString(item.UpdatedAt),
 	}
+}
+
+func apiKeyAutoResetWindow(item store.APIKey) any {
+	if item.AutoResetOAuthConnectionID == nil {
+		return nil
+	}
+	return "weekly"
+}
+
+func apiKeyAutoResetScope(item store.APIKey) any {
+	if item.AutoResetOAuthConnectionID == nil {
+		return nil
+	}
+	return "total"
 }
 
 func imageToolBridgePayload(item store.APIKey) any {

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -103,43 +103,45 @@ type CreateAPIKeyResult struct {
 }
 
 type CreateAPIKeyInput struct {
-	Name                 string
-	CustomKey            string
-	ModelPolicy          string
-	SiteModelIDs         []uuid.UUID
-	SitePolicy           string
-	SiteIDs              []uuid.UUID
-	SiteGroupIDs         []uuid.UUID
-	ModelRules           []store.APIKeyModelRule
-	ImageToolBridge      *ImageToolBridgeInput
-	QuotaLimit           *float64
-	QuotaUnlimited       bool
-	QuotaDailyLimit      *float64
-	QuotaDailyUnlimited  *bool
-	QuotaWeeklyLimit     *float64
-	QuotaWeeklyUnlimited *bool
-	ExpiresAt            *time.Time
-	RateLimit            *RateLimitInput
+	Name                       string
+	CustomKey                  string
+	ModelPolicy                string
+	SiteModelIDs               []uuid.UUID
+	SitePolicy                 string
+	SiteIDs                    []uuid.UUID
+	SiteGroupIDs               []uuid.UUID
+	ModelRules                 []store.APIKeyModelRule
+	ImageToolBridge            *ImageToolBridgeInput
+	QuotaLimit                 *float64
+	QuotaUnlimited             bool
+	QuotaDailyLimit            *float64
+	QuotaDailyUnlimited        *bool
+	QuotaWeeklyLimit           *float64
+	QuotaWeeklyUnlimited       *bool
+	AutoResetOAuthConnectionID *uuid.UUID
+	ExpiresAt                  *time.Time
+	RateLimit                  *RateLimitInput
 }
 
 type UpdateAPIKeyInput struct {
-	Name                 string
-	Status               string
-	ModelPolicy          string
-	SiteModelIDs         []uuid.UUID
-	SitePolicy           string
-	SiteIDs              []uuid.UUID
-	SiteGroupIDs         []uuid.UUID
-	ModelRules           []store.APIKeyModelRule
-	ImageToolBridge      *ImageToolBridgeInput
-	QuotaLimit           *float64
-	QuotaUnlimited       bool
-	QuotaDailyLimit      *float64
-	QuotaDailyUnlimited  *bool
-	QuotaWeeklyLimit     *float64
-	QuotaWeeklyUnlimited *bool
-	ExpiresAt            *time.Time
-	RateLimit            *RateLimitInput
+	Name                       string
+	Status                     string
+	ModelPolicy                string
+	SiteModelIDs               []uuid.UUID
+	SitePolicy                 string
+	SiteIDs                    []uuid.UUID
+	SiteGroupIDs               []uuid.UUID
+	ModelRules                 []store.APIKeyModelRule
+	ImageToolBridge            *ImageToolBridgeInput
+	QuotaLimit                 *float64
+	QuotaUnlimited             bool
+	QuotaDailyLimit            *float64
+	QuotaDailyUnlimited        *bool
+	QuotaWeeklyLimit           *float64
+	QuotaWeeklyUnlimited       *bool
+	AutoResetOAuthConnectionID *uuid.UUID
+	ExpiresAt                  *time.Time
+	RateLimit                  *RateLimitInput
 }
 
 type APIKeyDetails struct {
@@ -629,6 +631,9 @@ func (s *Service) CreateAPIKey(ctx context.Context, input CreateAPIKeyInput, adm
 	if err := validateAPIKeyQuota("quota_weekly_limit", input.QuotaWeeklyLimit, weeklyUnlimited, 0); err != nil {
 		return CreateAPIKeyResult{}, err
 	}
+	if err := s.validateAPIKeyAutoReset(ctx, input.AutoResetOAuthConnectionID, quotaUnlimited); err != nil {
+		return CreateAPIKeyResult{}, err
+	}
 
 	modelPolicy := normalizeModelPolicy(input.ModelPolicy)
 	siteModelIDs, err := s.normalizeExistingSiteModelIDs(ctx, input.SiteModelIDs)
@@ -663,26 +668,27 @@ func (s *Service) CreateAPIKey(ctx context.Context, input CreateAPIKeyInput, adm
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		apiKeyRepo := store.NewAPIKeyRepository(tx)
 		created, err := apiKeyRepo.Create(ctx, store.CreateAPIKeyParams{
-			Name:                 name,
-			KeyPrefix:            keyPrefix,
-			KeyHash:              hashToken(key),
-			EncryptedSecret:      encrypted,
-			MaskedKey:            masked,
-			KeyKind:              keyKind,
-			Scope:                "gateway",
-			Status:               "active",
-			ModelPolicy:          modelPolicy,
-			SitePolicy:           sitePolicy,
-			ModelMappings:        modelRules,
-			ImageToolBridge:      imageToolBridge,
-			QuotaLimit:           nullableFloat(input.QuotaLimit),
-			QuotaUnlimited:       quotaUnlimited,
-			QuotaDailyLimit:      nullableFloat(input.QuotaDailyLimit),
-			QuotaDailyUnlimited:  dailyUnlimited,
-			QuotaWeeklyLimit:     nullableFloat(input.QuotaWeeklyLimit),
-			QuotaWeeklyUnlimited: weeklyUnlimited,
-			ExpiresAt:            nullableTime(input.ExpiresAt),
-			CreatedByAdminID:     adminID,
+			Name:                       name,
+			KeyPrefix:                  keyPrefix,
+			KeyHash:                    hashToken(key),
+			EncryptedSecret:            encrypted,
+			MaskedKey:                  masked,
+			KeyKind:                    keyKind,
+			Scope:                      "gateway",
+			Status:                     "active",
+			ModelPolicy:                modelPolicy,
+			SitePolicy:                 sitePolicy,
+			ModelMappings:              modelRules,
+			ImageToolBridge:            imageToolBridge,
+			QuotaLimit:                 nullableFloat(input.QuotaLimit),
+			QuotaUnlimited:             quotaUnlimited,
+			QuotaDailyLimit:            nullableFloat(input.QuotaDailyLimit),
+			QuotaDailyUnlimited:        dailyUnlimited,
+			QuotaWeeklyLimit:           nullableFloat(input.QuotaWeeklyLimit),
+			QuotaWeeklyUnlimited:       weeklyUnlimited,
+			AutoResetOAuthConnectionID: input.AutoResetOAuthConnectionID,
+			ExpiresAt:                  nullableTime(input.ExpiresAt),
+			CreatedByAdminID:           adminID,
 		})
 		if err != nil {
 			return err
@@ -918,6 +924,9 @@ func (s *Service) UpdateAPIKey(ctx context.Context, id uuid.UUID, input UpdateAP
 	if err := validateAPIKeyQuota("quota_weekly_limit", weeklyLimit, weeklyUnlimited, current.EffectiveWeeklyQuotaUsed(time.Now(), s.timeZone)); err != nil {
 		return store.APIKey{}, err
 	}
+	if err := s.validateAPIKeyAutoReset(ctx, input.AutoResetOAuthConnectionID, quotaUnlimited); err != nil {
+		return store.APIKey{}, err
+	}
 
 	name := strings.TrimSpace(input.Name)
 	if name == "" {
@@ -983,23 +992,29 @@ func (s *Service) UpdateAPIKey(ctx context.Context, id uuid.UUID, input UpdateAP
 	}
 
 	var updated store.APIKey
+	autoResetLastResetAt := current.AutoResetLastResetAt
+	if !sameUUID(current.AutoResetOAuthConnectionID, input.AutoResetOAuthConnectionID) {
+		autoResetLastResetAt = nil
+	}
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
 		updated, err = store.NewAPIKeyRepository(tx).Update(ctx, store.UpdateAPIKeyParams{
-			ID:                   id,
-			Name:                 name,
-			Status:               status,
-			ModelPolicy:          modelPolicy,
-			SitePolicy:           sitePolicy,
-			ModelMappings:        modelRules,
-			ImageToolBridge:      imageToolBridge,
-			QuotaLimit:           nullableFloat(input.QuotaLimit),
-			QuotaUnlimited:       quotaUnlimited,
-			QuotaDailyLimit:      nullableFloat(dailyLimit),
-			QuotaDailyUnlimited:  dailyUnlimited,
-			QuotaWeeklyLimit:     nullableFloat(weeklyLimit),
-			QuotaWeeklyUnlimited: weeklyUnlimited,
-			ExpiresAt:            nullableTime(input.ExpiresAt),
+			ID:                         id,
+			Name:                       name,
+			Status:                     status,
+			ModelPolicy:                modelPolicy,
+			SitePolicy:                 sitePolicy,
+			ModelMappings:              modelRules,
+			ImageToolBridge:            imageToolBridge,
+			QuotaLimit:                 nullableFloat(input.QuotaLimit),
+			QuotaUnlimited:             quotaUnlimited,
+			QuotaDailyLimit:            nullableFloat(dailyLimit),
+			QuotaDailyUnlimited:        dailyUnlimited,
+			QuotaWeeklyLimit:           nullableFloat(weeklyLimit),
+			QuotaWeeklyUnlimited:       weeklyUnlimited,
+			AutoResetOAuthConnectionID: input.AutoResetOAuthConnectionID,
+			AutoResetLastResetAt:       autoResetLastResetAt,
+			ExpiresAt:                  nullableTime(input.ExpiresAt),
 		})
 		if err != nil {
 			return err
@@ -1155,19 +1170,21 @@ func (s *Service) SetAPIKeySiteModels(ctx context.Context, id uuid.UUID, siteMod
 		}
 		if strings.TrimSpace(modelPolicy) != "" && normalizeModelPolicy(modelPolicy) != current.ModelPolicy {
 			current, err = apiKeyRepo.Update(ctx, store.UpdateAPIKeyParams{
-				ID:                   id,
-				Name:                 current.Name,
-				Status:               current.Status,
-				ModelPolicy:          normalizeModelPolicy(modelPolicy),
-				SitePolicy:           current.SitePolicy,
-				ModelMappings:        current.ModelMappings,
-				QuotaLimit:           nullFloatAsAny(current.QuotaLimit),
-				QuotaUnlimited:       current.QuotaUnlimited,
-				QuotaDailyLimit:      nullFloatAsAny(current.QuotaDailyLimit),
-				QuotaDailyUnlimited:  current.QuotaDailyUnlimited,
-				QuotaWeeklyLimit:     nullFloatAsAny(current.QuotaWeeklyLimit),
-				QuotaWeeklyUnlimited: current.QuotaWeeklyUnlimited,
-				ExpiresAt:            timePtrAsAny(current.ExpiresAt),
+				ID:                         id,
+				Name:                       current.Name,
+				Status:                     current.Status,
+				ModelPolicy:                normalizeModelPolicy(modelPolicy),
+				SitePolicy:                 current.SitePolicy,
+				ModelMappings:              current.ModelMappings,
+				QuotaLimit:                 nullFloatAsAny(current.QuotaLimit),
+				QuotaUnlimited:             current.QuotaUnlimited,
+				QuotaDailyLimit:            nullFloatAsAny(current.QuotaDailyLimit),
+				QuotaDailyUnlimited:        current.QuotaDailyUnlimited,
+				QuotaWeeklyLimit:           nullFloatAsAny(current.QuotaWeeklyLimit),
+				QuotaWeeklyUnlimited:       current.QuotaWeeklyUnlimited,
+				AutoResetOAuthConnectionID: current.AutoResetOAuthConnectionID,
+				AutoResetLastResetAt:       current.AutoResetLastResetAt,
+				ExpiresAt:                  timePtrAsAny(current.ExpiresAt),
 			})
 			return err
 		}
@@ -1395,18 +1412,20 @@ func (s *Service) SetAPIKeySites(ctx context.Context, id uuid.UUID, siteIDs []uu
 		}
 		if strings.TrimSpace(sitePolicy) != "" && normalizeSitePolicy(sitePolicy) != current.SitePolicy {
 			current, err = apiKeyRepo.Update(ctx, store.UpdateAPIKeyParams{
-				ID:                   id,
-				Name:                 current.Name,
-				Status:               current.Status,
-				ModelPolicy:          current.ModelPolicy,
-				SitePolicy:           normalizeSitePolicy(sitePolicy),
-				QuotaLimit:           nullFloatAsAny(current.QuotaLimit),
-				QuotaUnlimited:       current.QuotaUnlimited,
-				QuotaDailyLimit:      nullFloatAsAny(current.QuotaDailyLimit),
-				QuotaDailyUnlimited:  current.QuotaDailyUnlimited,
-				QuotaWeeklyLimit:     nullFloatAsAny(current.QuotaWeeklyLimit),
-				QuotaWeeklyUnlimited: current.QuotaWeeklyUnlimited,
-				ExpiresAt:            timePtrAsAny(current.ExpiresAt),
+				ID:                         id,
+				Name:                       current.Name,
+				Status:                     current.Status,
+				ModelPolicy:                current.ModelPolicy,
+				SitePolicy:                 normalizeSitePolicy(sitePolicy),
+				QuotaLimit:                 nullFloatAsAny(current.QuotaLimit),
+				QuotaUnlimited:             current.QuotaUnlimited,
+				QuotaDailyLimit:            nullFloatAsAny(current.QuotaDailyLimit),
+				QuotaDailyUnlimited:        current.QuotaDailyUnlimited,
+				QuotaWeeklyLimit:           nullFloatAsAny(current.QuotaWeeklyLimit),
+				QuotaWeeklyUnlimited:       current.QuotaWeeklyUnlimited,
+				AutoResetOAuthConnectionID: current.AutoResetOAuthConnectionID,
+				AutoResetLastResetAt:       current.AutoResetLastResetAt,
+				ExpiresAt:                  timePtrAsAny(current.ExpiresAt),
 			})
 			return err
 		}
@@ -1442,19 +1461,21 @@ func (s *Service) SetAPIKeyModelMappings(ctx context.Context, id uuid.UUID, rule
 		return store.APIKey{}, err
 	}
 	return s.apiKeys.Update(ctx, store.UpdateAPIKeyParams{
-		ID:                   id,
-		Name:                 current.Name,
-		Status:               current.Status,
-		ModelPolicy:          current.ModelPolicy,
-		SitePolicy:           current.SitePolicy,
-		ModelMappings:        modelRules,
-		QuotaLimit:           nullFloatAsAny(current.QuotaLimit),
-		QuotaUnlimited:       current.QuotaUnlimited,
-		QuotaDailyLimit:      nullFloatAsAny(current.QuotaDailyLimit),
-		QuotaDailyUnlimited:  current.QuotaDailyUnlimited,
-		QuotaWeeklyLimit:     nullFloatAsAny(current.QuotaWeeklyLimit),
-		QuotaWeeklyUnlimited: current.QuotaWeeklyUnlimited,
-		ExpiresAt:            timePtrAsAny(current.ExpiresAt),
+		ID:                         id,
+		Name:                       current.Name,
+		Status:                     current.Status,
+		ModelPolicy:                current.ModelPolicy,
+		SitePolicy:                 current.SitePolicy,
+		ModelMappings:              modelRules,
+		QuotaLimit:                 nullFloatAsAny(current.QuotaLimit),
+		QuotaUnlimited:             current.QuotaUnlimited,
+		QuotaDailyLimit:            nullFloatAsAny(current.QuotaDailyLimit),
+		QuotaDailyUnlimited:        current.QuotaDailyUnlimited,
+		QuotaWeeklyLimit:           nullFloatAsAny(current.QuotaWeeklyLimit),
+		QuotaWeeklyUnlimited:       current.QuotaWeeklyUnlimited,
+		AutoResetOAuthConnectionID: current.AutoResetOAuthConnectionID,
+		AutoResetLastResetAt:       current.AutoResetLastResetAt,
+		ExpiresAt:                  timePtrAsAny(current.ExpiresAt),
 	})
 }
 
@@ -1864,6 +1885,32 @@ func normalizeSitePolicy(value string) string {
 	default:
 		return "allow_all"
 	}
+}
+
+func (s *Service) validateAPIKeyAutoReset(ctx context.Context, connectionID *uuid.UUID, quotaUnlimited bool) error {
+	if connectionID == nil || *connectionID == uuid.Nil {
+		return nil
+	}
+	if quotaUnlimited {
+		return fmt.Errorf("oauth weekly auto reset requires a limited total quota")
+	}
+	connection, err := store.NewOAuthConnectionRepository(s.db).GetByID(ctx, *connectionID)
+	if err != nil {
+		return fmt.Errorf("auto reset oauth connection was not found")
+	}
+	switch strings.TrimSpace(connection.Provider) {
+	case "codex", "claude_code":
+		return nil
+	default:
+		return fmt.Errorf("oauth provider %q does not expose a supported weekly quota", connection.Provider)
+	}
+}
+
+func sameUUID(left *uuid.UUID, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func validateAPIKeyQuota(field string, limit *float64, unlimited bool, used float64) error {

--- a/server/internal/oauth/service.go
+++ b/server/internal/oauth/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -966,13 +967,67 @@ func (s *Service) UpdateConnectionSync(ctx context.Context, connectionID uuid.UU
 	if len(connection.Metadata) > 0 {
 		_ = json.Unmarshal(connection.Metadata, &meta)
 	}
+	previousWeeklyResetAt, previousWeeklyResetOK := oauthWeeklyQuotaResetAt(meta)
 	for key, value := range metadataPatch {
 		meta[key] = value
+	}
+	currentWeeklyResetAt, currentWeeklyResetOK := oauthWeeklyQuotaResetAt(meta)
+	if weeklyResetOccurred(previousWeeklyResetAt, previousWeeklyResetOK, currentWeeklyResetAt, currentWeeklyResetOK, time.Now()) {
+		if _, err := store.NewAPIKeyRepository(s.db.DB()).ResetTotalForOAuthWeeklyReset(ctx, connectionID, currentWeeklyResetAt, time.Now()); err != nil {
+			return err
+		}
 	}
 	connection.Metadata = jsonBytes(meta)
 	connection.LastSyncAt = sql.NullTime{Time: time.Now(), Valid: true}
 	_, err = repo.Save(ctx, connection)
 	return err
+}
+
+func oauthWeeklyQuotaResetAt(metadata map[string]any) (time.Time, bool) {
+	quota, ok := metadata["quota"].(map[string]any)
+	if !ok {
+		return time.Time{}, false
+	}
+	weekly, ok := quota["weekly"].(map[string]any)
+	if !ok {
+		return time.Time{}, false
+	}
+	return oauthQuotaResetAt(weekly["reset_at"])
+}
+
+func oauthQuotaResetAt(value any) (time.Time, bool) {
+	var number float64
+	switch item := value.(type) {
+	case float64:
+		number = item
+	case int:
+		number = float64(item)
+	case int64:
+		number = float64(item)
+	case string:
+		text := strings.TrimSpace(item)
+		if parsed, err := time.Parse(time.RFC3339Nano, text); err == nil {
+			return parsed, true
+		}
+		parsed, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			return time.Time{}, false
+		}
+		number = parsed
+	default:
+		return time.Time{}, false
+	}
+	if number <= 0 {
+		return time.Time{}, false
+	}
+	if number >= 1e12 {
+		return time.UnixMilli(int64(number)), true
+	}
+	return time.Unix(int64(number), 0), true
+}
+
+func weeklyResetOccurred(previous time.Time, previousOK bool, current time.Time, currentOK bool, now time.Time) bool {
+	return previousOK && currentOK && !previous.After(now) && current.After(previous)
 }
 
 func (s *Service) MarkConnectionAccessTokenOnly(ctx context.Context, connectionID uuid.UUID) error {

--- a/server/internal/oauth/service_auto_reset_test.go
+++ b/server/internal/oauth/service_auto_reset_test.go
@@ -1,0 +1,57 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOAuthWeeklyResetTransition(t *testing.T) {
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	oldReset := now.Add(-time.Hour)
+
+	tests := []struct {
+		name                  string
+		previous, current     time.Time
+		previousOK, currentOK bool
+		want                  bool
+	}{
+		{name: "first sync", current: now.Add(time.Hour), currentOK: true},
+		{name: "upstream reset moved forward", previous: oldReset, current: now.Add(time.Hour), previousOK: true, currentOK: true, want: true},
+		{name: "same reset is idempotent", previous: oldReset, current: oldReset, previousOK: true, currentOK: true},
+		{name: "invalid previous reset", current: now.Add(time.Hour), currentOK: true},
+		{name: "invalid current reset", previous: oldReset, previousOK: true},
+		{name: "future previous reset", previous: now.Add(time.Hour), current: now.Add(2 * time.Hour), previousOK: true, currentOK: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := weeklyResetOccurred(test.previous, test.previousOK, test.current, test.currentOK, now); got != test.want {
+				t.Fatalf("weeklyResetOccurred() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestOAuthQuotaResetAtParsesUnixSecondsAndRFC3339(t *testing.T) {
+	want := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "unix seconds", value: want.Unix(), valid: true},
+		{name: "rfc3339 string", value: want.Format(time.RFC3339), valid: true},
+		{name: "invalid string", value: "not-a-time"},
+		{name: "zero", value: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := oauthQuotaResetAt(test.value)
+			if ok != test.valid || (ok && !got.Equal(want)) {
+				t.Fatalf("oauthQuotaResetAt(%#v) = %s, %v; want %s, %v", test.value, got, ok, want, test.valid)
+			}
+		})
+	}
+}

--- a/server/internal/site/service.go
+++ b/server/internal/site/service.go
@@ -698,7 +698,16 @@ func (s *Service) Delete(ctx context.Context, siteID uuid.UUID) error {
 	}
 
 	if err := s.db.WithinTx(ctx, func(tx store.Tx) error {
-		if err := store.NewOAuthConnectionRepository(tx).DeleteBySiteID(ctx, siteID); err != nil {
+		oauthRepo := store.NewOAuthConnectionRepository(tx)
+		connection, err := oauthRepo.GetBySiteID(ctx, siteID)
+		if err == nil {
+			if err := store.NewAPIKeyRepository(tx).ClearAutoResetOAuthConnection(ctx, connection.ID); err != nil {
+				return err
+			}
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		if err := oauthRepo.DeleteBySiteID(ctx, siteID); err != nil {
 			return err
 		}
 		if err := cleanupDeletedSiteRelations(ctx, tx, siteID); err != nil {

--- a/server/internal/store/api_key_oauth_auto_reset_test.go
+++ b/server/internal/store/api_key_oauth_auto_reset_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestAPIKeyRepositoryResetsTotalOnceForOAuthWeeklyReset(t *testing.T) {
+	apiKeyID := uuid.New()
+	oauthConnectionID := uuid.New()
+	upstreamResetAt := time.Date(2026, 8, 28, 11, 0, 0, 0, time.UTC)
+	now := upstreamResetAt.Add(time.Minute)
+	state := APIKey{
+		ID:                         apiKeyID,
+		AutoResetOAuthConnectionID: &oauthConnectionID,
+		QuotaLimit:                 sql.NullFloat64{Float64: 100, Valid: true},
+		QuotaTotalUsed:             42,
+		QuotaDailyUsed:             7,
+		QuotaWeeklyUsed:            21,
+	}
+	db := storeTransactionGorm(t, "oauth auto reset")
+	storeReplaceQueryCallback(t, db, func(tx *gorm.DB) {
+		switch destination := tx.Statement.Dest.(type) {
+		case *[]APIKey:
+			*destination = []APIKey{state}
+			tx.Statement.RowsAffected = 1
+		case *APIKey:
+			if locking, ok := tx.Statement.Clauses["FOR"].Expression.(clause.Locking); !ok || locking.Strength != clause.LockingStrengthUpdate {
+				tx.AddError(errors.New("oauth auto reset must lock api key row"))
+				return
+			}
+			*destination = state
+			tx.Statement.RowsAffected = 1
+		default:
+			tx.AddError(errors.New("unexpected oauth auto reset query destination"))
+		}
+	})
+	storeReplaceUpdateCallback(t, db, func(tx *gorm.DB) {
+		updates, ok := tx.Statement.Dest.(map[string]any)
+		if !ok {
+			tx.AddError(errors.New("unexpected oauth auto reset update destination"))
+			return
+		}
+		if updates["quota_total_used"] != 0 {
+			tx.AddError(errors.New("oauth auto reset must clear total usage"))
+			return
+		}
+		if updates["quota_daily_used"] != nil || updates["quota_weekly_used"] != nil {
+			tx.AddError(errors.New("oauth auto reset must preserve periodic usage"))
+			return
+		}
+		state.QuotaTotalUsed = 0
+		resetAt, ok := updates["quota_total_reset_at"].(*time.Time)
+		if !ok || resetAt == nil || !resetAt.Equal(now) {
+			tx.AddError(errors.New("oauth auto reset must record reset time"))
+			return
+		}
+		lastResetAt, ok := updates["auto_reset_last_reset_at"].(time.Time)
+		if !ok || !lastResetAt.Equal(upstreamResetAt) {
+			tx.AddError(errors.New("oauth auto reset must record upstream reset time"))
+			return
+		}
+		state.AutoResetLastResetAt = &lastResetAt
+		tx.Statement.RowsAffected = 1
+	})
+
+	repo := NewAPIKeyRepository(db)
+	resetCount, err := repo.ResetTotalForOAuthWeeklyReset(context.Background(), oauthConnectionID, upstreamResetAt, now)
+	if err != nil {
+		t.Fatalf("first reset returned error: %v", err)
+	}
+	if resetCount != 1 || state.QuotaTotalUsed != 0 || state.QuotaDailyUsed != 7 || state.QuotaWeeklyUsed != 21 {
+		t.Fatalf("first reset count/state = %d/%#v", resetCount, state)
+	}
+
+	resetCount, err = repo.ResetTotalForOAuthWeeklyReset(context.Background(), oauthConnectionID, upstreamResetAt, now)
+	if err != nil {
+		t.Fatalf("duplicate reset returned error: %v", err)
+	}
+	if resetCount != 0 {
+		t.Fatalf("duplicate reset count = %d, want 0", resetCount)
+	}
+}

--- a/server/internal/store/api_key_repository.go
+++ b/server/internal/store/api_key_repository.go
@@ -18,37 +18,39 @@ import (
 )
 
 type APIKey struct {
-	ID                     uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	Name                   string
-	KeyPrefix              string
-	KeyHash                string `gorm:"column:key_hash"`
-	EncryptedSecret        sql.NullString
-	MaskedKey              string
-	KeyKind                string `gorm:"default:generated;not null"`
-	Scope                  string
-	Status                 string
-	ModelPolicy            string
-	SitePolicy             string
-	ModelMappings          JSON `gorm:"type:jsonb;default:'[]'::jsonb"`
-	ImageToolBridge        JSON `gorm:"type:jsonb;default:'{}'::jsonb"`
-	QuotaLimit             sql.NullFloat64
-	QuotaUsed              float64
-	QuotaTotalUsed         float64 `gorm:"type:numeric(18,8);default:0;not null"`
-	QuotaTotalResetAt      *time.Time
-	QuotaUnlimited         bool
-	QuotaDailyLimit        sql.NullFloat64 `gorm:"type:numeric(18,8)"`
-	QuotaDailyUsed         float64         `gorm:"type:numeric(18,8);default:0;not null"`
-	QuotaDailyUnlimited    bool            `gorm:"default:true;not null"`
-	QuotaDailyWindowStart  *time.Time
-	QuotaWeeklyLimit       sql.NullFloat64 `gorm:"type:numeric(18,8)"`
-	QuotaWeeklyUsed        float64         `gorm:"type:numeric(18,8);default:0;not null"`
-	QuotaWeeklyUnlimited   bool            `gorm:"default:true;not null"`
-	QuotaWeeklyWindowStart *time.Time
-	CreatedByAdminID       *uuid.UUID
-	LastUsedAt             *time.Time
-	ExpiresAt              *time.Time
-	CreatedAt              time.Time
-	UpdatedAt              time.Time
+	ID                         uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	Name                       string
+	KeyPrefix                  string
+	KeyHash                    string `gorm:"column:key_hash"`
+	EncryptedSecret            sql.NullString
+	MaskedKey                  string
+	KeyKind                    string `gorm:"default:generated;not null"`
+	Scope                      string
+	Status                     string
+	ModelPolicy                string
+	SitePolicy                 string
+	ModelMappings              JSON `gorm:"type:jsonb;default:'[]'::jsonb"`
+	ImageToolBridge            JSON `gorm:"type:jsonb;default:'{}'::jsonb"`
+	QuotaLimit                 sql.NullFloat64
+	QuotaUsed                  float64
+	QuotaTotalUsed             float64 `gorm:"type:numeric(18,8);default:0;not null"`
+	QuotaTotalResetAt          *time.Time
+	QuotaUnlimited             bool
+	QuotaDailyLimit            sql.NullFloat64 `gorm:"type:numeric(18,8)"`
+	QuotaDailyUsed             float64         `gorm:"type:numeric(18,8);default:0;not null"`
+	QuotaDailyUnlimited        bool            `gorm:"default:true;not null"`
+	QuotaDailyWindowStart      *time.Time
+	QuotaWeeklyLimit           sql.NullFloat64 `gorm:"type:numeric(18,8)"`
+	QuotaWeeklyUsed            float64         `gorm:"type:numeric(18,8);default:0;not null"`
+	QuotaWeeklyUnlimited       bool            `gorm:"default:true;not null"`
+	QuotaWeeklyWindowStart     *time.Time
+	AutoResetOAuthConnectionID *uuid.UUID
+	AutoResetLastResetAt       *time.Time
+	CreatedByAdminID           *uuid.UUID
+	LastUsedAt                 *time.Time
+	ExpiresAt                  *time.Time
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
 }
 
 type APIKeyListOption struct {
@@ -99,43 +101,46 @@ type APIKeySitePermission struct {
 }
 
 type CreateAPIKeyParams struct {
-	Name                 string
-	KeyPrefix            string
-	KeyHash              string
-	EncryptedSecret      any
-	MaskedKey            string
-	KeyKind              string
-	Scope                string
-	Status               string
-	ModelPolicy          string
-	SitePolicy           string
-	ModelMappings        any
-	ImageToolBridge      any
-	QuotaLimit           any
-	QuotaUnlimited       bool
-	QuotaDailyLimit      any
-	QuotaDailyUnlimited  bool
-	QuotaWeeklyLimit     any
-	QuotaWeeklyUnlimited bool
-	ExpiresAt            any
-	CreatedByAdminID     uuid.UUID
+	Name                       string
+	KeyPrefix                  string
+	KeyHash                    string
+	EncryptedSecret            any
+	MaskedKey                  string
+	KeyKind                    string
+	Scope                      string
+	Status                     string
+	ModelPolicy                string
+	SitePolicy                 string
+	ModelMappings              any
+	ImageToolBridge            any
+	QuotaLimit                 any
+	QuotaUnlimited             bool
+	QuotaDailyLimit            any
+	QuotaDailyUnlimited        bool
+	QuotaWeeklyLimit           any
+	QuotaWeeklyUnlimited       bool
+	AutoResetOAuthConnectionID *uuid.UUID
+	ExpiresAt                  any
+	CreatedByAdminID           uuid.UUID
 }
 
 type UpdateAPIKeyParams struct {
-	ID                   uuid.UUID
-	Name                 string
-	Status               string
-	ModelPolicy          string
-	SitePolicy           string
-	ModelMappings        any
-	ImageToolBridge      any
-	QuotaLimit           any
-	QuotaUnlimited       bool
-	QuotaDailyLimit      any
-	QuotaDailyUnlimited  bool
-	QuotaWeeklyLimit     any
-	QuotaWeeklyUnlimited bool
-	ExpiresAt            any
+	ID                         uuid.UUID
+	Name                       string
+	Status                     string
+	ModelPolicy                string
+	SitePolicy                 string
+	ModelMappings              any
+	ImageToolBridge            any
+	QuotaLimit                 any
+	QuotaUnlimited             bool
+	QuotaDailyLimit            any
+	QuotaDailyUnlimited        bool
+	QuotaWeeklyLimit           any
+	QuotaWeeklyUnlimited       bool
+	AutoResetOAuthConnectionID *uuid.UUID
+	AutoResetLastResetAt       *time.Time
+	ExpiresAt                  any
 }
 
 type APIKeyRepository struct {
@@ -345,19 +350,21 @@ func (r APIKeyRepository) Update(ctx context.Context, params UpdateAPIKeyParams)
 		return APIKey{}, err
 	}
 	updates := map[string]any{
-		"name":                   params.Name,
-		"status":                 params.Status,
-		"model_policy":           params.ModelPolicy,
-		"site_policy":            params.SitePolicy,
-		"model_mappings":         jsonDefault(jsonFromAny(params.ModelMappings, string(apiKey.ModelMappings)), "[]"),
-		"image_tool_bridge":      jsonDefault(jsonFromAny(params.ImageToolBridge, string(apiKey.ImageToolBridge)), "{}"),
-		"quota_limit":            nullFloatFromAny(params.QuotaLimit),
-		"quota_unlimited":        params.QuotaUnlimited,
-		"quota_daily_limit":      nullFloatFromAny(params.QuotaDailyLimit),
-		"quota_daily_unlimited":  params.QuotaDailyUnlimited,
-		"quota_weekly_limit":     nullFloatFromAny(params.QuotaWeeklyLimit),
-		"quota_weekly_unlimited": params.QuotaWeeklyUnlimited,
-		"expires_at":             timePtrFromAny(params.ExpiresAt),
+		"name":                           params.Name,
+		"status":                         params.Status,
+		"model_policy":                   params.ModelPolicy,
+		"site_policy":                    params.SitePolicy,
+		"model_mappings":                 jsonDefault(jsonFromAny(params.ModelMappings, string(apiKey.ModelMappings)), "[]"),
+		"image_tool_bridge":              jsonDefault(jsonFromAny(params.ImageToolBridge, string(apiKey.ImageToolBridge)), "{}"),
+		"quota_limit":                    nullFloatFromAny(params.QuotaLimit),
+		"quota_unlimited":                params.QuotaUnlimited,
+		"quota_daily_limit":              nullFloatFromAny(params.QuotaDailyLimit),
+		"quota_daily_unlimited":          params.QuotaDailyUnlimited,
+		"quota_weekly_limit":             nullFloatFromAny(params.QuotaWeeklyLimit),
+		"quota_weekly_unlimited":         params.QuotaWeeklyUnlimited,
+		"auto_reset_oauth_connection_id": params.AutoResetOAuthConnectionID,
+		"auto_reset_last_reset_at":       params.AutoResetLastResetAt,
+		"expires_at":                     timePtrFromAny(params.ExpiresAt),
 	}
 	if err := r.db.WithContext(ctx).Model(&APIKey{ID: params.ID}).Updates(updates).Error; err != nil {
 		return APIKey{}, fmt.Errorf("update api key: %w", err)
@@ -367,6 +374,66 @@ func (r APIKeyRepository) Update(ctx context.Context, params UpdateAPIKeyParams)
 		return APIKey{}, fmt.Errorf("load updated api key: %w", err)
 	}
 	return updated, nil
+}
+
+// ResetTotalForOAuthWeeklyReset applies one observed upstream weekly reset to
+// every bound key. The row lock and reset timestamp make repeated site
+// refreshes and concurrent manual refreshes idempotent.
+func (r APIKeyRepository) ResetTotalForOAuthWeeklyReset(ctx context.Context, oauthConnectionID uuid.UUID, upstreamResetAt time.Time, now time.Time) (int, error) {
+	if oauthConnectionID == uuid.Nil || upstreamResetAt.IsZero() {
+		return 0, nil
+	}
+
+	var apiKeys []APIKey
+	if err := r.db.WithContext(ctx).Where("auto_reset_oauth_connection_id = ?", oauthConnectionID).Find(&apiKeys).Error; err != nil {
+		return 0, fmt.Errorf("list api keys for oauth weekly reset: %w", err)
+	}
+	resetCount := 0
+	for _, item := range apiKeys {
+		reset := false
+		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var apiKey APIKey
+			if err := tx.Clauses(clause.Locking{Strength: clause.LockingStrengthUpdate}).Where(&APIKey{ID: item.ID}).First(&apiKey).Error; err != nil {
+				return err
+			}
+			if apiKey.AutoResetLastResetAt != nil && !upstreamResetAt.After(*apiKey.AutoResetLastResetAt) {
+				return nil
+			}
+			updates := map[string]any{"auto_reset_last_reset_at": upstreamResetAt}
+			if !apiKey.QuotaUnlimited && apiKey.QuotaLimit.Valid && apiKey.QuotaLimit.Float64 > 0 {
+				resetAt := now
+				updates["quota_total_used"] = 0
+				updates["quota_total_reset_at"] = &resetAt
+				reset = true
+			}
+			if err := tx.Model(&apiKey).Updates(updates).Error; err != nil {
+				return fmt.Errorf("reset api key total quota: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return resetCount, err
+		}
+		if reset {
+			resetCount++
+		}
+	}
+	return resetCount, nil
+}
+
+func (r APIKeyRepository) ClearAutoResetOAuthConnection(ctx context.Context, oauthConnectionID uuid.UUID) error {
+	if oauthConnectionID == uuid.Nil {
+		return nil
+	}
+	if err := r.db.WithContext(ctx).Model(&APIKey{}).
+		Where("auto_reset_oauth_connection_id = ?", oauthConnectionID).
+		Updates(map[string]any{
+			"auto_reset_oauth_connection_id": nil,
+			"auto_reset_last_reset_at":       nil,
+		}).Error; err != nil {
+		return fmt.Errorf("clear api key oauth auto reset: %w", err)
+	}
+	return nil
 }
 
 type RotateAPIKeySecretParams struct {

--- a/server/internal/store/bootstrap.go
+++ b/server/internal/store/bootstrap.go
@@ -279,6 +279,17 @@ func ensureSchemaUpgrades(ctx context.Context, db *gorm.DB) error {
 			return fmt.Errorf("ensure api_keys quota column %s: %w", field, err)
 		}
 	}
+	for _, field := range []string{"AutoResetOAuthConnectionID", "AutoResetLastResetAt"} {
+		if migrator.HasColumn(&APIKey{}, field) {
+			continue
+		}
+		if err := migrator.AddColumn(&APIKey{}, field); err != nil {
+			return fmt.Errorf("ensure api_keys auto reset column %s: %w", field, err)
+		}
+	}
+	if err := ensureSchemaIndex(migrator, &APIKey{}, "api_keys_auto_reset_oauth_connection_id_idx"); err != nil {
+		return err
+	}
 	if err := ensureAPIKeyTotalQuotaBackfill(ctx, db, time.Now()); err != nil {
 		return err
 	}

--- a/server/migrations/00001_initial_schema.sql
+++ b/server/migrations/00001_initial_schema.sql
@@ -108,6 +108,8 @@ CREATE TABLE api_keys (
   quota_weekly_used NUMERIC(18,8) NOT NULL DEFAULT 0,
   quota_weekly_unlimited BOOLEAN NOT NULL DEFAULT TRUE,
   quota_weekly_window_start TIMESTAMPTZ,
+  auto_reset_oauth_connection_id UUID,
+  auto_reset_last_reset_at TIMESTAMPTZ,
   created_by_admin_id UUID REFERENCES admins(id) ON DELETE SET NULL,
   last_used_at TIMESTAMPTZ,
   expires_at TIMESTAMPTZ,
@@ -117,6 +119,7 @@ CREATE TABLE api_keys (
 
 CREATE INDEX api_keys_status_idx ON api_keys (status);
 CREATE INDEX api_keys_scope_status_idx ON api_keys (scope, status);
+CREATE INDEX api_keys_auto_reset_oauth_connection_id_idx ON api_keys (auto_reset_oauth_connection_id);
 
 CREATE TABLE sites (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/web/src/features/api-keys/api/api-keys.ts
+++ b/web/src/features/api-keys/api/api-keys.ts
@@ -89,6 +89,10 @@ export type DownstreamAPIKey = {
   quota_weekly_available?: number | null
   quota_weekly_unlimited?: boolean
   quota_weekly_reset_at?: string | null
+  auto_reset_oauth_connection_id?: string | null
+  auto_reset_last_reset_at?: string | null
+  auto_reset_window?: 'weekly' | string | null
+  auto_reset_scope?: 'total' | string | null
   rate_limit?: RateLimitConfig | null
   expires_at?: string | null
   last_used_at?: string | null
@@ -117,6 +121,7 @@ export type APIKeyUpsertInput = {
   quotaDailyUnlimited: boolean
   quotaWeeklyLimit?: number | null
   quotaWeeklyUnlimited: boolean
+  autoResetOAuthConnectionId?: string | null
   rateLimit?: RateLimitConfig
   expiresAt?: string | null
 }
@@ -272,6 +277,7 @@ function apiKeyUpsertBody(input: APIKeyUpsertInput) {
     quota_daily_unlimited: input.quotaDailyUnlimited,
     quota_weekly_limit: input.quotaWeeklyUnlimited ? null : input.quotaWeeklyLimit,
     quota_weekly_unlimited: input.quotaWeeklyUnlimited,
+    auto_reset_oauth_connection_id: input.autoResetOAuthConnectionId ?? null,
     rate_limit: input.rateLimit,
     expires_at: input.expiresAt ?? null,
   }

--- a/web/src/features/api-keys/components/api-key-form-draw.tsx
+++ b/web/src/features/api-keys/components/api-key-form-draw.tsx
@@ -34,6 +34,7 @@ import {
 import { siteModelItems } from '@/features/sites/lib/site-cache'
 import { sortSitesByName } from '@/features/sites/lib/site-utils'
 import type { SiteGroup } from '@/features/settings/api/site-groups'
+import type { OAuthConnectionListItem } from '@/features/oauth/api/oauth'
 
 const CUSTOM_API_KEY_PATTERN = /^[A-Za-z0-9-]+$/
 
@@ -77,6 +78,8 @@ export function APIKeyFormDraw({
   sitesLoading,
   siteGroups,
   siteGroupsLoading,
+  oauthConnections,
+  oauthConnectionsLoading,
   pending,
   onOpenChange,
   onSubmit,
@@ -89,6 +92,8 @@ export function APIKeyFormDraw({
   sitesLoading: boolean
   siteGroups: SiteGroup[]
   siteGroupsLoading: boolean
+  oauthConnections: OAuthConnectionListItem[]
+  oauthConnectionsLoading: boolean
   pending: boolean
   onOpenChange: (open: boolean) => void
   onSubmit: (input: APIKeyUpsertInput) => void
@@ -135,6 +140,15 @@ export function APIKeyFormDraw({
     label: group.name,
     description: t('form.fields.groupSiteCount', { count: group.sites.length }),
   })), [siteGroups, t])
+  const autoResetOAuthOptions = useMemo(
+    () => oauthConnections
+      .filter((connection) => (
+        (connection.provider === 'codex' || connection.provider === 'claude_code') &&
+        (connection.status === 'connected' || connection.status === 'pending_sync')
+      ))
+      .sort((left, right) => (left.email ?? left.account_id ?? '').localeCompare(right.email ?? right.account_id ?? '')),
+    [oauthConnections],
+  )
   const inheritedSiteIds = useMemo(() => {
     if (values.sitePolicy !== 'allow_list') return []
     const ids = new Set<string>()
@@ -396,6 +410,10 @@ export function APIKeyFormDraw({
       toast.error(t('form.validation.quotaTooLow', { used: quotaTotalUsed }))
       return
     }
+    if (parsedQuotaLimit == null && values.autoResetOAuthConnectionId) {
+      toast.error(t('form.validation.autoResetQuotaRequired'))
+      return
+    }
 
     const parsedQuotaDailyLimit = parseQuotaLimit(values.quotaDailyLimit)
     const quotaDailyUsed = initialKey?.quota_daily_used ?? 0
@@ -490,6 +508,7 @@ export function APIKeyFormDraw({
       quotaDailyUnlimited: parsedQuotaDailyLimit == null,
       quotaWeeklyLimit: parsedQuotaWeeklyLimit,
       quotaWeeklyUnlimited: parsedQuotaWeeklyLimit == null,
+      autoResetOAuthConnectionId: values.autoResetOAuthConnectionId || null,
       rateLimit: {
         status: values.rateLimitEnabled ? 'enabled' : 'disabled',
         rpm_limit: parsedRPMLimit || null,
@@ -857,6 +876,36 @@ export function APIKeyFormDraw({
                 value={values.quotaWeeklyLimit}
                 onChange={(quotaWeeklyLimit) => setValues((current) => ({ ...current, quotaWeeklyLimit }))}
               />
+            </FormField>
+            <FormField
+              label={t('form.fields.autoReset')}
+              description={t('form.fields.autoResetDesc')}
+            >
+              <Select
+                value={values.autoResetOAuthConnectionId || 'none'}
+                disabled={oauthConnectionsLoading || parseQuotaLimit(values.quotaLimit) == null}
+                onValueChange={(value) => setValues((current) => ({
+                  ...current,
+                  autoResetOAuthConnectionId: value === 'none' ? '' : value,
+                }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t('form.fields.autoResetNone')} />
+                </SelectTrigger>
+                <SelectContent searchable={false}>
+                  <SelectItem value="none">{t('form.fields.autoResetNone')}</SelectItem>
+                  {autoResetOAuthOptions.map((connection) => (
+                    <SelectItem key={connection.id} value={connection.id}>
+                      {connection.provider} · {connection.email ?? connection.account_id ?? connection.id.slice(0, 8)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {values.autoResetOAuthConnectionId ? (
+                <div className="mt-2 rounded-lg border border-[hsl(var(--glass-border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-xs leading-5 text-muted-soft">
+                  {t('form.fields.autoResetSummary')}
+                </div>
+              ) : null}
             </FormField>
           </FormSection>
 

--- a/web/src/features/api-keys/components/downstream-api-keys-table.tsx
+++ b/web/src/features/api-keys/components/downstream-api-keys-table.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { DataTable } from '@/components/common/data-table'
 import { EmptyState } from '@/components/common/empty-state'
+import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
 import type { DownstreamAPIKey } from '@/features/api-keys/api/api-keys'
 import { APIKeyActionsMenu } from '@/features/api-keys/components/api-key-actions-menu'
@@ -56,8 +57,15 @@ export function DownstreamAPIKeysTable({
         header: t('table.headers.key'),
         cell: ({ row }) => (
           <div className="min-w-0 space-y-1">
-            <div className="truncate font-medium text-foreground" title={row.original.name}>
-              {row.original.name}
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="truncate font-medium text-foreground" title={row.original.name}>
+                {row.original.name}
+              </div>
+              {row.original.auto_reset_oauth_connection_id ? (
+                <Badge variant="info" className="px-1.5 py-0 text-[10px]" title={t('table.autoResetHint')}>
+                  {t('table.autoReset')}
+                </Badge>
+              ) : null}
             </div>
             <APIKeyCopyMenu apiKey={row.original} />
           </div>

--- a/web/src/features/api-keys/components/downstream-api-keys-workspace.tsx
+++ b/web/src/features/api-keys/components/downstream-api-keys-workspace.tsx
@@ -61,12 +61,14 @@ import {
   type Site,
 } from '@/features/sites/api/sites'
 import { listSiteGroups, siteGroupQueryKeys, type SiteGroup } from '@/features/settings/api/site-groups'
+import { listOAuthConnections, oauthQueryKeys, type OAuthConnectionListItem } from '@/features/oauth/api/oauth'
 import { useMobileLayout } from '@/hooks/use-media-query'
 
 const EMPTY_API_KEYS: DownstreamAPIKey[] = []
 const EMPTY_MODELS: CanonicalModelItem[] = []
 const EMPTY_SITES: Site[] = []
 const EMPTY_SITE_GROUPS: SiteGroup[] = []
+const EMPTY_OAUTH_CONNECTIONS: OAuthConnectionListItem[] = []
 
 export function DownstreamAPIKeysWorkspace() {
   const { t } = useTranslation('api-keys')
@@ -107,6 +109,10 @@ export function DownstreamAPIKeysWorkspace() {
     queryKey: siteGroupQueryKeys.list(),
     queryFn: listSiteGroups,
   })
+  const oauthConnectionsQuery = useQuery({
+    queryKey: oauthQueryKeys.connections(),
+    queryFn: listOAuthConnections,
+  })
 
   const apiKeys = apiKeysQuery.data?.items ?? EMPTY_API_KEYS
   const canonicalModels = useMemo(
@@ -115,6 +121,7 @@ export function DownstreamAPIKeysWorkspace() {
   )
   const sites = sitesQuery.data?.items ?? EMPTY_SITES
   const siteGroups = siteGroupsQuery.data?.items ?? EMPTY_SITE_GROUPS
+  const oauthConnections = oauthConnectionsQuery.data?.items ?? EMPTY_OAUTH_CONNECTIONS
 
   const filteredAPIKeys = useMemo(() => {
     const keyword = search.trim().toLowerCase()
@@ -273,6 +280,8 @@ export function DownstreamAPIKeysWorkspace() {
           sitesLoading={sitesQuery.isLoading}
           siteGroups={siteGroups}
           siteGroupsLoading={siteGroupsQuery.isLoading}
+          oauthConnections={oauthConnections}
+          oauthConnectionsLoading={oauthConnectionsQuery.isLoading}
           pending={saveMutation.isPending && (saveMutation.variables?.id ?? null) === (editingKey?.id ?? null)}
           onOpenChange={(open) => {
             if (!open && !saveMutation.isPending) {

--- a/web/src/features/api-keys/components/mobile-api-keys-list.tsx
+++ b/web/src/features/api-keys/components/mobile-api-keys-list.tsx
@@ -119,6 +119,11 @@ function MobileAPIKeyCard({
             >
               {active ? t('workspace.status.active') : t('workspace.status.disabled')}
             </Badge>
+            {apiKey.auto_reset_oauth_connection_id ? (
+              <Badge variant="info" className="px-1.5 py-0 text-[10px]" title={t('table.autoResetHint')}>
+                {t('table.autoReset')}
+              </Badge>
+            ) : null}
           </div>
           <APIKeyCopyMenu apiKey={apiKey} triggerClassName="mt-1.5" />
         </div>

--- a/web/src/features/api-keys/lib/api-key-utils.ts
+++ b/web/src/features/api-keys/lib/api-key-utils.ts
@@ -26,6 +26,7 @@ const defaultFormValues: APIKeyFormValues = {
   quotaLimit: '',
   quotaDailyLimit: '',
   quotaWeeklyLimit: '',
+  autoResetOAuthConnectionId: '',
   rateLimitEnabled: false,
   rpmLimit: '',
   tpmLimit: '',
@@ -59,6 +60,7 @@ export function formValuesFromAPIKey(apiKey: DownstreamAPIKey | null): APIKeyFor
     quotaLimit: apiKey.quota_unlimited || apiKey.quota_limit == null ? '' : String(apiKey.quota_limit),
     quotaDailyLimit: apiKey.quota_daily_unlimited || apiKey.quota_daily_limit == null ? '' : String(apiKey.quota_daily_limit),
     quotaWeeklyLimit: apiKey.quota_weekly_unlimited || apiKey.quota_weekly_limit == null ? '' : String(apiKey.quota_weekly_limit),
+    autoResetOAuthConnectionId: apiKey.auto_reset_oauth_connection_id ?? '',
     rateLimitEnabled: apiKey.rate_limit?.status === 'enabled',
     rpmLimit: apiKey.rate_limit?.rpm_limit == null ? '' : String(apiKey.rate_limit.rpm_limit),
     tpmLimit: apiKey.rate_limit?.tpm_limit == null ? '' : String(apiKey.rate_limit.tpm_limit),
@@ -178,6 +180,7 @@ export function toUpdateInput(
     quotaDailyUnlimited: apiKey.quota_daily_unlimited || apiKey.quota_daily_limit == null,
     quotaWeeklyLimit: apiKey.quota_weekly_limit ?? null,
     quotaWeeklyUnlimited: apiKey.quota_weekly_unlimited || apiKey.quota_weekly_limit == null,
+    autoResetOAuthConnectionId: apiKey.auto_reset_oauth_connection_id ?? null,
     rateLimit: {
       status: apiKey.rate_limit?.status === 'enabled' ? 'enabled' : 'disabled',
       rpm_limit: apiKey.rate_limit?.rpm_limit ?? null,

--- a/web/src/features/api-keys/lib/types.ts
+++ b/web/src/features/api-keys/lib/types.ts
@@ -17,6 +17,7 @@ export type APIKeyFormValues = {
   quotaLimit: string
   quotaDailyLimit: string
   quotaWeeklyLimit: string
+  autoResetOAuthConnectionId: string
   rateLimitEnabled: boolean
   rpmLimit: string
   tpmLimit: string

--- a/web/src/locales/en/api-keys.json
+++ b/web/src/locales/en/api-keys.json
@@ -62,7 +62,9 @@
     "rotate": "Rotate key",
     "rotateCustomDisabled": "Custom keys cannot be rotated",
     "expired": "Expired",
-    "expiredToggleHint": "Expired — extend the expiration time first"
+    "expiredToggleHint": "Expired — extend the expiration time first",
+    "autoReset": "Auto reset",
+    "autoResetHint": "OAuth weekly reset resets this key's total quota"
   },
   "workspace": {
     "loadFailed": "Failed to load API keys",
@@ -186,7 +188,11 @@
       "quotaDailyLimit": "Daily quota limit",
       "quotaDailyDesc": "Empty or 0 means unlimited · Resets daily · Used ${{used}} in the current period",
       "quotaWeeklyLimit": "Weekly quota limit",
-      "quotaWeeklyDesc": "Empty or 0 means unlimited · Resets every Monday · Used ${{used}} in the current period"
+      "quotaWeeklyDesc": "Empty or 0 means unlimited · Resets every Monday · Used ${{used}} in the current period",
+      "autoReset": "Automatic total quota reset",
+      "autoResetDesc": "Reset this key's total quota when the selected OAuth account's weekly quota resets.",
+      "autoResetNone": "Disabled",
+      "autoResetSummary": "OAuth weekly reset → this key's total quota. Daily and weekly local quotas are unchanged."
     },
     "advanced": {
       "modelMapping": "Model mapping",
@@ -230,6 +236,7 @@
       "quotaDailyTooLow": "Daily quota cannot be less than current-period usage (${{used}})",
       "quotaWeeklyInvalid": "Please enter a valid weekly quota",
       "quotaWeeklyTooLow": "Weekly quota cannot be less than current-period usage (${{used}})",
+      "autoResetQuotaRequired": "A limited total quota is required for automatic reset",
       "rateLimitRequired": "At least one limit is required when rate limiting is enabled",
       "rpmInvalid": "In-flight limit must be an integer greater than 0",
       "tpmInvalid": "TPM must be a positive integer",

--- a/web/src/locales/jp/api-keys.json
+++ b/web/src/locales/jp/api-keys.json
@@ -62,7 +62,9 @@
     "rotate": "キーをローテーション",
     "rotateCustomDisabled": "カスタムキーはローテーションできません",
     "expired": "期限切れ",
-    "expiredToggleHint": "期限切れです。先に有効期限を延長してください"
+    "expiredToggleHint": "期限切れです。先に有効期限を延長してください",
+    "autoReset": "自動リセット",
+    "autoResetHint": "OAuth の週次リセット時にこのキーの合計クォータをリセットします"
   },
   "workspace": {
     "loadFailed": "API キーの読み込みに失敗しました",
@@ -186,7 +188,11 @@
       "quotaDailyLimit": "日次クォータ上限",
       "quotaDailyDesc": "空欄または 0 は無制限 · 毎日リセット · 現在の期間で ${{used}} 使用済み",
       "quotaWeeklyLimit": "週次クォータ上限",
-      "quotaWeeklyDesc": "空欄または 0 は無制限 · 毎週月曜日にリセット · 現在の期間で ${{used}} 使用済み"
+      "quotaWeeklyDesc": "空欄または 0 は無制限 · 毎週月曜日にリセット · 現在の期間で ${{used}} 使用済み",
+      "autoReset": "合計クォータの自動リセット",
+      "autoResetDesc": "選択した OAuth アカウントの週次クォータがリセットされたら、このキーの合計クォータをリセットします。",
+      "autoResetNone": "無効",
+      "autoResetSummary": "OAuth 週次リセット → このキーの合計クォータをリセット。日次・週次のローカルクォータは変更しません。"
     },
     "advanced": {
       "modelMapping": "モデルマッピング",
@@ -230,6 +236,7 @@
       "quotaDailyTooLow": "日次クォータは現在の期間の使用額 (${{used}}) 未満にはできません",
       "quotaWeeklyInvalid": "有効な週次クォータを入力してください",
       "quotaWeeklyTooLow": "週次クォータは現在の期間の使用額 (${{used}}) 未満にはできません",
+      "autoResetQuotaRequired": "自動リセットには制限付きの合計クォータが必要です",
       "rateLimitRequired": "レート制限を有効にする場合、少なくとも 1 つの上限が必要です",
       "rpmInvalid": "処理中リクエスト上限は 0 より大きい整数で指定してください",
       "tpmInvalid": "TPM は正の整数である必要があります",

--- a/web/src/locales/zh/api-keys.json
+++ b/web/src/locales/zh/api-keys.json
@@ -62,7 +62,9 @@
     "rotate": "轮换密钥",
     "rotateCustomDisabled": "自定义密钥不支持轮换",
     "expired": "已过期",
-    "expiredToggleHint": "已到期，请先修改到期时间"
+    "expiredToggleHint": "已到期，请先修改到期时间",
+    "autoReset": "自动重置",
+    "autoResetHint": "OAuth 周额度重置时会重置此密钥的总额度"
   },
   "workspace": {
     "loadFailed": "加载 API 密钥失败",
@@ -186,7 +188,11 @@
       "quotaDailyLimit": "日额度上限",
       "quotaDailyDesc": "空或 0 表示不限 · 每天自动重置 · 当前周期已用 ${{used}}",
       "quotaWeeklyLimit": "周额度上限",
-      "quotaWeeklyDesc": "空或 0 表示不限 · 每周一自动重置 · 当前周期已用 ${{used}}"
+      "quotaWeeklyDesc": "空或 0 表示不限 · 每周一自动重置 · 当前周期已用 ${{used}}",
+      "autoReset": "自动重置总额度",
+      "autoResetDesc": "所选 OAuth 账号的周额度重置后，自动重置此密钥的总额度。",
+      "autoResetNone": "不启用",
+      "autoResetSummary": "OAuth 周额度重置 → 此密钥总额度重置；本地日额度和周额度不受影响。"
     },
     "advanced": {
       "modelMapping": "模型映射",
@@ -230,6 +236,7 @@
       "quotaDailyTooLow": "日额度不能低于当前周期已使用金额 (${{used}})",
       "quotaWeeklyInvalid": "请输入有效的周额度",
       "quotaWeeklyTooLow": "周额度不能低于当前周期已使用金额 (${{used}})",
+      "autoResetQuotaRequired": "启用自动重置需要设置有限的总额度",
       "rateLimitRequired": "启用调用频率限制时，至少填写一项上限",
       "rpmInvalid": "在途请求上限必须是大于 0 的整数",
       "tpmInvalid": "每分钟 Token 数必须是大于 0 的整数",


### PR DESCRIPTION
## Summary

- Add an optional OAuth connection binding for downstream API keys.
- When a supported OAuth account's weekly quota reset advances, reset the bound API key's total quota usage.
- Keep the API key's daily and local weekly usage unchanged.
- Expose the setting with the existing API key form, Select, Badge, and localization components.

## Behavior

- Supported OAuth providers: Codex and Claude Code.
- Supported window: OAuth weekly/7d only; OAuth 5h is intentionally not included.
- Reset scope: API key `total` only.
- The first sync establishes a baseline and does not reset.
- Repeated observations of the same upstream `reset_at` are idempotent.
- Automatic detection uses the existing OAuth/site refresh flow; no new worker or dependency is introduced.

## Verification

- `go test ./...`
- `npm test` — 141 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `git diff --check`
