### PR TITLE
feat: Codex 客户端版本动态化，模型列表不再用静态兜底

### DIFF
--- a/server/internal/adapter/codex.go
+++ b/server/internal/adapter/codex.go
@@ -10,17 +10,29 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"xlyra/server/internal/codexversion"
 )
 
 const (
 	codexBackendDefaultBaseURL = "https://chatgpt.com/backend-api"
 	codexOriginURL             = "https://chatgpt.com"
 	codexRefererURL            = "https://chatgpt.com/codex"
-	CodexClientVersion         = "0.144.1"
-	CodexUserAgent             = "codex_cli_rs/" + CodexClientVersion + " (Mac OS 26.0; arm64) vscode/1.99.3"
 )
+
+// codexUserAgent mirrors the real Codex CLI user agent, with the client
+// version resolved at runtime so it tracks the latest published release
+// instead of a pinned build-time constant.
+func codexUserAgent() string {
+	return "codex_cli_rs/" + codexversion.Version() + " (Mac OS 26.0; arm64) vscode/1.99.3"
+}
+
+// CodexUserAgent returns the runtime user agent used for outbound Codex
+// requests. It is exported so the gateway can reuse the same identity.
+func CodexUserAgent() string { return codexUserAgent() }
 
 type Codex struct {
 	client *http.Client
@@ -143,6 +155,15 @@ func (a Codex) FetchUserSummary(ctx context.Context, site SiteConfig, auth Syste
 		}
 		modelItems = append(modelItems, raw)
 	}
+	// gpt-image-2 is not issued by the codex /codex/models endpoint for this
+	// account, but the gateway still routes explicit image requests to codex. It
+	// must stay in the site model catalog for that routing to keep working, so it
+	// is re-appended after every successful model sync (otherwise MarkUnavailable-
+	// Except would mark it unavailable). It is a routing capability, not a model
+	// the account was issued, and is labelled as such.
+	if len(models) > 0 && !hasUpstreamModel(models, codexImageSlug) {
+		modelItems = append(modelItems, codexImageRouteModel())
+	}
 	user := map[string]any{
 		"provider":   "codex",
 		"email":      auth.Email,
@@ -196,26 +217,37 @@ func (a Codex) fetchModels(ctx context.Context, site SiteConfig, accessToken str
 	endpoints := codexModelEndpoints(site.BaseURL)
 	var payload map[string]any
 	var err error
+	var lastErr error
 	for _, endpoint := range endpoints {
 		payload, err = a.getJSON(ctx, site, endpoint, accessToken, accountID)
-		if err == nil && len(codexModelsFromItems(extractCodexModelItems(payload))) > 0 {
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(codexModelsFromItems(extractCodexModelItems(payload))) > 0 {
+			lastErr = nil
 			break
 		}
 	}
 	models := codexModelsFromItems(extractCodexModelItems(payload))
 	if len(models) == 0 {
-		models = codexModelsFromItems(codexStaticModelItems())
-	}
-	if len(models) == 0 && err != nil {
-		return nil, err
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("codex upstream returned no models")
 	}
 	return models, nil
 }
 
 func codexModelsFromItems(items []map[string]any) []Model {
 	sorted := make([]map[string]any, 0, len(items))
+	current := codexversion.Version()
 	for _, item := range items {
 		if strings.EqualFold(strings.TrimSpace(stringFromAny(item["visibility"])), "hide") {
+			continue
+		}
+		minimal := strings.TrimSpace(stringFromAny(item["minimal_client_version"]))
+		if minimal != "" && versionGreaterThan(minimal, current) {
 			continue
 		}
 		sorted = append(sorted, item)
@@ -414,7 +446,7 @@ func (a Codex) getJSON(ctx context.Context, site SiteConfig, endpoint string, ac
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessToken))
 	req.Header.Set("Origin", codexOriginURL)
 	req.Header.Set("Referer", codexRefererURL)
-	req.Header.Set("User-Agent", CodexUserAgent)
+	req.Header.Set("User-Agent", codexUserAgent())
 	if trimmed := strings.TrimSpace(accountID); trimmed != "" {
 		req.Header.Set("ChatGPT-Account-Id", trimmed)
 	}
@@ -456,7 +488,7 @@ func (a Codex) postJSON(ctx context.Context, site SiteConfig, endpoint string, a
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessToken))
 	req.Header.Set("Origin", codexOriginURL)
 	req.Header.Set("Referer", codexRefererURL)
-	req.Header.Set("User-Agent", CodexUserAgent)
+	req.Header.Set("User-Agent", codexUserAgent())
 	if trimmed := strings.TrimSpace(accountID); trimmed != "" {
 		req.Header.Set("ChatGPT-Account-Id", trimmed)
 	}
@@ -712,56 +744,77 @@ func extractCodexModelItems(payload map[string]any) []map[string]any {
 	return nil
 }
 
-func codexStaticModelItems() []map[string]any {
-	models := []map[string]any{
-		codexStaticModel("gpt-5.6-sol", "GPT-5.6-Sol", 1, 372000, 128000, []string{"low", "medium", "high", "xhigh", "max", "ultra"}),
-		codexStaticModel("gpt-5.6-terra", "GPT-5.6-Terra", 2, 372000, 128000, []string{"low", "medium", "high", "xhigh", "max", "ultra"}),
-		codexStaticModel("gpt-5.6-luna", "GPT-5.6-Luna", 3, 372000, 128000, []string{"low", "medium", "high", "xhigh", "max"}),
-		codexStaticModel("gpt-5.5", "GPT-5.5", 7, 272000, 128000, []string{"low", "medium", "high", "xhigh"}),
-		codexStaticModel("gpt-5.4", "GPT-5.4", 16, 272000, 128000, []string{"low", "medium", "high", "xhigh"}),
-		codexStaticModel("gpt-5.4-mini", "GPT-5.4-Mini", 23, 272000, 128000, []string{"low", "medium", "high", "xhigh"}),
-		codexStaticModel("gpt-5.2", "GPT-5.2", 29, 272000, 128000, []string{"low", "medium", "high", "xhigh"}),
-	}
-	models = append(models, map[string]any{
-		"slug":                     "gpt-image-2",
+// codexImageSlug is the image model the proxy exposes for Codex image routing.
+// It is not issued by /codex/models but is required to keep explicit image
+// requests routable to the Codex site.
+const codexImageSlug = "gpt-image-2"
+
+// codexImageRouteModel returns the catalog entry that keeps gpt-image-2 routable
+// to Codex. It represents a routing capability rather than a model the account
+// was issued, so it is labelled distinctly from the upstream models and carries
+// only the image endpoint type.
+func codexImageRouteModel() map[string]any {
+	return map[string]any{
+		"slug":                     codexImageSlug,
 		"object":                   "model",
 		"created":                  int64(1704067200),
 		"owned_by":                 "openai",
 		"type":                     "openai",
 		"display_name":             "GPT Image 2",
-		"version":                  "gpt-image-2",
-		"priority":                 100,
-		"supported_endpoint_types": []string{"openai-response", "openai-image"},
+		"version":                  codexImageSlug,
+		"priority":                 1000,
+		"visibility":               "list",
+		"supported_endpoint_types": []string{"openai-image"},
 		"available":                true,
-		"source":                   "codex_static",
-	})
-	return models
+		"source":                   "codex_image_route",
+	}
 }
 
-func codexStaticModel(slug string, displayName string, priority int, contextWindow int, maxCompletionTokens int, thinkingLevels []string) map[string]any {
-	return map[string]any{
-		"slug":                  slug,
-		"object":                "model",
-		"owned_by":              "openai",
-		"type":                  "openai",
-		"display_name":          displayName,
-		"version":               slug,
-		"priority":              priority,
-		"visibility":            "list",
-		"context_window":        contextWindow,
-		"context_length":        contextWindow,
-		"max_completion_tokens": maxCompletionTokens,
-		"supported_parameters":  []string{"tools"},
-		"supported_endpoint_types": []string{
-			"openai",
-			"openai-response",
-		},
-		"thinking": map[string]any{
-			"levels": thinkingLevels,
-		},
-		"available": true,
-		"source":    "codex_static",
+func hasUpstreamModel(models []Model, upstreamName string) bool {
+	if strings.TrimSpace(upstreamName) == "" {
+		return false
 	}
+	for _, model := range models {
+		if strings.EqualFold(strings.TrimSpace(model.UpstreamName), strings.TrimSpace(upstreamName)) {
+			return true
+		}
+	}
+	return false
+}
+
+// versionGreaterThan reports whether a > b for dotted numeric versions. It is
+// used to drop models whose minimal_client_version is above the running client
+// version, mirroring the Codex CLI client-side gate.
+func versionGreaterThan(a string, b string) bool {
+	ai, okA := parseVersion(a)
+	bi, okB := parseVersion(b)
+	if !okA || !okB {
+		return strings.Compare(strings.TrimSpace(a), strings.TrimSpace(b)) > 0
+	}
+	switch {
+	case ai[0] != bi[0]:
+		return ai[0] > bi[0]
+	case ai[1] != bi[1]:
+		return ai[1] > bi[1]
+	default:
+		return ai[2] > bi[2]
+	}
+}
+
+func parseVersion(value string) ([3]int, bool) {
+	parts := strings.Split(strings.TrimSpace(value), ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for index, part := range parts {
+		number, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			return [3]int{}, false
+		}
+		out[index] = number
+	}
+	return out, true
 }
 
 func normalizeCodexBaseURL(baseURL string) string {
@@ -835,7 +888,7 @@ func codexWithClientVersion(endpoint string) string {
 	if strings.Contains(endpoint, "?") {
 		separator = "&"
 	}
-	return endpoint + separator + "client_version=" + CodexClientVersion
+	return endpoint + separator + "client_version=" + codexversion.Version()
 }
 
 func codexOriginFromBaseURL(baseURL string) string {

--- a/server/internal/adapter/codex_models_version_test.go
+++ b/server/internal/adapter/codex_models_version_test.go
@@ -1,0 +1,92 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"xlyra/server/internal/codexversion"
+)
+
+func TestCodexModelsFromItemsEnforcesMinimalClientVersion(t *testing.T) {
+	restore := codexversion.WithFetcher(func(context.Context) (string, error) { return "0.144.1", nil })
+	defer restore()
+
+	items := []map[string]any{
+		{"slug": "gpt-5.6-sol", "priority": 6, "minimal_client_version": "0.144.0"},
+		{"slug": "gpt-5.5", "priority": 12, "minimal_client_version": "0.124.0"},
+		{"slug": "gpt-5.4", "priority": 16, "minimal_client_version": "0.98.0"},
+		{"slug": "gpt-5.7-future", "priority": 1, "minimal_client_version": "0.154.0"},
+	}
+
+	models := codexModelsFromItems(items)
+	if len(models) != 3 {
+		t.Fatalf("models length = %d, want 3 (future-gated model filtered): %#v", len(models), models)
+	}
+	for _, model := range models {
+		if model.UpstreamName == "gpt-5.7-future" {
+			t.Fatalf("gpt-5.7-future should be filtered out, got %#v", models)
+		}
+	}
+}
+
+func TestCodexImageRouteModelCarriesImageCapability(t *testing.T) {
+	item := codexImageRouteModel()
+	if item["slug"] != codexImageSlug {
+		t.Fatalf("route model slug = %#v, want %s", item["slug"], codexImageSlug)
+	}
+	if item["source"] != "codex_image_route" {
+		t.Fatalf("route model source = %#v, want codex_image_route", item["source"])
+	}
+	endpoints, _ := item["supported_endpoint_types"].([]string)
+	if len(endpoints) != 1 || endpoints[0] != "openai-image" {
+		t.Fatalf("route model endpoints = %#v, want only openai-image", item["supported_endpoint_types"])
+	}
+}
+
+func TestHasUpstreamModelMatchesByName(t *testing.T) {
+	models := []Model{
+		{UpstreamName: "gpt-5.6-sol"},
+		{UpstreamName: "gpt-5.5"},
+	}
+	if !hasUpstreamModel(models, "gpt-5.5") {
+		t.Fatal("hasUpstreamModel should match existing upstream model")
+	}
+	if hasUpstreamModel(models, "gpt-image-2") {
+		t.Fatal("hasUpstreamModel should not report a model that is absent upstream")
+	}
+	if hasUpstreamModel(models, "") {
+		t.Fatal("hasUpstreamModel should reject empty upstream name")
+	}
+}
+
+func TestVersionGreaterThan(t *testing.T) {
+	cases := []struct {
+		a    string
+		b    string
+		want bool
+	}{
+		{"0.154.0", "0.153.3", true},
+		{"0.153.3", "0.153.3", false},
+		{"0.153.2", "0.153.3", false},
+		{"0.144.0", "0.98.0", true},
+		{"0.98.0", "0.144.0", false},
+		{"1.0.0", "0.9.9", true},
+	}
+	for _, tc := range cases {
+		if got := versionGreaterThan(tc.a, tc.b); got != tc.want {
+			t.Fatalf("versionGreaterThan(%s, %s) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestParseVersionRejectsMalformed(t *testing.T) {
+	if _, ok := parseVersion("1.2"); ok {
+		t.Fatal("parseVersion should reject two-part version")
+	}
+	if _, ok := parseVersion("a.b.c"); ok {
+		t.Fatal("parseVersion should reject non-numeric parts")
+	}
+	if _, ok := parseVersion("1.2.3"); !ok {
+		t.Fatal("parseVersion should accept three-part numeric version")
+	}
+}

--- a/server/internal/adapter/codex_oauth_account_test.go
+++ b/server/internal/adapter/codex_oauth_account_test.go
@@ -84,7 +84,7 @@ func TestCodexValidateSystemCredentialsStopsBeforeModelsOnUsageAuthError(t *test
 	}
 }
 
-func TestCodexListModelsWithAuthFallsBackToStaticModels(t *testing.T) {
+func TestCodexListModelsWithAuthErrorsWhenRemoteEmpty(t *testing.T) {
 	var requestedPaths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestedPaths = append(requestedPaths, r.URL.Path)
@@ -103,20 +103,11 @@ func TestCodexListModelsWithAuthFallsBackToStaticModels(t *testing.T) {
 			"plan_type": "plus",
 		},
 	})
-	if err != nil {
-		t.Fatalf("ListModelsWithAuth returned error: %v", err)
+	if err == nil {
+		t.Fatalf("ListModelsWithAuth should return an error when upstream returns no models, got %#v", models)
 	}
 	if len(requestedPaths) != 4 {
 		t.Fatalf("requested paths = %#v, want all distinct model endpoints", requestedPaths)
-	}
-	if codexModelByID(models, "gpt-5.6-sol") == nil {
-		t.Fatalf("fallback models missing gpt-5.6-sol: %#v", models)
-	}
-	if codexModelByID(models, "gpt-5.5") == nil {
-		t.Fatalf("fallback models missing gpt-5.5: %#v", models)
-	}
-	if codexModelByID(models, "gpt-5.3-codex-spark") != nil {
-		t.Fatalf("fallback catalog should not include plan-gated spark: %#v", models)
 	}
 }
 
@@ -229,8 +220,14 @@ func TestCodexFetchUserSummaryIncludesQuotaModelsAndPricingMetadata(t *testing.T
 		t.Fatalf("summary models = %#v, want map", summary.UserModels)
 	}
 	modelItems, ok := userModels["data"].([]map[string]any)
-	if !ok || len(modelItems) != 1 || modelItems[0]["id"] != "gpt-summary" {
-		t.Fatalf("summary model data = %#v, want raw remote model", userModels["data"])
+	if !ok || len(modelItems) != 2 {
+		t.Fatalf("summary model data = %#v, want raw remote model plus gpt-image-2 route item", userModels["data"])
+	}
+	if modelItems[0]["id"] != "gpt-summary" {
+		t.Fatalf("summary model data[0] = %#v, want raw remote model", modelItems[0])
+	}
+	if modelItems[1]["slug"] != codexImageSlug || modelItems[1]["source"] != "codex_image_route" {
+		t.Fatalf("summary model data[1] = %#v, want gpt-image-2 route item", modelItems[1])
 	}
 	pricing, ok := summary.Pricing.(map[string]any)
 	if !ok || pricing["plan_type"] != "plus" {
@@ -366,9 +363,6 @@ func TestCodexFetchPricingAndParsePricingArePlanAgnostic(t *testing.T) {
 	}
 
 	parsed := NewCodex().ParsePricing(map[string]any{"plan_type": "team"})
-	if codexPricingByModel(parsed.Items, "gpt-5.3-codex-spark") == nil {
-		t.Fatalf("parsed pricing missing spark: %#v", parsed.Items)
-	}
 	if codexPricingByModel(parsed.Items, "gpt-5.5") == nil {
 		t.Fatalf("parsed pricing missing gpt-5.5: %#v", parsed.Items)
 	}
@@ -397,8 +391,8 @@ func assertCodexHTTPHeaders(t *testing.T, r *http.Request, token string, account
 	if got := r.Header.Get("Referer"); got != codexRefererURL {
 		t.Fatalf("Referer = %q, want %s", got, codexRefererURL)
 	}
-	if got := r.Header.Get("User-Agent"); got != CodexUserAgent {
-		t.Fatalf("User-Agent = %q, want %s", got, CodexUserAgent)
+	if got := r.Header.Get("User-Agent"); got != codexUserAgent() {
+		t.Fatalf("User-Agent = %q, want %s", got, codexUserAgent())
 	}
 	if got := r.Header.Get("ChatGPT-Account-Id"); got != accountID {
 		t.Fatalf("ChatGPT-Account-Id = %q, want %s", got, accountID)

--- a/server/internal/adapter/codex_pricing.go
+++ b/server/internal/adapter/codex_pricing.go
@@ -221,45 +221,6 @@ func codexPricingDefinitions() []codexPriceDefinition {
 			EndpointTypes:  []any{"openai", "openai-response"},
 		},
 		{
-			ModelName:      "gpt-5.2",
-			DisplayName:    "GPT 5.2",
-			InputValue:     1.75,
-			HasInputValue:  true,
-			OutputValue:    14.00,
-			HasOutputValue: true,
-			CacheRatio:     0.1,
-			HasCacheRatio:  true,
-			BillingType:    "tokens",
-			Description:    "OpenAI official baseline price for GPT-5.2 used in Codex.",
-			EndpointTypes:  []any{"openai-response"},
-		},
-		{
-			ModelName:      "gpt-5.2-codex",
-			DisplayName:    "GPT 5.2 Codex",
-			InputValue:     1.75,
-			HasInputValue:  true,
-			OutputValue:    14.00,
-			HasOutputValue: true,
-			CacheRatio:     0.1,
-			HasCacheRatio:  true,
-			BillingType:    "tokens",
-			Description:    "OpenAI official baseline price for GPT-5.2-Codex.",
-			EndpointTypes:  []any{"openai-response"},
-		},
-		{
-			ModelName:      "gpt-5.3-codex",
-			DisplayName:    "GPT 5.3 Codex",
-			InputValue:     1.75,
-			HasInputValue:  true,
-			OutputValue:    14.00,
-			HasOutputValue: true,
-			CacheRatio:     0.1,
-			HasCacheRatio:  true,
-			BillingType:    "tokens",
-			Description:    "OpenAI official baseline price for GPT-5.3-Codex.",
-			EndpointTypes:  []any{"openai-response"},
-		},
-		{
 			ModelName:      "gpt-5.4",
 			DisplayName:    "GPT 5.4",
 			InputValue:     2.50,
@@ -301,12 +262,5 @@ func codexPricingDefinitions() []codexPriceDefinition {
 			EndpointTypes:  []any{"openai-response", "openai-image"},
 		},
 	}
-	items = append(items, codexPriceDefinition{
-		ModelName:     "gpt-5.3-codex-spark",
-		DisplayName:   "GPT 5.3 Codex Spark",
-		BillingType:   "tokens",
-		Description:   "Research preview in Codex. OpenAI notes that its credit rates are not final, so xLyra only syncs protocol metadata for now.",
-		EndpointTypes: []any{"openai-response"},
-	})
 	return items
 }

--- a/server/internal/adapter/codex_prime.go
+++ b/server/internal/adapter/codex_prime.go
@@ -119,7 +119,7 @@ func (a Codex) postStreamDiscard(ctx context.Context, site SiteConfig, endpoint 
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessToken))
 	req.Header.Set("Origin", codexOriginURL)
 	req.Header.Set("Referer", codexRefererURL)
-	req.Header.Set("User-Agent", CodexUserAgent)
+	req.Header.Set("User-Agent", codexUserAgent())
 	if trimmed := strings.TrimSpace(accountID); trimmed != "" {
 		req.Header.Set("ChatGPT-Account-Id", trimmed)
 	}

--- a/server/internal/adapter/codex_test.go
+++ b/server/internal/adapter/codex_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"xlyra/server/internal/codexversion"
 )
 
 func TestNormalizeCodexUsageWHAMWindows(t *testing.T) {
@@ -145,57 +147,6 @@ func TestCodexOAuthAuthErrorIgnoresTransientHTML403(t *testing.T) {
 	}
 }
 
-func TestCodexStaticModelItemsAlignOfficialCatalog(t *testing.T) {
-	items := codexStaticModelItems()
-	for _, slug := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-image-2"} {
-		if !codexModelItemExists(items, slug) {
-			t.Fatalf("static models missing %s: %#v", slug, items)
-		}
-	}
-	if codexModelItemExists(items, "gpt-5.3-codex-spark") {
-		t.Fatalf("static models should not include plan-gated spark: %#v", items)
-	}
-
-	sol := codexStaticModelByID(items, "gpt-5.6-sol")
-	if sol == nil {
-		t.Fatal("missing gpt-5.6-sol static model")
-	}
-	if sol["context_window"] != 372000 {
-		t.Fatalf("unexpected gpt-5.6-sol context window: %#v", sol)
-	}
-	solEndpoints, _ := sol["supported_endpoint_types"].([]string)
-	if len(solEndpoints) != 2 || solEndpoints[0] != "openai" || solEndpoints[1] != "openai-response" {
-		t.Fatalf("unexpected gpt-5.6-sol endpoints: %#v", sol["supported_endpoint_types"])
-	}
-	assertLevels := func(slugs []string, wantLevels []string) {
-		for _, slug := range slugs {
-			model := codexStaticModelByID(items, slug)
-			thinking, _ := model["thinking"].(map[string]any)
-			levels, _ := thinking["levels"].([]string)
-			if len(levels) != len(wantLevels) {
-				t.Fatalf("unexpected %s reasoning levels: %#v", slug, levels)
-			}
-			for index := range wantLevels {
-				if levels[index] != wantLevels[index] {
-					t.Fatalf("unexpected %s reasoning levels: %#v", slug, levels)
-				}
-			}
-		}
-	}
-	assertLevels([]string{"gpt-5.6-sol", "gpt-5.6-terra"}, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
-	assertLevels([]string{"gpt-5.6-luna"}, []string{"low", "medium", "high", "xhigh", "max"})
-	assertLevels([]string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"}, []string{"low", "medium", "high", "xhigh"})
-
-	image := codexStaticModelByID(items, "gpt-image-2")
-	if image == nil {
-		t.Fatal("missing gpt-image-2 static model")
-	}
-	endpoints, _ := image["supported_endpoint_types"].([]string)
-	if len(endpoints) != 2 || endpoints[0] != "openai-response" || endpoints[1] != "openai-image" {
-		t.Fatalf("unexpected gpt-image-2 endpoints: %#v", image["supported_endpoint_types"])
-	}
-}
-
 func TestCodexPricingSnapshotHasOfficialTokenPrices(t *testing.T) {
 	snapshot := codexPricingSnapshot("plus")
 	if len(snapshot.Items) == 0 {
@@ -255,14 +206,6 @@ func TestCodexPricingSnapshotHasOfficialTokenPrices(t *testing.T) {
 		t.Fatalf("unexpected gpt-5.6-luna pricing: %#v", luna)
 	}
 
-	spark := codexPricingByModel(snapshot.Items, "gpt-5.3-codex-spark")
-	if spark == nil {
-		t.Fatal("missing spark protocol metadata")
-	}
-	if spark.HasInputValue || spark.HasOutputValue {
-		t.Fatalf("spark should not have fixed prices: %#v", spark)
-	}
-
 	image := codexPricingByModel(snapshot.Items, "gpt-image-2")
 	if image == nil {
 		t.Fatal("missing gpt-image-2 pricing")
@@ -281,6 +224,20 @@ func TestCodexPricingSnapshotHasOfficialTokenPrices(t *testing.T) {
 	}
 	if !image.HasImageRatio || image.ImageRatio != 1.6 {
 		t.Fatalf("unexpected gpt-image-2 image ratio: %#v", image)
+	}
+}
+
+func TestCodexPricingSnapshotExcludesUnusableBaselineModels(t *testing.T) {
+	snapshot := codexPricingSnapshot("plus")
+	for _, unusable := range []string{
+		"gpt-5.2",
+		"gpt-5.2-codex",
+		"gpt-5.3-codex",
+		"gpt-5.3-codex-spark",
+	} {
+		if codexPricingByModel(snapshot.Items, unusable) != nil {
+			t.Fatalf("pricing should not surface unusable model %s: %#v", unusable, snapshot.Items)
+		}
 	}
 }
 
@@ -352,8 +309,8 @@ func TestCodexListModelsParsesOfficialSlugResponse(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.URL.Query().Get("client_version"); got != CodexClientVersion {
-			t.Fatalf("client_version = %q, want %q", got, CodexClientVersion)
+		if got := r.URL.Query().Get("client_version"); got != codexversion.Version() {
+			t.Fatalf("client_version = %q, want %q", got, codexversion.Version())
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -402,7 +359,7 @@ func TestCodexListModelsParsesOfficialSlugResponse(t *testing.T) {
 	}
 }
 
-func TestCodexListModelsFallsBackToStaticModelsWhenRemoteEmpty(t *testing.T) {
+func TestCodexListModelsErrorsWhenRemoteEmpty(t *testing.T) {
 	t.Parallel()
 
 	requests := 0
@@ -419,25 +376,11 @@ func TestCodexListModelsFallsBackToStaticModelsWhenRemoteEmpty(t *testing.T) {
 			"oauth_plan_type": "free",
 		},
 	}, "codex-token")
-	if err != nil {
-		t.Fatalf("ListModels returned error: %v", err)
+	if err == nil {
+		t.Fatalf("ListModels should return an error when upstream returns no models, got %#v", models)
 	}
 	if requests != 4 {
 		t.Fatalf("requests = %d, want all distinct model endpoints tried", requests)
-	}
-	if codexModelByID(models, "gpt-image-2") == nil {
-		t.Fatalf("fallback models missing gpt-image-2: %#v", models)
-	}
-	if codexModelByID(models, "gpt-5.5") == nil {
-		t.Fatalf("fallback models are plan-agnostic and should include gpt-5.5: %#v", models)
-	}
-	sol := codexModelByID(models, "gpt-5.6-sol")
-	if sol == nil {
-		t.Fatalf("fallback models missing gpt-5.6-sol: %#v", models)
-	}
-	endpoints, _ := sol.Capabilities["supported_endpoint_types"].([]string)
-	if len(endpoints) != 2 || endpoints[0] != "openai" || endpoints[1] != "openai-response" {
-		t.Fatalf("gpt-5.6-sol endpoints = %#v, want dual protocol", sol.Capabilities["supported_endpoint_types"])
 	}
 }
 
@@ -910,7 +853,7 @@ func TestCodexEndpointAndValueHelpers(t *testing.T) {
 		t.Fatalf("usage endpoints = %#v", usageEndpoints)
 	}
 	modelEndpoints := codexModelEndpoints("https://example.com/backend-api")
-	if len(modelEndpoints) != 2 || modelEndpoints[0] != "https://example.com/backend-api/codex/models?client_version="+CodexClientVersion {
+	if len(modelEndpoints) != 2 || modelEndpoints[0] != "https://example.com/backend-api/codex/models?client_version="+codexversion.Version() {
 		t.Fatalf("model endpoints = %#v", modelEndpoints)
 	}
 
@@ -926,19 +869,6 @@ func TestCodexEndpointAndValueHelpers(t *testing.T) {
 	if got := uniqueStrings(" a ", "a", "", "b"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Fatalf("uniqueStrings = %#v", got)
 	}
-}
-
-func codexModelItemExists(items []map[string]any, id string) bool {
-	return codexStaticModelByID(items, id) != nil
-}
-
-func codexStaticModelByID(items []map[string]any, id string) map[string]any {
-	for _, item := range items {
-		if item["slug"] == id || item["id"] == id {
-			return item
-		}
-	}
-	return nil
 }
 
 func codexPricingByModel(items []ModelPricing, modelName string) *ModelPricing {

--- a/server/internal/codexversion/version.go
+++ b/server/internal/codexversion/version.go
@@ -1,0 +1,136 @@
+// Package codexversion tracks the latest stable Codex CLI version as
+// published to the npm registry under @openai/codex. The real Codex client
+// gates which models the /codex/models endpoint returns by the client_version
+// it sends, so the proxy needs to follow that version instead of pinning a
+// compile-time constant.
+//
+// The value is seeded with DefaultVersion and refreshed by an external caller
+// (the scheduler). A failed refresh keeps the last known good version rather
+// than reverting to the default.
+package codexversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultVersion is the seed used until the first successful refresh. It
+// matches the latest stable release at the time this was written.
+const DefaultVersion = "0.153.3"
+
+// registryURL is the npm registry endpoint for the @openai/codex package.
+// The scoped package name must be encoded as @openai%2Fcodex.
+const registryURL = "https://registry.npmjs.org/@openai%2Fcodex"
+
+// Fetcher resolves the latest stable version string for the Codex CLI.
+type Fetcher func(ctx context.Context) (string, error)
+
+var versionRegexp = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+
+type state struct {
+	mu      sync.RWMutex
+	current string
+	fetcher Fetcher
+}
+
+var defaultState = &state{
+	current: DefaultVersion,
+	fetcher: fetchFromNPM,
+}
+
+// WithFetcher replaces the default upstream fetcher (primarily for tests) and
+// resets the current value to the default. It returns the previous fetcher.
+func WithFetcher(f Fetcher) func() {
+	defaultState.mu.Lock()
+	defer defaultState.mu.Unlock()
+	previous := defaultState.fetcher
+	defaultState.fetcher = f
+	defaultState.current = DefaultVersion
+	return func() {
+		defaultState.mu.Lock()
+		defer defaultState.mu.Unlock()
+		defaultState.fetcher = previous
+		defaultState.current = DefaultVersion
+	}
+}
+
+// Version returns the last known good Codex CLI version. It is always a
+// non-empty, validated version string; before the first successful refresh it
+// returns DefaultVersion.
+func Version() string {
+	defaultState.mu.RLock()
+	defer defaultState.mu.RUnlock()
+	return defaultState.current
+}
+
+// Refresh fetches the latest version and stores it. On failure the current
+// version is left untouched and the error is returned so callers can surface
+// the degradation.
+func Refresh(ctx context.Context) error {
+	defaultState.mu.RLock()
+	fetcher := defaultState.fetcher
+	defaultState.mu.RUnlock()
+
+	next, err := fetcher(ctx)
+	if err != nil {
+		return err
+	}
+	next = normalizeVersion(next)
+	if next == "" {
+		return fmt.Errorf("registry returned an invalid codex version")
+	}
+
+	defaultState.mu.Lock()
+	defaultState.current = next
+	defaultState.mu.Unlock()
+	return nil
+}
+
+// normalizeVersion trims surrounding whitespace, strips a leading "rust-"
+// prefix (used by the GitHub releases tag) and blank-ish values, and validates
+// that the result is a dotted numeric version. It returns "" for any input that
+// does not look like a Codex CLI version so callers can reject it.
+func normalizeVersion(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "rust-")
+	value = strings.TrimSpace(value)
+	if !versionRegexp.MatchString(value) {
+		return ""
+	}
+	return value
+}
+
+// fetchFromNPM queries the npm registry and returns the latest stable
+// distribution tag for @openai/codex.
+func fetchFromNPM(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create codex version request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "xlyra-codex-version")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch codex version: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("npm registry returned %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		DistTags map[string]string `json:"dist-tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode codex version payload: %w", err)
+	}
+	return payload.DistTags["latest"], nil
+}

--- a/server/internal/codexversion/version_test.go
+++ b/server/internal/codexversion/version_test.go
@@ -1,0 +1,86 @@
+package codexversion
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestVersionDefaultsBeforeRefresh(t *testing.T) {
+	restore := WithFetcher(func(context.Context) (string, error) { return "0.999.0", nil })
+	defer restore()
+
+	if got := Version(); got != DefaultVersion {
+		t.Fatalf("Version() = %q, want default %q", got, DefaultVersion)
+	}
+}
+
+func TestRefreshStoresLatest(t *testing.T) {
+	restore := WithFetcher(func(context.Context) (string, error) { return "0.154.0", nil })
+	defer restore()
+
+	if err := Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if got := Version(); got != "0.154.0" {
+		t.Fatalf("Version() = %q, want 0.154.0", got)
+	}
+}
+
+func TestRefreshKeepsCurrentOnError(t *testing.T) {
+	restore := WithFetcher(func(context.Context) (string, error) { return "", errors.New("registry down") })
+	defer restore()
+
+	if err := Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh returned nil error, want error")
+	}
+	if got := Version(); got != DefaultVersion {
+		t.Fatalf("Version() = %q, want prior default preserved", got)
+	}
+}
+
+func TestRefreshRejectsInvalidVersion(t *testing.T) {
+	restore := WithFetcher(func(context.Context) (string, error) { return "not-a-version", nil })
+	defer restore()
+
+	if err := Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh returned nil error, want error for invalid version")
+	}
+	if got := Version(); got != DefaultVersion {
+		t.Fatalf("Version() = %q, want prior default preserved", got)
+	}
+}
+
+func TestNormalizeVersionStripsRustPrefixAndWhitespace(t *testing.T) {
+	cases := map[string]string{
+		" 0.153.3 ":   "0.153.3",
+		"rust-0.153.3": "0.153.3",
+		"v0.153.3":     "",
+		"0.153":        "",
+		"":             "",
+		"beta":         "",
+	}
+	for input, want := range cases {
+		if got := normalizeVersion(input); got != want {
+			t.Fatalf("normalizeVersion(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestWithFetcherRestoresPrevious(t *testing.T) {
+	baseline := WithFetcher(func(context.Context) (string, error) { return "0.150.0", nil })
+	if err := Refresh(context.Background()); err != nil {
+		t.Fatalf("initial Refresh failed: %v", err)
+	}
+
+	restore := WithFetcher(func(context.Context) (string, error) { return "0.99.99", nil })
+	if err := Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh in override failed: %v", err)
+	}
+	restore()
+	baseline()
+
+	if got := Version(); got != DefaultVersion {
+		t.Fatalf("Version() after restore = %q, want default %q", got, DefaultVersion)
+	}
+}

--- a/server/internal/gateway/codex.go
+++ b/server/internal/gateway/codex.go
@@ -20,7 +20,9 @@ import (
 	"xlyra/server/internal/upstream"
 )
 
-const codexGatewayUserAgent = adapter.CodexUserAgent
+// codexGatewayUserAgent is resolved at package init so it carries the runtime
+// Codex client version rather than a build-time constant.
+var codexGatewayUserAgent = adapter.CodexUserAgent()
 
 func isCodexSite(siteType string) bool {
 	return strings.EqualFold(strings.TrimSpace(siteType), "codex")

--- a/server/internal/scheduler/default_configured_jobs_edges_test.go
+++ b/server/internal/scheduler/default_configured_jobs_edges_test.go
@@ -25,12 +25,12 @@ func TestRegisterDefaultJobsSupportsPartialCoreServices(t *testing.T) {
 			name:      "models_and_usage_without_sites",
 			sync:      &catalog.SyncService{},
 			summary:   &usage.SummaryService{},
-			wantCount: 2,
+			wantCount: 3,
 		},
 		{
 			name:      "sites_without_models_or_usage",
 			sites:     &site.Service{},
-			wantCount: 3,
+			wantCount: 4,
 			wantSite:  true,
 		},
 	} {

--- a/server/internal/scheduler/options_backup_jobs_edges_test.go
+++ b/server/internal/scheduler/options_backup_jobs_edges_test.go
@@ -48,8 +48,8 @@ func TestRegisterDefaultJobsRegistersOnlyConfiguredAutomaticBackup(t *testing.T)
 	if scheduler.autoBackupID == 0 {
 		t.Fatal("expected configured automatic backup job")
 	}
-	if entries := scheduler.cron.Entries(); len(entries) != 1 {
-		t.Fatalf("entries = %d, want only automatic backup job", len(entries))
+	if entries := scheduler.cron.Entries(); len(entries) != 2 {
+		t.Fatalf("entries = %d, want automatic backup plus codex version refresh job", len(entries))
 	}
 }
 

--- a/server/internal/scheduler/scheduler.go
+++ b/server/internal/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 
 	"xlyra/server/internal/backup"
 	"xlyra/server/internal/catalog"
+	"xlyra/server/internal/codexversion"
 	"xlyra/server/internal/config"
 	"xlyra/server/internal/site"
 	"xlyra/server/internal/usage"
@@ -20,6 +21,7 @@ import (
 const (
 	usageSummaryCron          = "1 0 * * *"
 	modelPricingSyncCron      = "@every 4h"
+	codexVersionRefreshCron   = "@every 6h"
 	automaticBackupJobTimeout = 10 * time.Minute
 )
 
@@ -62,6 +64,7 @@ type Scheduler struct {
 	summarizing   atomic.Bool
 	refreshing    atomic.Bool
 	checkingIn    atomic.Bool
+	versioning    atomic.Bool
 
 	modelsCacheInvalidator func()
 }
@@ -133,6 +136,16 @@ func (s *Scheduler) RegisterDefaultJobs() {
 			s.logger.Info("usage summary scheduler registered", "cron", usageSummaryCron)
 		}
 	}
+
+	// Codex version refresh is independent of every other service, so it is
+	// always registered. The initial refresh runs immediately so the proxy does
+	// not wait a full cycle for a current client version.
+	if _, err := s.cron.AddFunc(codexVersionRefreshCron, s.runCodexVersionRefresh); err != nil {
+		s.logger.Error("register codex version refresh scheduler failed", "error", err)
+	} else {
+		s.logger.Info("codex version refresh scheduler registered", "interval", codexVersionRefreshCron)
+	}
+	go s.runCodexVersionRefresh()
 
 	s.RegisterConfiguredJobs()
 	if s.options.ConfigFile != nil {
@@ -295,6 +308,29 @@ func (s *Scheduler) runModelsDevSync() {
 	}
 	if s.modelsCacheInvalidator != nil {
 		s.modelsCacheInvalidator()
+	}
+}
+
+// runCodexVersionRefresh refreshes the Codex client version from the npm
+// registry. The version gates which models the /codex/models endpoint returns,
+// so keeping it current is what lets model sync see newly released models.
+func (s *Scheduler) runCodexVersionRefresh() {
+	if !s.versioning.CompareAndSwap(false, true) {
+		s.logger.Warn("codex version refresh skipped: previous run still active")
+		return
+	}
+	defer s.versioning.Store(false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	previous := codexversion.Version()
+	if err := codexversion.Refresh(ctx); err != nil {
+		s.logger.Warn("codex version refresh failed", "error", err, "current", previous)
+		return
+	}
+	if next := codexversion.Version(); next != previous {
+		s.logger.Info("codex version refreshed", "previous", previous, "current", next)
 	}
 }
 

--- a/server/internal/scheduler/scheduler_test.go
+++ b/server/internal/scheduler/scheduler_test.go
@@ -63,15 +63,17 @@ func TestNewPreservesCustomOptions(t *testing.T) {
 	}
 }
 
-func TestRegisterDefaultJobsWithUnavailableServicesDoesNotRegisterJobs(t *testing.T) {
+func TestRegisterDefaultJobsRegistersCodexVersionRefreshWithoutServices(t *testing.T) {
 	t.Parallel()
 
 	scheduler := New(slog.Default(), Options{}, nil, nil, nil)
 
 	scheduler.RegisterDefaultJobs()
 
-	if entries := scheduler.cron.Entries(); len(entries) != 0 {
-		t.Fatalf("expected no registered jobs without services, got %d", len(entries))
+	// The codex version refresh is the only job that does not depend on a
+	// service, so it is always registered even when all other services are nil.
+	if entries := scheduler.cron.Entries(); len(entries) != 1 {
+		t.Fatalf("expected only the codex version refresh job, got %d", len(entries))
 	}
 }
 
@@ -88,8 +90,8 @@ func TestRegisterDefaultJobsWithCoreServicesRegistersBaseAndConfiguredJobs(t *te
 
 	scheduler.RegisterDefaultJobs()
 
-	if entries := scheduler.cron.Entries(); len(entries) != 5 {
-		t.Fatalf("expected site health, models.dev sync, usage summary, site refresh, and newapi checkin jobs, got %d", len(entries))
+	if entries := scheduler.cron.Entries(); len(entries) != 6 {
+		t.Fatalf("expected site health, models.dev sync, usage summary, site refresh, newapi checkin, and codex version refresh jobs, got %d", len(entries))
 	}
 	if scheduler.siteRefreshID == 0 {
 		t.Fatal("expected configured site refresh job id")

--- a/server/internal/scheduler/site_health_configured_jobs_edges_test.go
+++ b/server/internal/scheduler/site_health_configured_jobs_edges_test.go
@@ -67,8 +67,8 @@ func TestRegisterDefaultJobsAcceptsTinyPositiveSiteHealthInterval(t *testing.T) 
 
 	scheduler.RegisterDefaultJobs()
 
-	if entries := scheduler.cron.Entries(); len(entries) != 3 {
-		t.Fatalf("entries = %d, want site health plus configured site refresh and checkin jobs", len(entries))
+	if entries := scheduler.cron.Entries(); len(entries) != 4 {
+		t.Fatalf("entries = %d, want site health plus configured site refresh and checkin jobs plus codex version refresh", len(entries))
 	}
 	if scheduler.siteRefreshID == 0 || scheduler.checkinID == 0 {
 		t.Fatalf("expected configured site jobs to still register, got refresh=%d checkin=%d", scheduler.siteRefreshID, scheduler.checkinID)


### PR DESCRIPTION
## 改动概览

本期对 Codex 上游账号可用模型链路做了两处实质性改造：客户端版本不再写死、模型列表不再依赖静态兜底。

## 各模块改动

### 新增 `server/internal/codexversion`（版本动态检测）

- 新增 `codexversion` 包，从 npm registry `@openai/codex` 的 `dist-tags.latest` 拉取最新稳定版，进程内缓存。
- 默认种子版本 `0.153.3`；刷新失败保留上一次已知好版本，不回落默认值。
- `scheduler` 挂 6 小时周期任务，并注册后立即执行一次，进程启动即拿到较新版本。
- 暴露 `Version()` / `Refresh(ctx)` / `WithFetcher()`（可注入 fetcher 便于测试）。

### `server/internal/adapter/codex.go`（核心）

- **版本动态化**：移除 `CodexClientVersion = "0.144.1"` 常量，请求参数 `client_version` 与出站 User-Agent 统一改用运行时 `codexversion.Version()`。
- **去掉文本静态兜底**：`fetchModels` 4 端点全失败或全空即返回 error，不再回落 `codexStaticModelItems()`。
  - 效果：上游鉴权失败/返回为空时,站点标记 partial/stale,不再把过时/伪造模型当可用模型透传。
- **客户端侧版本门禁**：`codexModelsFromItems` 读取 `minimal_client_version`,若高于当前客户端版本即跳过,与上游按客户端版本返回可见模型的行为对齐。
- **gpt-image-2 保留为路由条目**:从静态兜底剥离为独立条目(`source: codex_image_route`,仅 `openai-image` 端点),在成功同步拿到文本模型时注入,确保图片请求仍能路由到 codex site,且不冒充账号下发模型。
- 删除已无用的 `codexStaticModelItems()` / `codexStaticModel()`。

### `server/internal/adapter/codex_prime.go` 与 `server/internal/gateway/codex.go`

- 出站 User-Agent 引用点改为运行时函数 `codexUserAgent()`。
- `codexGatewayUserAgent` 由 `const` 改为 `var`,随运行时版本初始化。

### `server/internal/adapter/codex_pricing.go`

- `codexPricingDefinitions()` 删除 `gpt-5.2`、`gpt-5.2-codex`、`gpt-5.3-codex`、`gpt-5.3-codex-spark` 定价基线条目。
- 原先这些条目经 `FetchUserSummary.Pricing` → `mergePricingModelsState` 被 Upsert 成 codex site 的 active site model,导致不可用的模型出现在 Agent 模型选择列表。删除后它们不再进入站点模型列表,直接请求这些模型名会得到 `no_route`,与实测“调用即失败”一致。

### 测试

- 新增 `codexversion` 包单元测试（默认值/刷新成功失败回退/非法版本拒绝/`rust-` 前缀剥离/fetcher 还原)。
- 新增 `codex_models_version_test.go`,覆盖 `minimal_client_version` 门禁、gpt-image-2 路由条目、`versionGreaterThan`。
- 新增 `TestCodexPricingSnapshotExcludesUnusableBaselineModels`,断言 4 个不可用模型不再出现在定价 payload。
- 移除旧静态名单相关测试（`TestCodexStaticModelItemsAlignOfficialCatalog`);两个“空响应回落静态”测试改为“空响应即报错”。
- 适配调度器注册计数断言（codex 版本刷新任务不依赖任何服务,始终注册)。

## 验证记录

- `go build ./...`（server）通过
- `go test ./internal/adapter ./internal/gateway ./internal/modelcapabilities ./internal/catalog ./internal/codexversion ./internal/scheduler` 全绿
- `go vet` 改动包通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
