### PR TITLE
fix(oauth): coordinate refresh token rotation across instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,19 @@ FROM node:24-alpine AS frontend-build
 WORKDIR /src
 
 COPY web/package.json web/package-lock.json ./
-RUN --mount=type=cache,id=npm,target=/root/.npm \
-    npm ci
+RUN npm ci
 
 COPY web/ .
 ARG BUILD_TIMESTAMP
 ENV VITE_BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
-RUN --mount=type=cache,id=npm,target=/root/.npm \
-    npm run build
+RUN npm run build
 
 FROM golang:1.26-alpine AS backend-build
 
 WORKDIR /src
 
 COPY server/go.mod server/go.sum ./
-RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
-    go mod download
+RUN go mod download
 
 COPY server/ .
 ARG TARGETOS=linux
@@ -28,9 +25,7 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_TIME=
-RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
-    --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath \
     -ldflags="-s -w \
       -X 'xlyra/server/internal/version.Version=${VERSION}' \

--- a/server/internal/oauth/refresh_lock.go
+++ b/server/internal/oauth/refresh_lock.go
@@ -1,0 +1,58 @@
+package oauth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const refreshLockNamespace = "xlyra/oauth-refresh/"
+
+// withPostgresAdvisoryLock holds a session-level advisory lock for the entire
+// callback. The dedicated *sql.Conn keeps lock and unlock on one PostgreSQL session.
+func withPostgresAdvisoryLock(ctx context.Context, db *sql.DB, key string, fn func(*sql.Conn) error) error {
+	if db == nil {
+		return fmt.Errorf("postgres refresh lock: database is nil")
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("postgres refresh lock: acquire connection: %w", err)
+	}
+
+	locked := false
+	defer func() {
+		if locked {
+			_, _ = conn.ExecContext(context.Background(), "select pg_advisory_unlock(hashtextextended($1, 0))", key)
+		}
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, "select pg_advisory_lock(hashtextextended($1, 0))", key); err != nil {
+		return fmt.Errorf("postgres refresh lock: acquire advisory lock: %w", err)
+	}
+	locked = true
+	return fn(conn)
+}
+
+func (s *Service) withRefreshConnectionLock(ctx context.Context, connectionID uuid.UUID, fn func() (CodexConnection, error)) (CodexConnection, error) {
+	if s == nil || s.db == nil || s.db.DB() == nil || s.db.DB().Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	db, err := s.db.DB().DB()
+	if err != nil {
+		return CodexConnection{}, fmt.Errorf("postgres refresh lock: get database: %w", err)
+	}
+
+	var result CodexConnection
+	err = withPostgresAdvisoryLock(ctx, db, refreshLockNamespace+connectionID.String(), func(_ *sql.Conn) error {
+		result, err = fn()
+		return err
+	})
+	if err != nil {
+		return CodexConnection{}, err
+	}
+	return result, nil
+}

--- a/server/internal/oauth/service.go
+++ b/server/internal/oauth/service.go
@@ -27,6 +27,7 @@ type Service struct {
 	httpClients  *httpclient.Manager
 	masterKey    string
 	refreshGroup singleflight.Group
+	refreshLock  func(context.Context, uuid.UUID, func() (CodexConnection, error)) (CodexConnection, error)
 }
 
 type PendingSite struct {
@@ -87,13 +88,15 @@ func NewService(db *store.Store, masterKey string, confFiles ...*config.ConfigFi
 	}
 	manager := httpclient.NewManager(confFile)
 	client, _ := manager.Client(httpclient.DefaultProfile())
-	return &Service{
+	service := &Service{
 		db:          db,
 		credentials: credential.NewService(masterKey),
 		httpClient:  client,
 		httpClients: manager,
 		masterKey:   masterKey,
 	}
+	service.refreshLock = service.withRefreshConnectionLock
+	return service
 }
 
 func (s *Service) DB() *store.Store {
@@ -645,7 +648,13 @@ func (s *Service) EnsureClaudeCodeConnectionFresh(ctx context.Context, siteID uu
 // disable a healthy site. Losers instead receive the winner's fresh result.
 func (s *Service) RefreshCodexConnection(ctx context.Context, connectionID uuid.UUID) (CodexConnection, error) {
 	result, err, _ := s.refreshGroup.Do(connectionID.String(), func() (any, error) {
-		return s.refreshConnectionOnce(ctx, connectionID)
+		lock := s.withRefreshConnectionLock
+		if s.refreshLock != nil {
+			lock = s.refreshLock
+		}
+		return lock(ctx, connectionID, func() (CodexConnection, error) {
+			return s.refreshConnectionOnce(ctx, connectionID)
+		})
 	})
 	if err != nil {
 		return CodexConnection{}, err

--- a/server/internal/oauth/service_gorm_test_helpers_test.go
+++ b/server/internal/oauth/service_gorm_test_helpers_test.go
@@ -1,10 +1,12 @@
 package oauth
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"unsafe"
 
+	"github.com/google/uuid"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -22,7 +24,11 @@ type oauthGormCallbacks struct {
 func oauthServiceWithCallbacks(t *testing.T, callbacks oauthGormCallbacks) *Service {
 	t.Helper()
 
-	return NewService(oauthStoreWithGorm(t, oauthGormWithCallbacks(t, callbacks)), "master-key")
+	service := NewService(oauthStoreWithGorm(t, oauthGormWithCallbacks(t, callbacks)), "master-key")
+	service.refreshLock = func(ctx context.Context, connectionID uuid.UUID, fn func() (CodexConnection, error)) (CodexConnection, error) {
+		return fn()
+	}
+	return service
 }
 
 func oauthGormWithCallbacks(t *testing.T, callbacks oauthGormCallbacks) *gorm.DB {

--- a/server/internal/oauth/service_refresh_lock_test.go
+++ b/server/internal/oauth/service_refresh_lock_test.go
@@ -1,0 +1,82 @@
+package oauth
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"xlyra/server/internal/store"
+)
+
+func TestRefreshConnectionDistributedLockSerializesIndependentDatabaseSessions(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cfg, err := devPostgresOAuthSmokeConfig()
+	if err != nil {
+		t.Skipf("dev PostgreSQL smoke disabled: %v", err)
+	}
+
+	firstStore, err := store.Open(ctx, cfg)
+	if err != nil {
+		t.Skipf("first PostgreSQL session unavailable: %v", redactOAuthDatabaseOpenError(err, cfg))
+	}
+	defer firstStore.Close()
+	secondStore, err := store.Open(ctx, cfg)
+	if err != nil {
+		t.Skipf("second PostgreSQL session unavailable: %v", redactOAuthDatabaseOpenError(err, cfg))
+	}
+	defer secondStore.Close()
+	firstDB, err := firstStore.DB().DB()
+	if err != nil {
+		t.Fatalf("first SQL database: %v", err)
+	}
+	secondDB, err := secondStore.DB().DB()
+	if err != nil {
+		t.Fatalf("second SQL database: %v", err)
+	}
+
+	key := "test-xlyra-oauth-refresh-lock"
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var wg sync.WaitGroup
+	var firstErr, secondErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		firstErr = withPostgresAdvisoryLock(ctx, firstDB, key, func(_ *sql.Conn) error {
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	select {
+	case <-firstEntered:
+	case <-ctx.Done():
+		t.Fatalf("first lock was not acquired: %v", ctx.Err())
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		secondErr = withPostgresAdvisoryLock(ctx, secondDB, key, func(_ *sql.Conn) error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second independent database session entered while first lock was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatalf("first lock callback: %v", firstErr)
+	}
+	if secondErr != nil {
+		t.Fatalf("second lock callback: %v", secondErr)
+	}
+}


### PR DESCRIPTION
## Summary

- Coordinate OAuth refreshes across xLyra processes/containers with a PostgreSQL session advisory lock.
- Keep the existing in-process `singleflight` behavior.
- Add a regression test proving independent database sessions serialize refresh callbacks.
- Remove BuildKit cache-mount syntax so the Dockerfile also builds with the legacy builder used by some deployments.

## Problem

Codex/Antigravity refresh tokens rotate. The existing `singleflight` only coordinates callers inside one Go process, so concurrent refreshes from separate xLyra processes can submit the same refresh token. The loser may receive `invalid_grant`, and the existing error handling can disable a healthy OAuth connection.

## Implementation

- Add `server/internal/oauth/refresh_lock.go`.
- Lock by OAuth `connectionID` using `pg_advisory_lock(hashtextextended(...))`.
- Hold the session-level lock through the refresh operation and release it with the same dedicated `*sql.Conn`.
- Wrap `refreshConnectionOnce` from `RefreshCodexConnection` after the existing `singleflight` layer.
- Inject a no-op lock in sqlmock-style tests.

## Validation

- `TestRefreshConnectionDistributedLock`
- `TestRefreshCodexConnectionCollapsesConcurrentRefreshes`
- `go test ./internal/oauth ./internal/gateway ./internal/site`
- `gofmt` and `git diff --check`

The patch was also built and deployed as a trial image on a private deployment based on xLyra `v1.4.0`; `/readyz` returned 200 and the PostgreSQL-backed OAuth connection remained connected. The full test suite had one pre-existing environment-dependent failure: `internal/config/TestResolveWorkdir_GitRoot` expects `/root/.xlyra` to be a Git worktree.

## Scope and limitation

This coordinates xLyra instances sharing the PostgreSQL database. It cannot coordinate refreshes performed by an external official client, so external refresh-token rotation remains a separate possible cause.
