### PR TITLE
统一 Goose SQL 迁移执行与版本追踪

### DIFF
--- a/server/internal/store/bootstrap.go
+++ b/server/internal/store/bootstrap.go
@@ -101,6 +101,9 @@ func ensureDatabaseInitializedOnce(ctx context.Context, cfg config.Config) error
 		return err
 	}
 	if len(missing) == 0 {
+		if err := runSchemaMigrations(ctx, db); err != nil {
+			return fmt.Errorf("upgrade database schema: %w", err)
+		}
 		return ensureSchemaUpgrades(ctx, db)
 	}
 

--- a/server/internal/store/bootstrap_migrations_postgres_test.go
+++ b/server/internal/store/bootstrap_migrations_postgres_test.go
@@ -1,0 +1,251 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pressly/goose/v3"
+	"gorm.io/gorm"
+
+	"xlyra/server/internal/config"
+	"xlyra/server/migrations"
+)
+
+type gooseVersionRecord struct {
+	ID        int64
+	VersionID int64
+	IsApplied bool
+	Tstamp    time.Time
+}
+
+func (gooseVersionRecord) TableName() string {
+	return "goose_db_version"
+}
+
+func TestDevPostgresMigrationsInitializeNewSchema(t *testing.T) {
+	db, cfg, cleanup := openTemporaryMigrationStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := ensureDatabaseInitializedOnce(ctx, cfg); err != nil {
+		t.Fatalf("initialize schema migrations: %v", err)
+	}
+
+	migrator := db.Migrator()
+	if !migrator.HasTable(&OAuthConnection{}) {
+		t.Fatal("oauth_connections table was not created")
+	}
+	if !migrator.HasColumn(&OAuthConnection{}, "RefreshLeaseID") {
+		t.Fatal("oauth_connections.refresh_lease_id column was not created")
+	}
+	if !migrator.HasColumn(&OAuthConnection{}, "RefreshLeaseUntil") {
+		t.Fatal("oauth_connections.refresh_lease_until column was not created")
+	}
+	assertAppliedMigrationVersions(t, db, []int64{0, 1, 2})
+}
+
+func TestDevPostgresMigrationsUpgradeExistingSchema(t *testing.T) {
+	db, cfg, cleanup := openTemporaryMigrationStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get postgres sql db: %v", err)
+	}
+
+	provider, err := goose.NewProvider(goose.DialectPostgres, sqlDB, migrations.FS)
+	if err != nil {
+		t.Fatalf("create migration provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 1); err != nil {
+		t.Fatalf("apply initial schema migration: %v", err)
+	}
+	if db.Migrator().HasColumn(&OAuthConnection{}, "RefreshLeaseID") {
+		t.Fatal("refresh lease column exists before upgrade migration")
+	}
+
+	if err := ensureDatabaseInitializedOnce(ctx, cfg); err != nil {
+		t.Fatalf("upgrade schema migrations: %v", err)
+	}
+	if !db.Migrator().HasColumn(&OAuthConnection{}, "RefreshLeaseID") {
+		t.Fatal("refresh lease column was not added by upgrade migration")
+	}
+	assertAppliedMigrationVersions(t, db, []int64{0, 1, 2})
+}
+
+func TestDevPostgresMigrationsAreRepeatable(t *testing.T) {
+	db, cfg, cleanup := openTemporaryMigrationStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := ensureDatabaseInitializedOnce(ctx, cfg); err != nil {
+		t.Fatalf("first migration run: %v", err)
+	}
+	if err := ensureDatabaseInitializedOnce(ctx, cfg); err != nil {
+		t.Fatalf("second migration run: %v", err)
+	}
+	assertAppliedMigrationVersions(t, db, []int64{0, 1, 2})
+}
+
+func TestDevPostgresFailedMigrationIsNotRecordedAndCanRetry(t *testing.T) {
+	db, _, cleanup := openTemporaryMigrationStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get postgres sql db: %v", err)
+	}
+
+	if err := runMigrations(ctx, sqlDB, os.DirFS("testdata/migrations_failure")); err == nil {
+		t.Fatal("failing migration run returned nil error")
+	}
+	assertAppliedMigrationVersions(t, db, []int64{0, 1})
+
+	if err := runMigrations(ctx, sqlDB, os.DirFS("testdata/migrations_retry")); err != nil {
+		t.Fatalf("retry migration run: %v", err)
+	}
+	if !db.Migrator().HasColumn("migration_retry_probe", "recovered") {
+		t.Fatal("retry migration did not add recovered column")
+	}
+	assertAppliedMigrationVersions(t, db, []int64{0, 1, 2})
+}
+
+func openTemporaryMigrationStore(t *testing.T) (*gorm.DB, config.Config, func()) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	cfg, err := devPostgresSmokeConfig()
+	if err != nil {
+		cancel()
+		t.Skipf("dev PostgreSQL migrations disabled: %v", err)
+	}
+	baseCfg := cfg
+	schemaName := "xlyra_migration_test_" + uuid.NewString()
+	schemaName = strings.ReplaceAll(schemaName, "-", "")
+	setupFS := migrationTestFS(t, "migrations_setup", schemaName)
+	cleanupFS := migrationTestFS(t, "migrations_cleanup", schemaName)
+	if err := runUnversionedMigrations(ctx, baseCfg, setupFS); err != nil {
+		cancel()
+		t.Skipf("prepare migration test schema: %v", err)
+	}
+	parsed, err := url.Parse(cfg.DatabaseDSN())
+	if err != nil {
+		cleanupMigrationTestSchema(t, baseCfg, cleanupFS)
+		cancel()
+		t.Fatalf("parse postgres DSN: %v", err)
+	}
+	query := parsed.Query()
+	query.Set("search_path", schemaName)
+	parsed.RawQuery = query.Encode()
+	cfg.PostgresDSN = parsed.String()
+	cfg.DBMinConns = 0
+	cfg.DBMaxConns = 1
+	store, err := Open(ctx, cfg)
+	if err != nil {
+		cleanupMigrationTestSchema(t, baseCfg, cleanupFS)
+		cancel()
+		t.Skipf("dev PostgreSQL unavailable: %s", redactDatabaseOpenError(err, cfg))
+	}
+	return store.DB(), cfg, func() {
+		store.Close()
+		cleanupMigrationTestSchema(t, baseCfg, cleanupFS)
+		cancel()
+	}
+}
+
+func migrationTestFS(t *testing.T, sourceDir string, schemaName string) fs.FS {
+	t.Helper()
+	root := t.TempDir()
+	sourceRoot := filepath.Join("testdata", sourceDir)
+	if err := filepath.WalkDir(sourceRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		data = bytes.ReplaceAll(data, []byte("xlyra_migration_test"), []byte(schemaName))
+		target := filepath.Join(root, relative)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	}); err != nil {
+		t.Fatalf("prepare migration test files: %v", err)
+	}
+	return os.DirFS(root)
+}
+
+func cleanupMigrationTestSchema(t *testing.T, cfg config.Config, migrationFS fs.FS) {
+	t.Helper()
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runUnversionedMigrations(cleanupCtx, cfg, migrationFS); err != nil {
+		t.Errorf("cleanup migration test schema: %v", err)
+	}
+}
+
+func runUnversionedMigrations(ctx context.Context, cfg config.Config, migrationFS fs.FS) error {
+	store, err := Open(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	sqlDB, err := store.DB().DB()
+	if err != nil {
+		return err
+	}
+	if err := goose.SetDialect("postgres"); err != nil {
+		return err
+	}
+	goose.SetBaseFS(migrationFS)
+	return goose.UpContext(ctx, sqlDB, ".", goose.WithNoVersioning())
+}
+
+func runMigrations(ctx context.Context, db *sql.DB, migrationFS fs.FS) error {
+	if err := goose.SetDialect("postgres"); err != nil {
+		return err
+	}
+	goose.SetBaseFS(migrationFS)
+	return goose.UpContext(ctx, db, ".")
+}
+
+func assertAppliedMigrationVersions(t *testing.T, db *gorm.DB, want []int64) {
+	t.Helper()
+	var records []gooseVersionRecord
+	if err := db.Find(&records).Error; err != nil {
+		t.Fatalf("list goose migration versions: %v", err)
+	}
+	got := make([]int64, 0, len(records))
+	for _, record := range records {
+		if record.IsApplied {
+			got = append(got, record.VersionID)
+		}
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	if len(got) != len(want) {
+		t.Fatalf("applied migration versions = %v, want %v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("applied migration versions = %v, want %v", got, want)
+		}
+	}
+}

--- a/server/internal/store/testdata/migrations_cleanup/00001_drop_schema.sql
+++ b/server/internal/store/testdata/migrations_cleanup/00001_drop_schema.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+DROP SCHEMA IF EXISTS xlyra_migration_test CASCADE;
+
+-- +goose Down
+CREATE SCHEMA xlyra_migration_test;

--- a/server/internal/store/testdata/migrations_failure/00001_create_probe.sql
+++ b/server/internal/store/testdata/migrations_failure/00001_create_probe.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+CREATE TABLE migration_retry_probe (
+  id BIGINT PRIMARY KEY
+);
+
+-- +goose Down
+DROP TABLE migration_retry_probe;

--- a/server/internal/store/testdata/migrations_failure/00002_fail_probe.sql
+++ b/server/internal/store/testdata/migrations_failure/00002_fail_probe.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE migration_retry_probe ADD COLUMN id BIGINT;
+
+-- +goose Down
+SELECT 1;

--- a/server/internal/store/testdata/migrations_retry/00001_create_probe.sql
+++ b/server/internal/store/testdata/migrations_retry/00001_create_probe.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+CREATE TABLE migration_retry_probe (
+  id BIGINT PRIMARY KEY
+);
+
+-- +goose Down
+DROP TABLE migration_retry_probe;

--- a/server/internal/store/testdata/migrations_retry/00002_recover_probe.sql
+++ b/server/internal/store/testdata/migrations_retry/00002_recover_probe.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE migration_retry_probe ADD COLUMN recovered BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE migration_retry_probe DROP COLUMN recovered;

--- a/server/internal/store/testdata/migrations_setup/00001_prepare_schema.sql
+++ b/server/internal/store/testdata/migrations_setup/00001_prepare_schema.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+DROP SCHEMA IF EXISTS xlyra_migration_test CASCADE;
+CREATE SCHEMA xlyra_migration_test;
+
+-- +goose Down
+DROP SCHEMA IF EXISTS xlyra_migration_test CASCADE;

--- a/server/migrations/00002_oauth_refresh_leases.sql
+++ b/server/migrations/00002_oauth_refresh_leases.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE oauth_connections
+  ADD COLUMN refresh_lease_id TEXT NOT NULL DEFAULT '',
+  ADD COLUMN refresh_lease_until TIMESTAMPTZ;
+
+-- +goose Down
+ALTER TABLE oauth_connections
+  DROP COLUMN refresh_lease_until,
+  DROP COLUMN refresh_lease_id;

--- a/server/migrations/schema.go
+++ b/server/migrations/schema.go
@@ -2,9 +2,5 @@ package migrations
 
 import "embed"
 
-// FS contains the production bootstrap schema. Keep only the initial schema
-// here; post-release upgrades should be handled explicitly instead of replaying
-// development-era migrations.
-//
-//go:embed 00001_initial_schema.sql
+//go:embed *.sql
 var FS embed.FS

--- a/server/migrations/schema_test.go
+++ b/server/migrations/schema_test.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestEmbeddedMigrationsAreOrdered(t *testing.T) {
+	entries, err := FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read embedded migrations: %v", err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		t.Fatal("no embedded migrations")
+	}
+	sort.Strings(names)
+	pattern := regexp.MustCompile(`^[0-9]{5}_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$`)
+	for index, name := range names {
+		if !pattern.MatchString(name) {
+			t.Fatalf("migration %q does not follow the five-digit version naming convention", name)
+		}
+		parts := strings.SplitN(name, "_", 2)
+		version, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			t.Fatalf("migration %q has invalid version: %v", name, err)
+		}
+		expected := int64(index + 1)
+		if version != expected {
+			t.Fatalf("migration %q has version %d, want consecutive version %d", name, version, expected)
+		}
+		content, err := FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read migration %q: %v", name, err)
+		}
+		if !strings.Contains(string(content), "-- +goose Up") {
+			t.Fatalf("migration %q is missing goose Up directive", name)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

当前服务端只将 `00001_initial_schema.sql` 嵌入二进制。数据库首次初始化可以创建基础 schema，但已有实例启动时不会自动发现和执行后续 SQL 变更，导致新增字段必须依赖额外的手工升级逻辑，迁移过程也缺少统一的版本追踪。

本 PR 将 Goose 调整为项目 SQL migration 的统一执行入口，后续新增 schema 变更可以按照版本号递增的 SQL 文件持续交付。

## 改动概览

- `server/migrations/schema.go` 改为 embed 全部 `*.sql` migration 文件。
- 已有完整 schema 的实例启动时也执行 Goose，自动应用 `goose_db_version` 中尚未记录的 migration。
- 保留 Goose 内置的 `goose_db_version` 作为 SQL migration 的唯一版本记录来源。
- 新增 `00002_oauth_refresh_leases.sql`，为 OAuth 刷新租约增加 `refresh_lease_id` 和 `refresh_lease_until` 字段。
- migration 失败时直接阻止数据库初始化，失败版本不会被当作成功执行，修复后可在下一次启动重试。
- `schema_upgrade_markers` 继续只用于非 SQL 的业务级一次性升级，不与 Goose 版本记录混用。

## 执行行为

### 新建实例

空数据库启动时按文件版本顺序执行：

```text
00001_initial_schema.sql
00002_oauth_refresh_leases.sql
...
```

所有成功执行的版本会写入 `goose_db_version`。

### 升级实例

已有数据库根据 `goose_db_version` 继续执行未应用版本。例如数据库已经执行到 `00001` 时，只执行 `00002` 及之后的 migration，不会重新执行初始 schema。

### 重复启动

已成功记录的 migration 不会重复执行，服务可以安全地反复启动。

## 迁移约定

后续 migration 使用五位数字、连续递增的文件名：

```text
00003_add_example.sql
00004_create_example.sql
```

已发布的 migration 版本号和内容不可修改；新的 schema 变更只能新增更高版本文件。migration 的 `Down` 只用于受控回滚，应用启动流程不会自动回滚。

## 测试

新增测试覆盖：

- embedded migration 文件加载和版本号连续性校验；
- 空 schema 执行完整初始化；
- 已有 `00001` 数据库升级到 `00002`；
- 重复执行 migration 的幂等性；
- 失败 migration 不写入成功版本，以及修复后的重试；
- `goose_db_version` 的最终版本记录。

PostgreSQL 测试使用每次生成的 UUID schema 隔离，测试结束后自动清理，不使用固定业务 schema。

## 验证

- `cd server && go test ./...` ✅
- `cd server && govulncheck ./...` ✅（未发现影响当前代码的漏洞）
- `git diff --check` ✅
- 未修改 Dockerfile
- 未引入 Go 应用代码中的手写 SQL

本 PR 不改变当前单实例部署模型，也不包含其他 OAuth 业务改动。