### PR TITLE
fix: 🐛 补上 codex OAuth 刷新路径的 gpt-image-2 路由模型

### DIFF
--- a/server/internal/adapter/codex.go
+++ b/server/internal/adapter/codex.go
@@ -128,7 +128,7 @@ func (a Codex) SummarizeAPIKey(ctx context.Context, site SiteConfig, apiKey stri
 	}
 	return APIKeySummary{
 		Usage:  usage,
-		Models: models,
+		Models: codexModelsWithImageRoute(models),
 		Raw:    usage,
 	}, nil
 }
@@ -146,22 +146,20 @@ func (a Codex) FetchUserSummary(ctx context.Context, site SiteConfig, auth Syste
 	if err != nil {
 		return UserSummary{}, err
 	}
-	modelItems := make([]map[string]any, 0, len(models))
-	for _, model := range models {
-		raw, _ := model.Capabilities["raw"].(map[string]any)
-		if raw == nil {
-			raw = map[string]any{"id": model.UpstreamName}
-		}
-		modelItems = append(modelItems, raw)
-	}
 	// gpt-image-2 is not issued by the codex /codex/models endpoint for this
 	// account, but the gateway still routes explicit image requests to codex. It
 	// must stay in the site model catalog for that routing to keep working, so it
 	// is re-appended after every successful model sync (otherwise MarkUnavailable-
 	// Except would mark it unavailable). It is a routing capability, not a model
 	// the account was issued, and is labelled as such.
-	if len(models) > 0 && !hasUpstreamModel(models, codexImageSlug) {
-		modelItems = append(modelItems, codexImageRouteModel())
+	modelsWithRoute := codexModelsWithImageRoute(models)
+	modelItems := make([]map[string]any, 0, len(modelsWithRoute))
+	for _, model := range modelsWithRoute {
+		raw, _ := model.Capabilities["raw"].(map[string]any)
+		if raw == nil {
+			raw = map[string]any{"id": model.UpstreamName}
+		}
+		modelItems = append(modelItems, raw)
 	}
 	user := map[string]any{
 		"provider":   "codex",
@@ -281,6 +279,26 @@ func codexModelsFromItems(items []map[string]any) []Model {
 		})
 	}
 	return models
+}
+
+// codexModelsWithImageRoute ensures gpt-image-2 stays in the model list. It is not
+// issued by the codex /codex/models endpoint, but the gateway still routes explicit
+// image requests to codex, so the site catalog must keep it (otherwise
+// MarkUnavailableExcept marks it unavailable). Applied to both the API-key summary
+// (used by the key-provisioned refresh path) and the user summary.
+func codexModelsWithImageRoute(models []Model) []Model {
+	if len(models) == 0 || hasUpstreamModel(models, codexImageSlug) {
+		return models
+	}
+	route := codexImageRouteModel()
+	return append(models, Model{
+		UpstreamName: codexImageSlug,
+		DisplayName:  defaultString(stringFromAny(route["display_name"]), codexImageSlug),
+		Capabilities: map[string]any{
+			"source": "codex_image_route",
+			"raw":    route,
+		},
+	})
 }
 
 func (a Codex) fetchUsage(ctx context.Context, site SiteConfig, accessToken string, accountID string) (map[string]any, error) {

--- a/server/internal/adapter/codex_test.go
+++ b/server/internal/adapter/codex_test.go
@@ -732,12 +732,16 @@ func TestCodexSummaryKeepsModelsWhenUsageTransientFailure(t *testing.T) {
 	if usage["available"] != false || usage["success"] != false {
 		t.Fatalf("summary usage should record transient failure: %#v", usage)
 	}
-	if len(summary.Models) != 1 {
-		t.Fatalf("summary models length = %d, want 1", len(summary.Models))
+	if len(summary.Models) != 2 {
+		t.Fatalf("summary models length = %d, want 2 (raw upstream model + gpt-image-2 route item)", len(summary.Models))
 	}
 	model := summary.Models[0]
 	if model.UpstreamName != "gpt-summary-test" || model.DisplayName != "GPT Summary Test" {
 		t.Fatalf("unexpected summary model: %#v", model)
+	}
+	routeModel := summary.Models[1]
+	if routeModel.UpstreamName != codexImageSlug {
+		t.Fatalf("route model upstream name = %q, want %q", routeModel.UpstreamName, codexImageSlug)
 	}
 }
 


### PR DESCRIPTION
## 背景
上一轮合入的 gpt-image-2 修复（#45）只在 `FetchUserSummary` 里追加路由模型，而它仅被「无可用 key 的 fallback」路径消费。codex OAuth 账号持有有效 token 时，站点 refresh 走 `syncModelState`，聚合的是 `SummarizeAPIKey` 返回的 `Models`——那条路径从不追加 gpt-image-2。因此刷新后 OAuth 账号的站点模型列表里仍没有 gpt-image-2。

## 改动
抽出共用助手 `codexModelsWithImageRoute`，让 `SummarizeAPIKey` 与 `FetchUserSummary` 都调用，确保两条 refresh 路径一致地把 gpt-image-2 路由模型带进站点模型目录。

- `server/internal/adapter/codex.go`：新增 `codexModelsWithImageRoute`；`SummarizeAPIKey` 返回 `codexModelsWithImageRoute(models)`；`FetchUserSummary` 复用同一助手（消除重复判断）
- `server/internal/adapter/codex_test.go`：同步断言 `SummarizeAPIKey` 现在返回 raw + gpt-image-2 route 两个模型

## 验证
- `go test ./internal/adapter/...` 通过
- 已在本地 test 分支（含 main 合入）验证刷新后 OAuth Codex 账号能显示 gpt-image-2

> 仅含本次 image 修复，未包含 test 分支的 agent 相关改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)