### PR TITLE
fix: gpt-image-2 路由条目补 id 字段，避免被站点层解析丢弃

### DIFF
--- a/server/internal/adapter/codex.go
+++ b/server/internal/adapter/codex.go
@@ -753,6 +753,7 @@ const codexImageSlug = "gpt-image-2"
 // only the image endpoint type.
 func codexImageRouteModel() map[string]any {
 	return map[string]any{
+		"id":                       codexImageSlug,
 		"slug":                     codexImageSlug,
 		"object":                   "model",
 		"created":                  int64(1704067200),

--- a/server/internal/adapter/codex_models_version_test.go
+++ b/server/internal/adapter/codex_models_version_test.go
@@ -31,8 +31,8 @@ func TestCodexModelsFromItemsEnforcesMinimalClientVersion(t *testing.T) {
 
 func TestCodexImageRouteModelCarriesImageCapability(t *testing.T) {
 	item := codexImageRouteModel()
-	if item["slug"] != codexImageSlug {
-		t.Fatalf("route model slug = %#v, want %s", item["slug"], codexImageSlug)
+	if item["id"] != codexImageSlug || item["slug"] != codexImageSlug {
+		t.Fatalf("route model id/slug = %#v/%#v, want %s", item["id"], item["slug"], codexImageSlug)
 	}
 	if item["source"] != "codex_image_route" {
 		t.Fatalf("route model source = %#v, want codex_image_route", item["source"])

--- a/server/internal/site/refresh_test.go
+++ b/server/internal/site/refresh_test.go
@@ -524,6 +524,17 @@ func TestModelsFromUserSummaryPayloadVariants(t *testing.T) {
 		t.Fatalf("unexpected data models: %#v", dataNested)
 	}
 
+	// Codex image route items carry an id field; ensure they are not dropped by
+	// the data-array parser (regression: slug-only entries were silently skipped).
+	codexImage := modelsFromUserSummaryPayload(map[string]any{
+		"data": []any{
+			map[string]any{"id": "gpt-image-2", "slug": "gpt-image-2", "source": "codex_image_route"},
+		},
+	})
+	if len(codexImage) != 1 || codexImage[0].UpstreamName != "gpt-image-2" {
+		t.Fatalf("codex image route model was dropped by user summary parser: %#v", codexImage)
+	}
+
 	direct := modelsFromUserSummaryPayload(map[string]any{
 		"success":    true,
 		"message":    "ok",


### PR DESCRIPTION
## 问题

Codex 的 `gpt-image-2` 是图片路由条目（`codex_image_route`），不是账号经 `/codex/models` 下发的模型。此前它只在适配器层被注入 `UserModels`，但**缺少 `id` 字段**（只有 `slug`）。

站点层 `modelsFromUserSummaryPayload` 解析 `UserModels` 时只认 `id` / `model_name` 字段，`slug`-only 条目会被静默跳过，导致 `gpt-image-2` 未进入站点模型列表，从而：
- 模型列表里看不到 gpt-image-2
- 图片请求无法路由到 codex site

## 改动

`server/internal/adapter/codex.go`
- `codexImageRouteModel()` 增加 `id: codexImageSlug` 字段，与下游解析逻辑对齐。

测试
- `server/internal/adapter/codex_models_version_test.go`：`TestCodexImageRouteModelCarriesImageCapability` 增加 `id` 断言。
- `server/internal/site/refresh_test.go`：新增回归用例，验证 `data` 数组里带 `id` 的 gpt-image-2 能被 `modelsFromUserSummaryPayload` 正常取出（针对 slug-only 被丢弃的 bug）。

## 验证

- `go test ./internal/adapter ./internal/site` 通过
- 修复后链路：注入（带 `id`）→ 站点层解析 → active site model → `matchOrCreateCanonical` 建 canonical → 路由候选（`openai-image`）生成，gpt-image-2 可显示且可路由。
- codex site 走 `applyModelNameEndpointTypes` 时 `UsesModelNameEndpointInference("codex")` 为 false，不会覆盖其 `["openai-image"]` 端点类型。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
