### PR TITLE
fix: 🐛 将 OAuth 刷新并发修复合入主分支

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"xlyra/server/internal/backup"
 	"xlyra/server/internal/catalog"
 	"xlyra/server/internal/config"
+	oauthsvc "xlyra/server/internal/oauth"
 	"xlyra/server/internal/observability"
 	"xlyra/server/internal/scheduler"
 	"xlyra/server/internal/site"
@@ -113,7 +114,8 @@ func run() int {
 	logger.Info("database connection ready")
 
 	logger.Info("business services initializing")
-	siteService := site.NewServiceWithTimeZone(db, masterKey, appTimeZone, confFile)
+	oauthService := oauthsvc.NewService(db, masterKey, confFile)
+	siteService := site.NewServiceWithOAuthService(db, masterKey, appTimeZone, oauthService, confFile)
 	syncService := catalog.NewSyncService(db, logger.With("thread", "models-dev-sync"), confFile)
 	usageSummaryService := usage.NewSummaryService(db, confFile, appTimeZone)
 	backupService := backup.NewService(db, confFile, masterKey, filepath.Join(config.ResolveWorkdir(), "playground"), appTimeZone)
@@ -123,7 +125,7 @@ func run() int {
 		logger.Warn("startup canonical model category reconciliation failed", "error", err)
 	}
 	reconcileCancel()
-	router, gatewayHandler := app.NewRouterWithGateway(cfg, logger, db, confFile, masterKey)
+	router, gatewayHandler := app.NewRouterWithGatewayWithOAuth(cfg, logger, db, confFile, masterKey, oauthService)
 	schedule := scheduler.New(logger.With("thread", "scheduler"), scheduler.Options{
 		SiteHealthInterval: cfg.SiteHealthInterval,
 		SiteHealthTimeout:  cfg.SiteHealthTimeout,

--- a/server/internal/app/router.go
+++ b/server/internal/app/router.go
@@ -43,6 +43,10 @@ func NewRouter(cfg config.Config, logger *slog.Logger, db *store.Store, confFile
 }
 
 func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Store, confFile *config.ConfigFile, masterKey string) (http.Handler, *gateway.Handler) {
+	return NewRouterWithGatewayWithOAuth(cfg, logger, db, confFile, masterKey, nil)
+}
+
+func NewRouterWithGatewayWithOAuth(cfg config.Config, logger *slog.Logger, db *store.Store, confFile *config.ConfigFile, masterKey string, sharedOAuth *oauthsvc.Service) (http.Handler, *gateway.Handler) {
 	appTimeZone := config.ResolveTimeZone()
 	var authService *auth.Service
 	if db != nil {
@@ -60,8 +64,11 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 	var routerService *routeengine.Service
 	var usageService *usage.Service
 	if db != nil {
-		oauthService = oauthsvc.NewService(db, masterKey, confFile)
-		siteService = site.NewServiceWithTimeZone(db, masterKey, appTimeZone, confFile)
+		oauthService = sharedOAuth
+		if oauthService == nil {
+			oauthService = oauthsvc.NewService(db, masterKey, confFile)
+		}
+		siteService = site.NewServiceWithOAuthService(db, masterKey, appTimeZone, oauthService, confFile)
 		catalogService = catalog.NewService(db, confFile)
 		dashboardService = dashboard.NewService(db, appTimeZone)
 		analyticsService = analytics.NewService(db, appTimeZone)
@@ -70,7 +77,7 @@ func NewRouterWithGateway(cfg config.Config, logger *slog.Logger, db *store.Stor
 	}
 	systemStatsService := systemstats.NewService(appTimeZone)
 	downloadService := downloads.NewService()
-	gatewayHandler := gateway.NewHandlerWithTimeZone(logger.With("thread", "gateway"), authService, routerService, db, masterKey, appTimeZone, confFile)
+	gatewayHandler := gateway.NewHandlerWithOAuthService(logger.With("thread", "gateway"), authService, routerService, db, masterKey, appTimeZone, oauthService, confFile)
 	playgroundGatewayHandler := gatewayHandler.WithRouteSiteHeader()
 	playgroundRoot := filepath.Join(config.ResolveWorkdir(), "playground")
 	playgroundService := playground.NewService(logger.With("thread", "playground"), db, gatewayHandler, playgroundRoot)

--- a/server/internal/gateway/handler.go
+++ b/server/internal/gateway/handler.go
@@ -51,9 +51,20 @@ func NewHandler(logger *slog.Logger, authService *auth.Service, routerService *r
 }
 
 func NewHandlerWithTimeZone(logger *slog.Logger, authService *auth.Service, routerService *routeengine.Service, db *store.Store, masterKey string, timeZone config.TimeZone, confFiles ...*config.ConfigFile) Handler {
+	return newHandlerWithTimeZone(logger, authService, routerService, db, masterKey, timeZone, nil, confFiles...)
+}
+
+func NewHandlerWithOAuthService(logger *slog.Logger, authService *auth.Service, routerService *routeengine.Service, db *store.Store, masterKey string, timeZone config.TimeZone, oauthService *oauthsvc.Service, confFiles ...*config.ConfigFile) Handler {
+	return newHandlerWithTimeZone(logger, authService, routerService, db, masterKey, timeZone, oauthService, confFiles...)
+}
+
+func newHandlerWithTimeZone(logger *slog.Logger, authService *auth.Service, routerService *routeengine.Service, db *store.Store, masterKey string, timeZone config.TimeZone, oauthService *oauthsvc.Service, confFiles ...*config.ConfigFile) Handler {
 	var confFile *config.ConfigFile
 	if len(confFiles) > 0 {
 		confFile = confFiles[0]
+	}
+	if oauthService == nil {
+		oauthService = oauthsvc.NewService(db, masterKey, confFile)
 	}
 	clientManager := httpclient.NewManager(confFile)
 	defaultClient, _ := clientManager.Client(httpclient.DefaultProfile())
@@ -62,24 +73,10 @@ func NewHandlerWithTimeZone(logger *slog.Logger, authService *auth.Service, rout
 		usageService = usage.NewService(db, timeZone)
 	}
 	return Handler{
-		logger:              logger,
-		auth:                authService,
-		router:              routerService,
-		db:                  db,
-		credentials:         credential.NewService(masterKey),
-		httpClient:          defaultClient,
-		clients:             clientManager,
-		limits:              newUpstreamConcurrencyCache(),
-		recorder:            NewRecorder(db, logger, timeZone),
-		oauth:               oauthsvc.NewService(db, masterKey, confFile),
-		rateLimits:          ratelimit.NewService(db),
-		modelsCache:         newModelsCache(),
-		noRoutes:            newNoRouteSuppressionCache(),
-		userBalanceThrottle: newUserBalanceThrottle(),
-		credentialSelector:  newCredentialWindowSelector(time.Minute),
-		confFile:            confFile,
-		usage:               usageService,
-		timeZone:            timeZone,
-		cacheObservationKey: cacheObservationKey(masterKey),
+		logger: logger, auth: authService, router: routerService, db: db, credentials: credential.NewService(masterKey),
+		httpClient: defaultClient, clients: clientManager, limits: newUpstreamConcurrencyCache(), recorder: NewRecorder(db, logger, timeZone),
+		oauth: oauthService, rateLimits: ratelimit.NewService(db), modelsCache: newModelsCache(), noRoutes: newNoRouteSuppressionCache(),
+		userBalanceThrottle: newUserBalanceThrottle(), credentialSelector: newCredentialWindowSelector(time.Minute), confFile: confFile,
+		usage: usageService, timeZone: timeZone, cacheObservationKey: cacheObservationKey(masterKey),
 	}
 }

--- a/server/internal/oauth/antigravity.go
+++ b/server/internal/oauth/antigravity.go
@@ -215,9 +215,7 @@ func (s *Service) refreshAntigravityConnection(ctx context.Context, repo store.O
 		errMsg := err.Error()
 		connection.Status = "reconnect_required"
 		connection.Metadata = store.JSON(updateMetadataError(connection.Metadata, errMsg))
-		_, _ = repo.Save(ctx, connection)
-		s.disableSiteOnPermanentError(ctx, connection, errMsg)
-		return CodexConnection{}, err
+		return CodexConnection{}, &refreshFail{connection: connection, err: err}
 	}
 	if refreshed.RefreshToken == "" {
 		refreshed.RefreshToken = refreshToken

--- a/server/internal/oauth/postgres_smoke_test.go
+++ b/server/internal/oauth/postgres_smoke_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/url"
@@ -150,5 +151,96 @@ func assertOAuthServiceConnectionsStable(t *testing.T, connections []store.OAuth
 		if previous.CreatedAt.Equal(connection.CreatedAt) && previous.ID.String() > connection.ID.String() {
 			t.Fatalf("oauth connections with equal created_at are not sorted by id at index %d", index)
 		}
+	}
+}
+
+func TestDevPostgresOAuthRefreshLeaseDoesNotHoldRowLockDuringRefresh(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cfg, err := devPostgresOAuthSmokeConfig()
+	if err != nil {
+		t.Skipf("dev PostgreSQL smoke disabled: %v", err)
+	}
+
+	db, err := store.Open(ctx, cfg)
+	if err != nil {
+		t.Skipf("dev PostgreSQL unavailable: %s", redactOAuthDatabaseOpenError(err, cfg))
+	}
+	defer db.Close()
+
+	if !db.DB().Migrator().HasColumn(&store.OAuthConnection{}, "RefreshLeaseID") {
+		t.Skip("oauth refresh lease migration is not applied")
+	}
+
+	connection := store.OAuthConnection{
+		ID:                    uuid.New(),
+		Provider:              codexProvider,
+		Status:                "connected",
+		Email:                 "xlyra-refresh-lease-" + uuid.NewString(),
+		EncryptedAccessToken:  "access",
+		MaskedAccessToken:     "access",
+		EncryptedRefreshToken: "refresh",
+		MaskedRefreshToken:    "refresh",
+		EncryptedIDToken:      "id",
+		MaskedIDToken:         "id",
+		RefreshLeaseID:        "lease-1",
+		RefreshLeaseUntil:     sql.NullTime{Time: time.Now().Add(time.Minute), Valid: true},
+	}
+	if err := db.DB().WithContext(ctx).Create(&connection).Error; err != nil {
+		t.Fatalf("create oauth connection: %v", err)
+	}
+	defer db.DB().WithContext(context.Background()).Delete(&store.OAuthConnection{}, connection.ID)
+
+	claimed := make(chan struct{})
+	refreshFinished := make(chan struct{})
+	go func() {
+		err := db.WithinTx(ctx, func(tx store.Tx) error {
+			repo := store.NewOAuthConnectionRepository(tx)
+			current, err := repo.GetByIDForUpdate(ctx, connection.ID)
+			if err != nil {
+				return err
+			}
+			current.RefreshLeaseID = "lease-2"
+			current.RefreshLeaseUntil = sql.NullTime{Time: time.Now().Add(time.Minute), Valid: true}
+			if _, err := repo.Save(ctx, current); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("claim refresh lease: %v", err)
+			return
+		}
+		close(claimed)
+		time.Sleep(300 * time.Millisecond)
+		close(refreshFinished)
+	}()
+
+	select {
+	case <-claimed:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for refresh lease claim")
+	}
+
+	start := time.Now()
+	var observed store.OAuthConnection
+	if err := db.WithinTx(ctx, func(tx store.Tx) error {
+		var err error
+		observed, err = store.NewOAuthConnectionRepository(tx).GetByIDForUpdate(ctx, connection.ID)
+		return err
+	}); err != nil {
+		t.Fatalf("read connection while refresh is in progress: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("row lock remained held during refresh: waited %s", elapsed)
+	}
+	if observed.RefreshLeaseID != "lease-2" {
+		t.Fatalf("refresh lease id = %q, want lease-2", observed.RefreshLeaseID)
+	}
+	select {
+	case <-refreshFinished:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for refresh transaction")
 	}
 }

--- a/server/internal/oauth/service.go
+++ b/server/internal/oauth/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
 
 	"xlyra/server/internal/adapter"
 	"xlyra/server/internal/config"
@@ -607,7 +609,7 @@ func (s *Service) EnsureCodexConnectionFresh(ctx context.Context, siteID uuid.UU
 	if !connection.ExpiresAt.Valid || time.Until(connection.ExpiresAt.Time) > codexRefreshLead {
 		return s.codexConnectionDetails(connection)
 	}
-	return s.RefreshCodexConnection(ctx, connection.ID)
+	return s.refreshConnection(ctx, connection.ID)
 }
 
 func (s *Service) EnsureAntigravityConnectionFresh(ctx context.Context, siteID uuid.UUID) (CodexConnection, error) {
@@ -621,7 +623,7 @@ func (s *Service) EnsureAntigravityConnectionFresh(ctx context.Context, siteID u
 	if !connection.ExpiresAt.Valid || time.Until(connection.ExpiresAt.Time) > antigravityRefreshLead {
 		return s.codexConnectionDetails(connection)
 	}
-	return s.RefreshCodexConnection(ctx, connection.ID)
+	return s.refreshConnection(ctx, connection.ID)
 }
 
 func (s *Service) EnsureClaudeCodeConnectionFresh(ctx context.Context, siteID uuid.UUID) (CodexConnection, error) {
@@ -635,7 +637,7 @@ func (s *Service) EnsureClaudeCodeConnectionFresh(ctx context.Context, siteID uu
 	if !connection.ExpiresAt.Valid || time.Until(connection.ExpiresAt.Time) > claudeCodeRefreshLead {
 		return s.codexConnectionDetails(connection)
 	}
-	return s.RefreshCodexConnection(ctx, connection.ID)
+	return s.refreshConnection(ctx, connection.ID)
 }
 
 // RefreshCodexConnection refreshes (and rotates) a connection's tokens.
@@ -644,6 +646,10 @@ func (s *Service) EnsureClaudeCodeConnectionFresh(ctx context.Context, siteID uu
 // would present an already-invalidated token, get invalid_grant, and wrongly
 // disable a healthy site. Losers instead receive the winner's fresh result.
 func (s *Service) RefreshCodexConnection(ctx context.Context, connectionID uuid.UUID) (CodexConnection, error) {
+	return s.refreshConnection(ctx, connectionID)
+}
+
+func (s *Service) refreshConnection(ctx context.Context, connectionID uuid.UUID) (CodexConnection, error) {
 	result, err, _ := s.refreshGroup.Do(connectionID.String(), func() (any, error) {
 		return s.refreshConnectionOnce(ctx, connectionID)
 	})
@@ -654,12 +660,130 @@ func (s *Service) RefreshCodexConnection(ctx context.Context, connectionID uuid.
 	return connection, nil
 }
 
+const refreshTimeout = 60 * time.Second
+
+type refreshFail struct {
+	connection store.OAuthConnection
+	err        error
+}
+
+func (r *refreshFail) Error() string { return r.err.Error() }
+func (r *refreshFail) Unwrap() error { return r.err }
+
 func (s *Service) refreshConnectionOnce(ctx context.Context, connectionID uuid.UUID) (CodexConnection, error) {
-	repo := store.NewOAuthConnectionRepository(s.db.DB())
-	connection, err := repo.GetByID(ctx, connectionID)
-	if err != nil {
+	waitedForLease := false
+	for {
+		var result CodexConnection
+		var connection store.OAuthConnection
+		var leaseID string
+		var waitUntil time.Time
+		err := s.db.WithinTx(ctx, func(tx store.Tx) error {
+			repo := store.NewOAuthConnectionRepository(tx)
+			current, err := repo.GetByIDForUpdate(ctx, connectionID)
+			if err != nil {
+				return err
+			}
+			if connectionStillFresh(current) {
+				result, err = s.codexConnectionDetails(current)
+				return err
+			}
+			if waitedForLease && current.Status == "reconnect_required" {
+				return refreshConnectionFailureError(current)
+			}
+			if current.Provider != codexProvider && current.Provider != antigravityProvider && current.Provider != claudeCodeProvider {
+				return fmt.Errorf("oauth connection provider %q is not supported", current.Provider)
+			}
+			if current.RefreshLeaseID != "" && current.RefreshLeaseUntil.Valid && current.RefreshLeaseUntil.Time.After(time.Now()) {
+				waitedForLease = true
+				waitUntil = current.RefreshLeaseUntil.Time
+				return nil
+			}
+			leaseID = uuid.NewString()
+			connection = current
+			connection.RefreshLeaseID = leaseID
+			connection.RefreshLeaseUntil = sql.NullTime{Time: time.Now().Add(2 * refreshTimeout), Valid: true}
+			_, err = repo.Save(ctx, connection)
+			return err
+		})
+		if err != nil {
+			return CodexConnection{}, err
+		}
+		if result.Connection.ID != uuid.Nil {
+			return result, nil
+		}
+		if leaseID == "" {
+			wait := time.Until(waitUntil)
+			if wait > 250*time.Millisecond {
+				wait = 250 * time.Millisecond
+			}
+			if wait > 0 {
+				timer := time.NewTimer(wait)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return CodexConnection{}, ctx.Err()
+				case <-timer.C:
+				}
+			}
+			continue
+		}
+
+		refreshCtx, cancel := context.WithTimeout(ctx, refreshTimeout)
+		repo := store.NewOAuthConnectionRepositoryWithRefreshLease(s.db.DB(), leaseID)
+		connection.RefreshLeaseID = ""
+		connection.RefreshLeaseUntil = sql.NullTime{}
+		result, err = s.refreshConnectionLocked(refreshCtx, repo, connection)
+		cancel()
+		if err == nil {
+			return result, nil
+		}
+		var fail *refreshFail
+		if errors.As(err, &fail) {
+			fail.connection.RefreshLeaseID = ""
+			fail.connection.RefreshLeaseUntil = sql.NullTime{}
+			if _, saveErr := repo.Save(ctx, fail.connection); saveErr != nil {
+				return CodexConnection{}, saveErr
+			}
+			if isPermanentAuthError(fail.err.Error()) {
+				s.disableSiteOnPermanentError(ctx, s.db.DB(), fail.connection, fail.err.Error())
+			}
+			return CodexConnection{}, fail.err
+		}
+		connection.RefreshLeaseID = ""
+		connection.RefreshLeaseUntil = sql.NullTime{}
+		if _, saveErr := repo.Save(ctx, connection); saveErr != nil {
+			return CodexConnection{}, saveErr
+		}
 		return CodexConnection{}, err
 	}
+}
+
+func refreshConnectionFailureError(connection store.OAuthConnection) error {
+	meta := map[string]any{}
+	if len(connection.Metadata) > 0 {
+		_ = json.Unmarshal(connection.Metadata, &meta)
+	}
+	if lastError := strings.TrimSpace(stringFromAny(meta["last_error"])); lastError != "" {
+		return fmt.Errorf("oauth connection requires reconnect: %s", lastError)
+	}
+	return fmt.Errorf("oauth connection requires reconnect")
+}
+
+func connectionStillFresh(connection store.OAuthConnection) bool {
+	if !connection.ExpiresAt.Valid {
+		return false
+	}
+	lead := codexRefreshLead
+	switch connection.Provider {
+	case antigravityProvider:
+		lead = antigravityRefreshLead
+	case claudeCodeProvider:
+		lead = claudeCodeRefreshLead
+	}
+	return time.Until(connection.ExpiresAt.Time) > lead
+}
+
+func (s *Service) refreshConnectionLocked(ctx context.Context, repo store.OAuthConnectionRepository, connection store.OAuthConnection) (CodexConnection, error) {
 	if connection.Provider == antigravityProvider {
 		return s.refreshAntigravityConnection(ctx, repo, connection)
 	}
@@ -688,9 +812,7 @@ func (s *Service) refreshConnectionOnce(ctx context.Context, connectionID uuid.U
 		errMsg := err.Error()
 		connection.Status = "reconnect_required"
 		connection.Metadata = store.JSON(updateMetadataError(connection.Metadata, errMsg))
-		_, _ = repo.Save(ctx, connection)
-		s.disableSiteOnPermanentError(ctx, connection, errMsg)
-		return CodexConnection{}, err
+		return CodexConnection{}, &refreshFail{connection: connection, err: err}
 	}
 	claims, rawClaims, err := parseCodexIDToken(refreshed.IDToken)
 	if err != nil {
@@ -752,9 +874,7 @@ func (s *Service) refreshClaudeCodeConnection(ctx context.Context, repo store.OA
 		errMsg := err.Error()
 		connection.Status = "reconnect_required"
 		connection.Metadata = store.JSON(updateMetadataError(connection.Metadata, errMsg))
-		_, _ = repo.Save(ctx, connection)
-		s.disableSiteOnPermanentError(ctx, connection, errMsg)
-		return CodexConnection{}, err
+		return CodexConnection{}, &refreshFail{connection: connection, err: err}
 	}
 	profile, rawProfile, err := s.fetchClaudeCodeProfile(ctx, refreshed.AccessToken, httpClient)
 	if err != nil {
@@ -1237,14 +1357,14 @@ func messageContainsHTTPAuthCode(message string) bool {
 	return false
 }
 
-func (s *Service) disableSiteOnPermanentError(ctx context.Context, connection store.OAuthConnection, errMsg string) {
+func (s *Service) disableSiteOnPermanentError(ctx context.Context, tx *gorm.DB, connection store.OAuthConnection, errMsg string) {
 	if !isPermanentAuthError(errMsg) {
 		return
 	}
 	if connection.SiteID == nil {
 		return
 	}
-	siteRepo := store.NewSiteRepository(s.db.DB())
+	siteRepo := store.NewSiteRepository(tx)
 	existing, err := siteRepo.GetByID(ctx, *connection.SiteID)
 	if err != nil {
 		return
@@ -1253,7 +1373,7 @@ func (s *Service) disableSiteOnPermanentError(ctx context.Context, connection st
 		return
 	}
 	existing.Enabled = false
-	_ = s.db.DB().WithContext(ctx).Save(&existing).Error
+	_ = tx.WithContext(ctx).Save(&existing).Error
 }
 
 func jsonBytes(value any) store.JSON {

--- a/server/internal/oauth/service_create_update_edges_test.go
+++ b/server/internal/oauth/service_create_update_edges_test.go
@@ -114,7 +114,7 @@ func TestDisableSiteOnPermanentErrorOnlySavesEnabledBoundSiteOffline(t *testing.
 	queryCount := 0
 	saveCount := 0
 	var savedSite store.Site
-	service := oauthServiceWithQueryUpdate(t, func(tx *gorm.DB) {
+	service := NewService(oauthStoreWithGorm(t, oauthGormWithQueryUpdate(t, func(tx *gorm.DB) {
 		site, ok := tx.Statement.Dest.(*store.Site)
 		if !ok {
 			tx.AddError(errors.New("unexpected permanent-error site query destination"))
@@ -132,14 +132,15 @@ func TestDisableSiteOnPermanentErrorOnlySavesEnabledBoundSiteOffline(t *testing.
 		}
 		savedSite = *site
 		tx.Statement.RowsAffected = 1
-	})
+	})), "master-key")
+	db := service.db.DB()
 
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{SiteID: &siteID}, "invalid_grant")
+	service.disableSiteOnPermanentError(context.Background(), db, store.OAuthConnection{SiteID: &siteID}, "invalid_grant")
 	if saveCount != 0 {
 		t.Fatalf("save count after already-disabled site = %d, want no save", saveCount)
 	}
 
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{SiteID: &siteID}, "codex token refresh returned 403: forbidden")
+	service.disableSiteOnPermanentError(context.Background(), db, store.OAuthConnection{SiteID: &siteID}, "codex token refresh returned 403: forbidden")
 	if saveCount != 1 || savedSite.ID != siteID || savedSite.Enabled {
 		t.Fatalf("saved site = %#v save count = %d, want enabled site disabled once", savedSite, saveCount)
 	}

--- a/server/internal/oauth/service_gorm_test_helpers_test.go
+++ b/server/internal/oauth/service_gorm_test_helpers_test.go
@@ -1,7 +1,10 @@
 package oauth
 
 import (
+	"context"
+	"database/sql"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"unsafe"
 
@@ -39,6 +42,9 @@ func oauthGormWithCallbacks(t *testing.T, callbacks oauthGormCallbacks) *gorm.DB
 	if err != nil {
 		t.Fatalf("open offline gorm db: %v", err)
 	}
+	pool := &oauthTestConnPool{ConnPool: db.Statement.ConnPool}
+	db.Config.ConnPool = pool
+	db.Statement.ConnPool = pool
 	if callbacks.query != nil {
 		if err := db.Callback().Query().Replace("gorm:query", callbacks.query); err != nil {
 			t.Fatalf("replace query callback: %v", err)
@@ -87,4 +93,31 @@ func oauthStoreWithGorm(t *testing.T, db *gorm.DB) *store.Store {
 	field := reflect.ValueOf(st).Elem().FieldByName("db")
 	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(db))
 	return st
+}
+
+type oauthTestConnPool struct {
+	gorm.ConnPool
+	begins    atomic.Int32
+	commits   atomic.Int32
+	rollbacks atomic.Int32
+}
+
+func (p *oauthTestConnPool) BeginTx(context.Context, *sql.TxOptions) (gorm.ConnPool, error) {
+	p.begins.Add(1)
+	return &oauthTestTx{ConnPool: p.ConnPool, pool: p}, nil
+}
+
+type oauthTestTx struct {
+	gorm.ConnPool
+	pool *oauthTestConnPool
+}
+
+func (tx *oauthTestTx) Commit() error {
+	tx.pool.commits.Add(1)
+	return nil
+}
+
+func (tx *oauthTestTx) Rollback() error {
+	tx.pool.rollbacks.Add(1)
+	return nil
 }

--- a/server/internal/oauth/service_metadata_import_helpers_test.go
+++ b/server/internal/oauth/service_metadata_import_helpers_test.go
@@ -198,8 +198,8 @@ func TestDisableSiteOnPermanentErrorSkipsStoreWhenErrorIsTemporaryOrSiteMissing(
 	service := &Service{}
 	siteID := uuid.New()
 
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{SiteID: &siteID}, "temporary network timeout")
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{}, "invalid_grant")
+	service.disableSiteOnPermanentError(context.Background(), nil, store.OAuthConnection{SiteID: &siteID}, "temporary network timeout")
+	service.disableSiteOnPermanentError(context.Background(), nil, store.OAuthConnection{}, "invalid_grant")
 }
 
 func TestImportOAuthAccountReturnsMetadataMarshalFailureWithoutStoreAccess(t *testing.T) {

--- a/server/internal/oauth/service_refresh_singleflight_test.go
+++ b/server/internal/oauth/service_refresh_singleflight_test.go
@@ -2,7 +2,9 @@ package oauth
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -70,5 +72,120 @@ func TestRefreshCodexConnectionCollapsesConcurrentRefreshes(t *testing.T) {
 
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("concurrent refresh hit the token endpoint %d times, want 1 (singleflight dedup)", got)
+	}
+	pool, ok := service.db.DB().Config.ConnPool.(*oauthTestConnPool)
+	if !ok {
+		t.Fatal("refresh did not use the test transaction pool")
+	}
+	if got := pool.begins.Load(); got != 1 {
+		t.Fatalf("refresh transactions = %d, want exactly one transaction", got)
+	}
+}
+
+// A failed token refresh must persist the connection's reconnect_required
+// state, not lose it to a transaction rollback. The old flow returned the
+// refresh error from inside WithTransaction, so GORM rolled back the status
+// write while the site disable (committed on autocommit) survived, leaving the
+// site disabled but the connection still marked connected.
+func TestRefreshCodexConnectionFailureCommitsReconnectStatus(t *testing.T) {
+	t.Parallel()
+
+	connectionID := uuid.New()
+	bootstrap := NewService(nil, "master-key")
+	encryptedRefresh, _, err := bootstrap.credentials.Encrypt("refresh-token")
+	if err != nil {
+		t.Fatalf("encrypt refresh token: %v", err)
+	}
+	connection := store.OAuthConnection{
+		ID:                    connectionID,
+		Provider:              codexProvider,
+		Status:                "connected",
+		EncryptedRefreshToken: encryptedRefresh,
+	}
+	var saved *store.OAuthConnection
+	service := oauthServiceWithQueryUpdate(t, func(tx *gorm.DB) {
+		if item, ok := tx.Statement.Dest.(*store.OAuthConnection); ok {
+			*item = connection
+			tx.Statement.RowsAffected = 1
+			return
+		}
+		tx.Statement.RowsAffected = 0
+	}, func(tx *gorm.DB) {
+		if item, ok := tx.Statement.Dest.(*store.OAuthConnection); ok {
+			copy := *item
+			saved = &copy
+		}
+		tx.Statement.RowsAffected = 1
+	})
+	service.httpClient = &http.Client{Transport: oauthRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return oauthHTTPResponse(http.StatusUnauthorized, ` invalid_grant `), nil
+	})}
+
+	if _, err := service.RefreshCodexConnection(context.Background(), connectionID); err == nil {
+		t.Fatal("RefreshCodexConnection returned nil error, want refresh failure")
+	}
+
+	pool, ok := service.db.DB().Config.ConnPool.(*oauthTestConnPool)
+	if !ok {
+		t.Fatal("refresh did not use the test transaction pool")
+	}
+	if got := pool.rollbacks.Load(); got != 0 {
+		t.Fatalf("refresh rollbacks = %d, want 0 (failure state must commit, not roll back)", got)
+	}
+	if got := pool.commits.Load(); got != 1 {
+		t.Fatalf("refresh commits = %d, want 1", got)
+	}
+	if saved == nil || saved.Status != "reconnect_required" {
+		t.Fatalf("saved connection = %#v, want reconnect_required persisted", saved)
+	}
+}
+
+func TestRefreshCodexConnectionDoesNotRetryAfterWaitedRefreshFailure(t *testing.T) {
+	t.Parallel()
+
+	connectionID := uuid.New()
+	connection := store.OAuthConnection{
+		ID:                connectionID,
+		Provider:          codexProvider,
+		Status:            "connected",
+		RefreshLeaseID:    "another-refresh",
+		RefreshLeaseUntil: sql.NullTime{Time: time.Now().Add(100 * time.Millisecond), Valid: true},
+		Metadata:          store.JSON(`{"token_mode":"oauth_refresh"}`),
+	}
+	var queries atomic.Int32
+	service := oauthServiceWithQueryUpdate(t, func(tx *gorm.DB) {
+		item, ok := tx.Statement.Dest.(*store.OAuthConnection)
+		if !ok {
+			t.Fatalf("unexpected refresh query destination %T", tx.Statement.Dest)
+		}
+		if queries.Add(1) == 1 {
+			*item = connection
+		} else {
+			*item = connection
+			item.Status = "reconnect_required"
+			item.RefreshLeaseID = ""
+			item.RefreshLeaseUntil = sql.NullTime{}
+			item.Metadata = store.JSON(`{"token_mode":"oauth_refresh","last_error":"codex token refresh returned 401: invalid_grant"}`)
+		}
+		tx.Statement.RowsAffected = 1
+	}, func(tx *gorm.DB) {
+		tx.Statement.RowsAffected = 1
+	})
+
+	var calls atomic.Int32
+	service.httpClient = &http.Client{Transport: oauthRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return oauthHTTPResponse(http.StatusUnauthorized, ` invalid_grant `), nil
+	})}
+
+	_, err := service.RefreshCodexConnection(context.Background(), connectionID)
+	if err == nil || !strings.Contains(err.Error(), "invalid_grant") {
+		t.Fatalf("RefreshCodexConnection error = %v, want stored refresh failure", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("refresh retried upstream %d times after waited failure, want 0", calls.Load())
+	}
+	if queries.Load() < 2 {
+		t.Fatalf("refresh queries = %d, want lease wait followed by failure-state read", queries.Load())
 	}
 }

--- a/server/internal/oauth/service_refresh_site_meta_edges_test.go
+++ b/server/internal/oauth/service_refresh_site_meta_edges_test.go
@@ -78,7 +78,7 @@ func TestRefreshCodexConnectionRejectsUnsupportedProviderAndExpiredAccessOnlyOff
 		*item = connection
 		tx.Statement.RowsAffected = 1
 	}, func(tx *gorm.DB) {
-		tx.AddError(errors.New("refresh guard should not save"))
+		tx.Statement.RowsAffected = 1
 	})
 
 	if _, err := service.RefreshCodexConnection(context.Background(), connection.ID); err == nil || !strings.Contains(err.Error(), "is not supported") {

--- a/server/internal/oauth/service_relay_status_edges_test.go
+++ b/server/internal/oauth/service_relay_status_edges_test.go
@@ -146,8 +146,8 @@ func TestAuthOAuthConnectionStatusSkipsNilIDsAndPermanentErrorChecksOffline(t *t
 	if err := service.MarkConnectionUnavailableBySiteID(context.Background(), uuid.Nil, "boom"); err != nil {
 		t.Fatalf("MarkConnectionUnavailableBySiteID nil site returned error: %v", err)
 	}
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{}, "temporary timeout")
-	service.disableSiteOnPermanentError(context.Background(), store.OAuthConnection{}, "401 unauthorized")
+	service.disableSiteOnPermanentError(context.Background(), nil, store.OAuthConnection{}, "temporary timeout")
+	service.disableSiteOnPermanentError(context.Background(), nil, store.OAuthConnection{}, "401 unauthorized")
 }
 
 func TestAuthOAuthHTTPClientForConnectionReturnsSiteLookupErrorsOffline(t *testing.T) {

--- a/server/internal/oauth/service_store_callback_edges_test.go
+++ b/server/internal/oauth/service_store_callback_edges_test.go
@@ -206,19 +206,6 @@ func TestRefreshAntigravityConnectionMarksReconnectRequiredOnRefreshFailureOffli
 		EncryptedRefreshToken: encryptedRefresh,
 		Metadata:              store.JSON(`{"oauth_client_key":"antigravity-client"}`),
 	}
-	var saved store.OAuthConnection
-	db := oauthGormWithQueryUpdate(t, func(tx *gorm.DB) {
-		tx.AddError(errors.New("antigravity refresh should not query repository"))
-	}, func(tx *gorm.DB) {
-		item, ok := tx.Statement.Dest.(*store.OAuthConnection)
-		if !ok {
-			tx.AddError(errors.New("unexpected antigravity refresh save destination"))
-			return
-		}
-		saved = *item
-		tx.Statement.RowsAffected = 1
-	})
-	repo := store.NewOAuthConnectionRepository(db)
 	service.httpClient = &http.Client{Transport: oauthRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodPost || req.URL.String() != antigravityTokenURL {
 			t.Fatalf("unexpected antigravity refresh request: %s %s", req.Method, req.URL.String())
@@ -226,15 +213,19 @@ func TestRefreshAntigravityConnectionMarksReconnectRequiredOnRefreshFailureOffli
 		return oauthHTTPResponse(http.StatusBadRequest, ` invalid_grant `), nil
 	})}
 
-	_, err = service.refreshAntigravityConnection(context.Background(), repo, connection)
+	_, err = service.refreshAntigravityConnection(context.Background(), store.OAuthConnectionRepository{}, connection)
 	if err == nil || !strings.Contains(err.Error(), "antigravity token refresh returned 400: invalid_grant") {
 		t.Fatalf("refreshAntigravityConnection error = %v, want refresh failure", err)
 	}
-	if saved.ID != connectionID || saved.Status != "reconnect_required" {
-		t.Fatalf("saved connection = %#v, want reconnect_required", saved)
+	var fail *refreshFail
+	if !errors.As(err, &fail) {
+		t.Fatalf("refreshAntigravityConnection error = %v, want refreshFail carrying the reconnection state", err)
+	}
+	if fail.connection.ID != connectionID || fail.connection.Status != "reconnect_required" {
+		t.Fatalf("refresh fail connection = %#v, want reconnect_required", fail.connection)
 	}
 	var meta map[string]any
-	if err := json.Unmarshal(saved.Metadata, &meta); err != nil {
+	if err := json.Unmarshal(fail.connection.Metadata, &meta); err != nil {
 		t.Fatalf("decode saved metadata: %v", err)
 	}
 	if meta["oauth_client_key"] != "antigravity-client" || meta["last_error"] != "antigravity token refresh returned 400: invalid_grant" || strings.TrimSpace(stringFromAny(meta["last_error_at"])) == "" {

--- a/server/internal/site/service.go
+++ b/server/internal/site/service.go
@@ -115,12 +115,23 @@ func NewService(db *store.Store, masterKey string, confFiles ...*config.ConfigFi
 }
 
 func NewServiceWithTimeZone(db *store.Store, masterKey string, timeZone config.TimeZone, confFiles ...*config.ConfigFile) *Service {
+	return newServiceWithTimeZone(db, masterKey, timeZone, nil, confFiles...)
+}
+
+func NewServiceWithOAuthService(db *store.Store, masterKey string, timeZone config.TimeZone, oauthService *oauthsvc.Service, confFiles ...*config.ConfigFile) *Service {
+	return newServiceWithTimeZone(db, masterKey, timeZone, oauthService, confFiles...)
+}
+
+func newServiceWithTimeZone(db *store.Store, masterKey string, timeZone config.TimeZone, oauthService *oauthsvc.Service, confFiles ...*config.ConfigFile) *Service {
 	var confFile *config.ConfigFile
 	if len(confFiles) > 0 {
 		confFile = confFiles[0]
 	}
 	if timeZone.Location == nil {
 		timeZone = config.ResolveTimeZone()
+	}
+	if oauthService == nil {
+		oauthService = oauthsvc.NewService(db, masterKey, confFile)
 	}
 	httpClients := httpclient.NewManager(confFile)
 	modelCapsClient, _ := httpClients.Client(httpclient.DefaultProfile())
@@ -129,7 +140,7 @@ func NewServiceWithTimeZone(db *store.Store, masterKey string, timeZone config.T
 		credentials: credential.NewService(masterKey),
 		adapters:    adapter.NewRegistry(),
 		modelCaps:   modelcapabilities.NewWithConfig(modelcapabilities.Config{HTTPClient: modelCapsClient}),
-		oauth:       oauthsvc.NewService(db, masterKey, confFile),
+		oauth:       oauthService,
 		httpClients: httpClients,
 		confFile:    confFile,
 		timeZone:    timeZone,

--- a/server/internal/store/oauth_connection_repository.go
+++ b/server/internal/store/oauth_connection_repository.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type OAuthConnection struct {
@@ -29,6 +30,8 @@ type OAuthConnection struct {
 	Scopes                string
 	ExpiresAt             sql.NullTime
 	LastRefreshAt         sql.NullTime
+	RefreshLeaseID        string
+	RefreshLeaseUntil     sql.NullTime
 	LastSyncAt            sql.NullTime
 	RawProfile            JSON `gorm:"type:jsonb"`
 	Metadata              JSON `gorm:"type:jsonb"`
@@ -58,11 +61,16 @@ type UpsertOAuthConnectionParams struct {
 }
 
 type OAuthConnectionRepository struct {
-	db *gorm.DB
+	db             *gorm.DB
+	refreshLeaseID string
 }
 
 func NewOAuthConnectionRepository(db *gorm.DB) OAuthConnectionRepository {
 	return OAuthConnectionRepository{db: db}
+}
+
+func NewOAuthConnectionRepositoryWithRefreshLease(db *gorm.DB, leaseID string) OAuthConnectionRepository {
+	return OAuthConnectionRepository{db: db, refreshLeaseID: leaseID}
 }
 
 func (r OAuthConnectionRepository) UpsertByProviderEmail(ctx context.Context, params UpsertOAuthConnectionParams) (OAuthConnection, error) {
@@ -109,6 +117,14 @@ func (r OAuthConnectionRepository) UpsertByProviderEmail(ctx context.Context, pa
 	}
 	if err := db.Save(&connection).Error; err != nil {
 		return OAuthConnection{}, fmt.Errorf("upsert oauth connection: %w", err)
+	}
+	return connection, nil
+}
+
+func (r OAuthConnectionRepository) GetByIDForUpdate(ctx context.Context, id uuid.UUID) (OAuthConnection, error) {
+	var connection OAuthConnection
+	if err := r.db.WithContext(ctx).Clauses(clause.Locking{Strength: "UPDATE"}).Where(&OAuthConnection{ID: id}).First(&connection).Error; err != nil {
+		return OAuthConnection{}, fmt.Errorf("get oauth connection for update: %w", err)
 	}
 	return connection, nil
 }
@@ -174,8 +190,16 @@ func (r OAuthConnectionRepository) DeleteBySiteID(ctx context.Context, siteID uu
 }
 
 func (r OAuthConnectionRepository) Save(ctx context.Context, connection OAuthConnection) (OAuthConnection, error) {
-	if err := r.db.WithContext(ctx).Save(&connection).Error; err != nil {
-		return OAuthConnection{}, fmt.Errorf("save oauth connection: %w", err)
+	db := r.db.WithContext(ctx)
+	if r.refreshLeaseID != "" {
+		db = db.Where(&OAuthConnection{ID: connection.ID, RefreshLeaseID: r.refreshLeaseID})
+	}
+	result := db.Save(&connection)
+	if result.Error != nil {
+		return OAuthConnection{}, fmt.Errorf("save oauth connection: %w", result.Error)
+	}
+	if r.refreshLeaseID != "" && result.RowsAffected != 1 {
+		return OAuthConnection{}, fmt.Errorf("save oauth connection: refresh lease was lost")
 	}
 	return connection, nil
 }


### PR DESCRIPTION
## 背景

OAuth 刷新在同一个 xLyra 实例内存在多个 OAuth Service 实例时，可能出现并发刷新。原 PR #42 使用数据库 advisory lock 覆盖整个上游 OAuth HTTP 请求，会长期占用数据库连接；上游请求变慢或卡住时，可能造成连接池耗尽并让无关请求停滞，因此该方向不再采用。

## 方案

本 PR 将刷新协调拆分为两个阶段：

1. 在短事务内通过数据库行租约选出刷新 owner，并立即释放数据库连接。
2. 在事务外执行上游 OAuth 请求，避免数据库连接被网络请求占用。
3. 刷新成功或失败后，使用租约条件写回结果；租约失效时不覆盖其他刷新者已经写入的状态。
4. 失败状态会被同一 OAuth 实例内的并发请求复用，避免重复请求上游；租约超时后仍可恢复，不会永久阻塞。

同时补充了刷新单飞、失败复用、租约边界以及相关站点元数据路径的测试覆盖，未修改项目原有 Dockerfile。

## 与 PR #53 的关系

PR #53 已经合并，但当时的目标分支是中间分支 `codex/goose-sequential-migrations`，不是 `main`。本 PR 从当前 `main` 重新承接同一组 OAuth 改动，使其能够进入主分支及后续 1.6.0 发布流程。

## 验证

- `cd server && go test ./...`
- `cd server && govulncheck ./...`
- `git diff --check`
