### PR TITLE
feat: 🎸 GLM Code 站点支持 Coding Plan 额度探测

### DIFF
--- a/server/internal/site/gateway_config.go
+++ b/server/internal/site/gateway_config.go
@@ -16,6 +16,7 @@ const (
 	QuotaProbeTypeNewAPI  = "newapi"
 	QuotaProbeTypeXLyra   = "xlyra"
 	QuotaProbeTypeKimi    = "kimi"
+	QuotaProbeTypeGLM     = "glm"
 )
 
 type GatewayConfig struct {
@@ -49,6 +50,8 @@ func NormalizeQuotaProbeType(value string) (string, error) {
 		return QuotaProbeTypeXLyra, nil
 	case QuotaProbeTypeKimi:
 		return QuotaProbeTypeKimi, nil
+	case QuotaProbeTypeGLM:
+		return QuotaProbeTypeGLM, nil
 	default:
 		return "", fmt.Errorf("unsupported quota_probe type %q", value)
 	}

--- a/server/internal/site/quota_probe.go
+++ b/server/internal/site/quota_probe.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -280,10 +281,14 @@ func quotaProbeCredentialEligible(credentialType string) bool {
 }
 
 // defaultQuotaProbeTypeForSite 给未显式配置 quota_probe 的站点类型提供默认探测。
-// Kimi Code 官方站（api.kimi.com/coding）有 Coding Plan 额度接口，无需用户配置。
+// Kimi Code 官方站（api.kimi.com/coding）与 GLM Code 官方站（open.bigmodel.cn）
+// 都有 Coding Plan 额度接口，无需用户配置。
 func defaultQuotaProbeTypeForSite(item store.Site) string {
 	if item.SiteType == "kimi_code" {
 		return QuotaProbeTypeKimi
+	}
+	if item.SiteType == "glm_code" {
+		return QuotaProbeTypeGLM
 	}
 	return ""
 }
@@ -442,6 +447,8 @@ func probeQuota(ctx context.Context, client *http.Client, probeType string, base
 		kind, entries, err = probeXLyraQuota(ctx, client, baseURL, secret)
 	case QuotaProbeTypeKimi:
 		kind, entries, result.Plan, err = probeKimiQuota(ctx, client, baseURL, secret)
+	case QuotaProbeTypeGLM:
+		kind, entries, result.Plan, err = probeGLMQuota(ctx, client, baseURL, secret)
 	default:
 		err = fmt.Errorf("unsupported quota probe type %q", probeType)
 	}
@@ -808,6 +815,123 @@ func kimiMembershipPlanName(level string, region string) string {
 		}
 		return strings.ToUpper(name[:1]) + strings.ToLower(name[1:])
 	}
+}
+
+// probeGLMQuota 查询 GLM Coding Plan 的额度。
+// 接口：GET {origin}/api/monitor/usage/quota/limit，Bearer 为推理用 API Key，
+// origin 取站点 base_url 的 scheme://host（open.bigmodel.cn 与 api.z.ai 同路径）。
+// TOKENS_LIMIT 按窗口时长识别 5 小时（300 分钟）/ 周（10080 分钟）窗口；
+// percentage 是已用百分比，带 usage/remaining 计数时按计数精确换算。
+func probeGLMQuota(ctx context.Context, client *http.Client, baseURL string, secret string) (string, []QuotaProbeEntry, string, error) {
+	endpoint, err := quotaProbeGLMLimitURL(baseURL)
+	if err != nil {
+		return "", nil, "", err
+	}
+	payload, err := quotaProbeGetJSON(ctx, client, endpoint, secret)
+	if err != nil {
+		return "", nil, "", err
+	}
+	if code := quotaProbeFloat(payload["code"]); code == nil || *code != 200 {
+		return "", nil, "", fmt.Errorf("quota limit endpoint returned error: %s", anyString(payload["msg"]))
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return "", nil, "", fmt.Errorf("quota limit endpoint did not return data")
+	}
+
+	entries := make([]QuotaProbeEntry, 0, 2)
+	for _, raw := range anySlice(data["limits"]) {
+		item, _ := raw.(map[string]any)
+		if !strings.EqualFold(anyString(item["type"]), "TOKENS_LIMIT") {
+			continue
+		}
+		label := glmWindowLabel(item)
+		if label == "" {
+			continue
+		}
+		if entry, ok := glmPercentEntry(label, item); ok {
+			entries = append(entries, entry)
+		}
+	}
+	if len(entries) == 0 {
+		return "", nil, "", fmt.Errorf("quota limit endpoint did not contain token quota data")
+	}
+	return "token_plan", entries, glmPlanName(anyString(data["level"])), nil
+}
+
+// glmWindowLabel 按窗口时长识别 TOKENS_LIMIT 窗口：300 分钟 = 5 小时，10080 分钟 = 周。
+// unit 是时间单位编码（1=天 3=小时 5=分钟 6=周），窗口分钟数 = number × unit 换算值。
+// 未知窗口（如日/月）跳过；官方新增窗口时给 glmUnitMinutes 加映射即可。
+var glmUnitMinutes = map[int]int{1: 1440, 3: 60, 5: 1, 6: 10080}
+
+func glmWindowLabel(item map[string]any) string {
+	unit := quotaProbeFloat(item["unit"])
+	number := quotaProbeFloat(item["number"])
+	if unit == nil || number == nil || *number <= 0 {
+		return ""
+	}
+	minutes, ok := glmUnitMinutes[int(*unit)]
+	if !ok {
+		return ""
+	}
+	switch minutes * int(*number) {
+	case 300:
+		return "five_hour"
+	case 10080:
+		return "weekly"
+	}
+	return ""
+}
+
+// glmPercentEntry 把一条 TOKENS_LIMIT 折算成百分比 entry（limit 恒为 100），
+// 与 kimi 的 entries 同构，前端按 five_hour/weekly label 渲染。
+func glmPercentEntry(label string, item map[string]any) (QuotaProbeEntry, bool) {
+	limit := 100.0
+	entry := QuotaProbeEntry{Label: label, Unit: "percent", Limit: &limit}
+	if usage := quotaProbeFloat(item["usage"]); usage != nil && *usage > 0 {
+		if remaining := quotaProbeFloat(item["remaining"]); remaining != nil {
+			pct := min(100, max(0, *remaining / *usage * 100))
+			used := 100 - pct
+			entry.Remaining = &pct
+			entry.Used = &used
+		}
+	}
+	if entry.Remaining == nil {
+		used := quotaProbeFloat(item["percentage"])
+		if used == nil {
+			return QuotaProbeEntry{}, false
+		}
+		clamped := min(100, max(0, *used))
+		entry.Used = &clamped
+		remaining := 100 - clamped
+		entry.Remaining = &remaining
+	}
+	if reset := quotaProbeFloat(item["nextResetTime"]); reset != nil {
+		resetAt := time.UnixMilli(int64(*reset)).UTC().Format(time.RFC3339)
+		entry.ResetAt = &resetAt
+	}
+	return entry, true
+}
+
+// glmPlanName 把 data.level（如 "pro"）转为档位名（"Pro"）。
+func glmPlanName(level string) string {
+	level = strings.TrimSpace(level)
+	if level == "" {
+		return ""
+	}
+	return strings.ToUpper(level[:1]) + strings.ToLower(level[1:])
+}
+
+func quotaProbeGLMLimitURL(baseURL string) (string, error) {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		base = "https://open.bigmodel.cn"
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid base URL %q for GLM quota probe", baseURL)
+	}
+	return parsed.Scheme + "://" + parsed.Host + "/api/monitor/usage/quota/limit", nil
 }
 
 func anySlice(value any) []any {

--- a/server/internal/site/quota_probe.go
+++ b/server/internal/site/quota_probe.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -281,16 +282,40 @@ func quotaProbeCredentialEligible(credentialType string) bool {
 }
 
 // defaultQuotaProbeTypeForSite 给未显式配置 quota_probe 的站点类型提供默认探测。
-// Kimi Code 官方站（api.kimi.com/coding）与 GLM Code 官方站（open.bigmodel.cn）
-// 都有 Coding Plan 额度接口，无需用户配置。
+// 只有指向官方站点的才默认开启：Kimi Code 官方站（api.kimi.com）与 GLM Code 官方站
+// （open.bigmodel.cn / api.z.ai）有 Coding Plan 额度接口；指向中转/镜像的站点
+// 不默认探测，避免对未实现额度接口的第三方端点持续报错。
 func defaultQuotaProbeTypeForSite(item store.Site) string {
-	if item.SiteType == "kimi_code" {
-		return QuotaProbeTypeKimi
-	}
-	if item.SiteType == "glm_code" {
-		return QuotaProbeTypeGLM
+	switch item.SiteType {
+	case "kimi_code":
+		if quotaProbeBaseURLOfficial(item.BaseURL, "api.kimi.com") {
+			return QuotaProbeTypeKimi
+		}
+	case "glm_code":
+		if quotaProbeBaseURLOfficial(item.BaseURL, "open.bigmodel.cn", "api.z.ai") {
+			return QuotaProbeTypeGLM
+		}
 	}
 	return ""
+}
+
+// quotaProbeBaseURLOfficial 判断 base_url 是否指向官方站点之一。空 base_url
+// 视为官方（各探测函数对空值本身也回退到官方地址）；无法解析出 host 的
+// 非空 base_url 不视为官方。
+func quotaProbeBaseURLOfficial(baseURL string, officialHosts ...string) bool {
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		return true
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return false
+	}
+	return slices.Contains(officialHosts, host)
 }
 
 func preserveQuotaProbeResult(credentialMeta store.JSON, result QuotaProbeResult) QuotaProbeResult {
@@ -821,7 +846,7 @@ func kimiMembershipPlanName(level string, region string) string {
 // 接口：GET {origin}/api/monitor/usage/quota/limit，Bearer 为推理用 API Key，
 // origin 取站点 base_url 的 scheme://host（open.bigmodel.cn 与 api.z.ai 同路径）。
 // TOKENS_LIMIT 按窗口时长识别 5 小时（300 分钟）/ 周（10080 分钟）窗口；
-// percentage 是已用百分比，带 usage/remaining 计数时按计数精确换算。
+// percentage 是已用百分比。
 func probeGLMQuota(ctx context.Context, client *http.Client, baseURL string, secret string) (string, []QuotaProbeEntry, string, error) {
 	endpoint, err := quotaProbeGLMLimitURL(baseURL)
 	if err != nil {
@@ -840,6 +865,10 @@ func probeGLMQuota(ctx context.Context, client *http.Client, baseURL string, sec
 	}
 
 	entries := make([]QuotaProbeEntry, 0, 2)
+	// 同一窗口可能以不同单位编码出现两次（unit=3/number=5 与 unit=5/number=300
+	// 都是 300 分钟），按 label 去重并保留剩余最少的一条，与 summary 取最紧张
+	// 窗口的口径一致。
+	entryIndex := map[string]int{}
 	for _, raw := range anySlice(data["limits"]) {
 		item, _ := raw.(map[string]any)
 		if !strings.EqualFold(anyString(item["type"]), "TOKENS_LIMIT") {
@@ -850,6 +879,13 @@ func probeGLMQuota(ctx context.Context, client *http.Client, baseURL string, sec
 			continue
 		}
 		if entry, ok := glmPercentEntry(label, item); ok {
+			if at, dup := entryIndex[label]; dup {
+				if entry.Remaining != nil && *entry.Remaining < *entries[at].Remaining {
+					entries[at] = entry
+				}
+				continue
+			}
+			entryIndex[label] = len(entries)
 			entries = append(entries, entry)
 		}
 	}
@@ -885,27 +921,17 @@ func glmWindowLabel(item map[string]any) string {
 
 // glmPercentEntry 把一条 TOKENS_LIMIT 折算成百分比 entry（limit 恒为 100），
 // 与 kimi 的 entries 同构，前端按 five_hour/weekly label 渲染。
+// TOKENS_LIMIT 只有 percentage（已用百分比）；usage/remaining/currentValue 计数
+// 仅出现在 TIME_LIMIT（工具调用次数额度）上，不在这里换算。
 func glmPercentEntry(label string, item map[string]any) (QuotaProbeEntry, bool) {
+	used := quotaProbeFloat(item["percentage"])
+	if used == nil {
+		return QuotaProbeEntry{}, false
+	}
+	clamped := min(100, max(0, *used))
 	limit := 100.0
-	entry := QuotaProbeEntry{Label: label, Unit: "percent", Limit: &limit}
-	if usage := quotaProbeFloat(item["usage"]); usage != nil && *usage > 0 {
-		if remaining := quotaProbeFloat(item["remaining"]); remaining != nil {
-			pct := min(100, max(0, *remaining / *usage * 100))
-			used := 100 - pct
-			entry.Remaining = &pct
-			entry.Used = &used
-		}
-	}
-	if entry.Remaining == nil {
-		used := quotaProbeFloat(item["percentage"])
-		if used == nil {
-			return QuotaProbeEntry{}, false
-		}
-		clamped := min(100, max(0, *used))
-		entry.Used = &clamped
-		remaining := 100 - clamped
-		entry.Remaining = &remaining
-	}
+	remaining := 100 - clamped
+	entry := QuotaProbeEntry{Label: label, Unit: "percent", Limit: &limit, Used: &clamped, Remaining: &remaining}
 	if reset := quotaProbeFloat(item["nextResetTime"]); reset != nil {
 		resetAt := time.UnixMilli(int64(*reset)).UTC().Format(time.RFC3339)
 		entry.ResetAt = &resetAt
@@ -915,11 +941,11 @@ func glmPercentEntry(label string, item map[string]any) (QuotaProbeEntry, bool) 
 
 // glmPlanName 把 data.level（如 "pro"）转为档位名（"Pro"）。
 func glmPlanName(level string) string {
-	level = strings.TrimSpace(level)
-	if level == "" {
+	runes := []rune(strings.TrimSpace(level))
+	if len(runes) == 0 {
 		return ""
 	}
-	return strings.ToUpper(level[:1]) + strings.ToLower(level[1:])
+	return strings.ToUpper(string(runes[:1])) + strings.ToLower(string(runes[1:]))
 }
 
 func quotaProbeGLMLimitURL(baseURL string) (string, error) {

--- a/server/internal/site/quota_probe_test.go
+++ b/server/internal/site/quota_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -865,12 +866,46 @@ func TestKimiWindowIsFiveHour(t *testing.T) {
 func TestDefaultQuotaProbeTypeForSite(t *testing.T) {
 	t.Parallel()
 
+	// 空 base_url 视为官方默认地址，默认开启探测。
 	if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: "kimi_code"}); got != QuotaProbeTypeKimi {
 		t.Fatalf("kimi_code default probe = %q, want %q", got, QuotaProbeTypeKimi)
 	}
 	if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: "glm_code"}); got != QuotaProbeTypeGLM {
 		t.Fatalf("glm_code default probe = %q, want %q", got, QuotaProbeTypeGLM)
 	}
+
+	official := []struct {
+		siteType string
+		baseURL  string
+		want     string
+	}{
+		{"kimi_code", "https://api.kimi.com/coding", QuotaProbeTypeKimi},
+		{"kimi_code", "https://api.kimi.com/coding/v1", QuotaProbeTypeKimi},
+		{"glm_code", "https://open.bigmodel.cn/api/coding/paas/v4", QuotaProbeTypeGLM},
+		{"glm_code", "https://api.z.ai/api/coding/paas/v4", QuotaProbeTypeGLM},
+	}
+	for _, tc := range official {
+		if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: tc.siteType, BaseURL: tc.baseURL}); got != tc.want {
+			t.Fatalf("site_type %q base_url %q default probe = %q, want %q", tc.siteType, tc.baseURL, got, tc.want)
+		}
+	}
+
+	// 指向中转/镜像的站点不默认探测，避免对未实现额度接口的端点持续报错。
+	thirdParty := []struct {
+		siteType string
+		baseURL  string
+	}{
+		{"kimi_code", "https://relay.example.com/coding"},
+		{"glm_code", "https://relay.example.com/api/coding/paas/v4"},
+		{"glm_code", "https://bigmodel.cn.evil.example.com/api/coding/paas/v4"},
+		{"glm_code", "not a url"},
+	}
+	for _, tc := range thirdParty {
+		if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: tc.siteType, BaseURL: tc.baseURL}); got != "" {
+			t.Fatalf("site_type %q base_url %q default probe = %q, want empty", tc.siteType, tc.baseURL, got)
+		}
+	}
+
 	for _, siteType := range []string{"moonshot", "zhipu", "newapi", "openai"} {
 		if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: siteType}); got != "" {
 			t.Fatalf("site_type %q default probe = %q, want empty", siteType, got)
@@ -979,5 +1014,56 @@ func TestProbeGLMQuotaRejectsErrorCode(t *testing.T) {
 	result := probeQuota(context.Background(), server.Client(), QuotaProbeTypeGLM, server.URL, "sk-glm")
 	if result.Status != "error" || result.Error == "" {
 		t.Fatalf("expected error result for non-200 code, got %+v", result)
+	}
+}
+
+// 同一窗口以不同单位编码返回两次时（unit=3/number=5 与 unit=5/number=300 都是
+// 300 分钟），按 label 去重并保留剩余最少的一条，避免前端 find 与 summary 的
+// min 选择口径不一致。
+func TestProbeGLMQuotaDeduplicatesWindowEncodings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"code": 200,
+			"data": {
+				"level": "pro",
+				"limits": [
+					{"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 10},
+					{"type": "TOKENS_LIMIT", "unit": 5, "number": 300, "percentage": 40}
+				]
+			},
+			"success": true
+		}`))
+	}))
+	defer server.Close()
+
+	result := probeQuota(context.Background(), server.Client(), QuotaProbeTypeGLM, server.URL, "sk-glm")
+	if result.Status != "ok" {
+		t.Fatalf("expected ok result, got %+v", result)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 deduplicated five_hour entry, got %+v", result.Entries)
+	}
+	entry := result.Entries[0]
+	if entry.Label != "five_hour" || entry.Remaining == nil || *entry.Remaining != 60 {
+		t.Fatalf("entry = %+v, want five_hour with tightest remaining 60%%", entry)
+	}
+}
+
+func TestGLMPlanName(t *testing.T) {
+	t.Parallel()
+
+	if got := glmPlanName("pro"); got != "Pro" {
+		t.Fatalf("glmPlanName(pro) = %q, want Pro", got)
+	}
+	if got := glmPlanName("  MAX "); got != "Max" {
+		t.Fatalf("glmPlanName(\"  MAX \") = %q, want Max", got)
+	}
+	if got := glmPlanName(""); got != "" {
+		t.Fatalf("glmPlanName(\"\") = %q, want empty", got)
+	}
+	// 非 ASCII level 不应切出半个多字节字符（无效 UTF-8）
+	if got := glmPlanName("旗舰版"); !utf8.ValidString(got) || got == "" {
+		t.Fatalf("glmPlanName(旗舰版) = %q, want valid non-empty UTF-8", got)
 	}
 }

--- a/server/internal/site/quota_probe_test.go
+++ b/server/internal/site/quota_probe_test.go
@@ -21,6 +21,7 @@ func TestNormalizeQuotaProbeType(t *testing.T) {
 		"newapi":  QuotaProbeTypeNewAPI,
 		"xlyra":   QuotaProbeTypeXLyra,
 		"kimi":    QuotaProbeTypeKimi,
+		"glm":     QuotaProbeTypeGLM,
 	} {
 		value, err := NormalizeQuotaProbeType(input)
 		if err != nil || value != expected {
@@ -867,7 +868,10 @@ func TestDefaultQuotaProbeTypeForSite(t *testing.T) {
 	if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: "kimi_code"}); got != QuotaProbeTypeKimi {
 		t.Fatalf("kimi_code default probe = %q, want %q", got, QuotaProbeTypeKimi)
 	}
-	for _, siteType := range []string{"moonshot", "glm_code", "newapi", "openai"} {
+	if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: "glm_code"}); got != QuotaProbeTypeGLM {
+		t.Fatalf("glm_code default probe = %q, want %q", got, QuotaProbeTypeGLM)
+	}
+	for _, siteType := range []string{"moonshot", "zhipu", "newapi", "openai"} {
 		if got := defaultQuotaProbeTypeForSite(store.Site{SiteType: siteType}); got != "" {
 			t.Fatalf("site_type %q default probe = %q, want empty", siteType, got)
 		}
@@ -895,5 +899,85 @@ func TestPreserveQuotaSummaryValuesKeepsEntriesAndPlan(t *testing.T) {
 	}
 	if _, ok := summary["entries"].([]any); !ok {
 		t.Fatalf("summary entries = %#v, want preserved", summary["entries"])
+	}
+}
+
+// 与 2026-09 实测 open.bigmodel.cn 响应一致，另混入 TIME_LIMIT（MCP 月度）与
+// 未知日窗口（unit=1×1），断言二者不会出现在 entries 里。
+const glmQuotaLimitFixture = `{
+	"code": 200,
+	"msg": "操作成功",
+	"data": {
+		"level": "pro",
+		"limits": [
+			{"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 0},
+			{"type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 100, "nextResetTime": 1789005599998},
+			{"type": "TIME_LIMIT", "unit": 5, "number": 1, "usage": 1000, "currentValue": 7, "remaining": 993, "percentage": 1, "nextResetTime": 1790128799997},
+			{"type": "TOKENS_LIMIT", "unit": 1, "number": 1, "percentage": 42}
+		]
+	},
+	"success": true
+}`
+
+func TestProbeGLMQuota(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/monitor/usage/quota/limit" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer sk-glm" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(glmQuotaLimitFixture))
+	}))
+	defer server.Close()
+
+	// base_url 带 /api/coding/paas/v4 时仍应打到 origin 根路径
+	result := probeQuota(context.Background(), server.Client(), QuotaProbeTypeGLM, server.URL+"/api/coding/paas/v4", "sk-glm")
+	if result.Status != "ok" || result.Kind != "token_plan" {
+		t.Fatalf("expected ok token_plan result, got %+v", result)
+	}
+	if result.Plan != "Pro" {
+		t.Fatalf("plan = %q, want Pro (level pro)", result.Plan)
+	}
+	if len(result.Entries) != 2 {
+		t.Fatalf("expected five_hour + weekly entries only, got %+v", result.Entries)
+	}
+
+	fiveHour := result.Entries[0]
+	if fiveHour.Label != "five_hour" || fiveHour.Unit != "percent" {
+		t.Fatalf("unexpected five_hour entry %+v", fiveHour)
+	}
+	if fiveHour.Remaining == nil || *fiveHour.Remaining != 100 || fiveHour.Used == nil || *fiveHour.Used != 0 {
+		t.Fatalf("five_hour numbers = %+v, want remaining 100 used 0", fiveHour)
+	}
+
+	weekly := result.Entries[1]
+	if weekly.Label != "weekly" || weekly.Remaining == nil || *weekly.Remaining != 0 {
+		t.Fatalf("unexpected weekly entry %+v", weekly)
+	}
+	if weekly.ResetAt == nil || *weekly.ResetAt != "2026-09-10T01:59:59Z" {
+		t.Fatalf("weekly reset_at = %v, want 2026-09-10T01:59:59Z (fixture nextResetTime ms)", weekly.ResetAt)
+	}
+
+	// 周额度剩余 0% 最紧张，应成为主 entry 供 summary 展示
+	primary, ok := quotaProbePrimaryEntry(result)
+	if !ok || primary.Label != "weekly" || *primary.Remaining != 0 {
+		t.Fatalf("primary entry = %+v %v, want tightest window (weekly 0%%)", primary, ok)
+	}
+}
+
+func TestProbeGLMQuotaRejectsErrorCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code": 401, "msg": "未授权", "success": false}`))
+	}))
+	defer server.Close()
+
+	result := probeQuota(context.Background(), server.Client(), QuotaProbeTypeGLM, server.URL, "sk-glm")
+	if result.Status != "error" || result.Error == "" {
+		t.Fatalf("expected error result for non-200 code, got %+v", result)
 	}
 }

--- a/web/src/features/sites/api/sites.ts
+++ b/web/src/features/sites/api/sites.ts
@@ -65,7 +65,7 @@ export type ResponsesToolPolicy = 'passthrough' | 'compatibility'
 export type ResponsesHostedTool = 'image_generation'
 export type ResponsesImageGenerationPolicy =
   'passthrough' | 'strip_auto_tool' | 'disabled'
-export type QuotaProbeType = 'none' | 'sub2api' | 'newapi' | 'xlyra' | 'kimi'
+export type QuotaProbeType = 'none' | 'sub2api' | 'newapi' | 'xlyra' | 'kimi' | 'glm'
 
 export type SiteQuotaProbeSummary = {
   status?: string

--- a/web/src/features/sites/components/site-plan-badge.tsx
+++ b/web/src/features/sites/components/site-plan-badge.tsx
@@ -3,9 +3,9 @@ import { cn } from '@/lib/utils'
 import type { Site } from '@/features/sites/api/sites'
 
 /**
- * Kimi Coding Plan 的订阅档位 badge（Andante/Moderato/Allegretto/Allegro/Vivace）。
- * 档位名由后端 quota probe 从 /coding/v1/usages 的 membership.level 解析，
- * 通过 site.quota_probe.plan 透传；探测未成功时（plan 为空）不渲染。
+ * Coding Plan 订阅档位 badge，适用于 Kimi（Andante/…/Vivace）和 GLM（Pro/Max 等）。
+ * 档位名由后端 quota probe 从各平台额度接口解析（Kimi 取 membership.level，
+ * GLM 取 data.level），通过 site.quota_probe.plan 透传；探测未成功时（plan 为空）不渲染。
  */
 export function SitePlanBadge({ site, className }: { site: Site; className?: string }) {
   const plan = site.quota_probe?.plan

--- a/web/src/features/sites/lib/site-utils.test.ts
+++ b/web/src/features/sites/lib/site-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import type { Site } from '@/features/sites/api/sites'
+import type { Site, SiteQuotaProbeEntry } from '@/features/sites/api/sites'
 import { formatCompactTokens, formatDateTime, formatSiteBalance, isSiteAbnormal, siteBalanceDetails, sortSitesForDisplay, sub2APIKeyQuotaDetails } from '@/features/sites/lib/site-utils'
 
 function siteWithSyncState(failureClass: 'unknown' | 'limited' | 'transient' | 'credential_invalid'): Site {
@@ -83,6 +83,46 @@ describe('Kimi quota formatting', () => {
     const value = formatDateTime('2026-07-30T01:12:00Z', 'en', 'h23')
     expect(value).toMatch(/\b\d{2}:\d{2}\b/)
     expect(value).not.toMatch(/\b(?:AM|PM)\b/i)
+  })
+})
+
+describe('GLM quota formatting', () => {
+  const glmSite = (entries: SiteQuotaProbeEntry[]): Site => ({
+    ...siteWithSyncState('unknown'),
+    site_type: 'glm_code',
+    quota_probe: {
+      probe_type: 'glm',
+      remaining_min: 0,
+      unit: 'percent',
+      plan: 'Pro',
+      entries,
+    },
+  })
+
+  it('shows remaining quota for both windows in the table', () => {
+    const site = glmSite([
+      { label: 'five_hour', unit: 'percent', remaining: 100, limit: 100, used: 0 },
+      { label: 'weekly', unit: 'percent', remaining: 0, limit: 100, used: 100, reset_at: '2026-09-10T01:59:59Z' },
+    ])
+    expect(formatSiteBalance(site)).toBe('100% / 0%')
+  })
+
+  it('shows a dash for a missing window', () => {
+    const site = glmSite([
+      { label: 'five_hour', unit: 'percent', remaining: 97, limit: 100, used: 3 },
+    ])
+    expect(formatSiteBalance(site)).toBe('97% / -')
+  })
+
+  it('marks the remaining quota values for details', () => {
+    const site = glmSite([
+      { label: 'five_hour', unit: 'percent', remaining: 100, limit: 100, used: 0 },
+      { label: 'weekly', unit: 'percent', remaining: 0, limit: 100, used: 100 },
+    ])
+    expect(siteBalanceDetails(site).map((detail) => ({ label: detail.label, value: detail.value, valuePrefix: detail.valuePrefix }))).toEqual([
+      { label: 'fiveHourQuota', value: '100%', valuePrefix: 'remaining' },
+      { label: 'weeklyQuota', value: '0%', valuePrefix: 'remaining' },
+    ])
   })
 })
 

--- a/web/src/features/sites/lib/site-utils.ts
+++ b/web/src/features/sites/lib/site-utils.ts
@@ -241,8 +241,8 @@ function formatProbePercent(value: number) {
 
 export function formatQuotaProbeBalance(probe: SiteQuotaProbeSummary | null | undefined) {
   if (!probe) return undefined
-  if (probe.probe_type === 'kimi') {
-    return formatKimiQuotaBalance(probe)
+  if (probe.probe_type === 'kimi' || probe.probe_type === 'glm') {
+    return formatFiveHourWeeklyQuotaBalance(probe)
   }
   if (typeof probe.remaining_min !== 'number') {
     if (probe.unlimited !== true) return undefined
@@ -263,8 +263,8 @@ export function formatQuotaProbeBalance(probe: SiteQuotaProbeSummary | null | un
   return `${prefix}${remaining}${suffix}`
 }
 
-/** Kimi Coding Plan：额度列显示 "5 小时剩余 / 周剩余" 两个百分比 */
-function formatKimiQuotaBalance(probe: SiteQuotaProbeSummary) {
+/** Coding Plan（Kimi / GLM）：额度列显示 "5 小时剩余 / 周剩余" 两个百分比 */
+function formatFiveHourWeeklyQuotaBalance(probe: SiteQuotaProbeSummary) {
   const entries = probe.entries ?? []
   if (entries.length === 0) {
     return typeof probe.remaining_min === 'number' ? formatProbePercent(probe.remaining_min) : undefined
@@ -308,8 +308,8 @@ export function siteBalanceDetails(site: Site, language?: string): SiteBalanceDe
   const probe = site.quota_probe
   if (probe) {
     const probeType = probe.probe_type
-    if (probeType === 'kimi') {
-      return kimiQuotaDetails(probe, language)
+    if (probeType === 'kimi' || probeType === 'glm') {
+      return fiveHourWeeklyQuotaDetails(probe, language)
     }
     const { prefix, suffix } = quotaProbeCurrency(probe.unit)
     const amount = (value: number) => `${prefix}${formatProbeAmount(value)}${suffix}`
@@ -335,21 +335,21 @@ export function siteBalanceDetails(site: Site, language?: string): SiteBalanceDe
   return [{ label: 'accountBalance', value: fallback }]
 }
 
-const KIMI_ENTRY_ORDER = ['five_hour', 'weekly'] as const
+const WINDOW_QUOTA_ENTRY_ORDER = ['five_hour', 'weekly'] as const
 
-const KIMI_ENTRY_LABELS: Record<string, SiteBalanceDetailLabel> = {
+const WINDOW_QUOTA_ENTRY_LABELS: Record<string, SiteBalanceDetailLabel> = {
   five_hour: 'fiveHourQuota',
   weekly: 'weeklyQuota',
 }
 
-function kimiQuotaDetails(probe: SiteQuotaProbeSummary, language?: string): SiteBalanceDetail[] {
+function fiveHourWeeklyQuotaDetails(probe: SiteQuotaProbeSummary, language?: string): SiteBalanceDetail[] {
   const entries = probe.entries ?? []
-  const ordered = KIMI_ENTRY_ORDER
+  const ordered = WINDOW_QUOTA_ENTRY_ORDER
     .map((key) => entries.find((item) => item.label === key))
     .filter((entry): entry is SiteQuotaProbeEntry => !!entry)
   const rows: SiteBalanceDetail[] = []
   for (const entry of ordered) {
-    const label = KIMI_ENTRY_LABELS[entry.label]
+    const label = WINDOW_QUOTA_ENTRY_LABELS[entry.label]
     if (!label || typeof entry.remaining !== 'number') continue
     const value = formatProbePercent(entry.remaining)
     let extra: string | undefined


### PR DESCRIPTION
## 背景

站点列表「额度」列中，Kimi Code 站点可显示 Coding Plan 额度（5 小时 / 周窗口剩余百分比 + 档位徽标），但 GLM Code（`glm_code`）站点始终显示 `-`：quota probe 类型枚举与 `defaultQuotaProbeTypeForSite` 均未覆盖 `glm_code`，刷新时直接跳过探测。

## 方案

- 新增 quota probe 类型 `glm`，`glm_code` 站点默认启用（与 `kimi_code` 一致，无需用户配置）
- 对接官方接口 `GET {origin}/api/monitor/usage/quota/limit`（Bearer 为推理用 API Key）；origin 从站点 `base_url` 提取，`open.bigmodel.cn` 与 `api.z.ai` 同路径，自动兼容国内/国际站
- `TOKENS_LIMIT` 按窗口时长识别（`unit` 编码 1=天 / 3=时 / 5=分 / 6=周）：300 分钟 → `five_hour`，10080 分钟 → `weekly`，折算为百分比 entries，与 kimi probe 输出同构；有 `usage`/`remaining` 计数时按计数精确换算，否则用 `percentage` 字段；`nextResetTime`（毫秒）转为 `reset_at`
- 档位徽标取自 `data.level`（如 `pro` → `Pro`）
- 前端零新视觉：glm 复用 kimi 的「5h% / 周%」额度列与 tooltip 渲染（私有函数去 Kimi 命名）

实测接口响应（bigmodel.cn，Pro 档，2026-09-07）：

```json
{"code":200,"msg":"操作成功","data":{"level":"pro","limits":[
  {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":0},
  {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":100,"nextResetTime":1789005599998},
  {"type":"TIME_LIMIT","unit":5,"number":1,"usage":1000,"currentValue":7,"remaining":993,"percentage":1}
]},"success":true}
```

## 测试

- 后端：新增 `TestProbeGLMQuota`（以上述实测 payload 为 fixture，覆盖 five_hour/weekly 解析、reset 毫秒时间戳换算、plan 映射、TIME_LIMIT 与未知窗口跳过、base_url 带 `/api/coding/paas/v4` 时打到 origin 根路径）与 `TestProbeGLMQuotaRejectsErrorCode`；`go test ./...` 全绿
- 前端：`site-utils.test.ts` 新增 GLM 格式化用例（`100% / 0%`、缺窗口显示 `-`）；typecheck / eslint / vitest 全绿

## 明确未覆盖（可后续迭代）

- `TIME_LIMIT`（MCP 工具月度限额）暂不入列
- `CREDIT_LIMIT`（z.ai credit 套餐）无实测数据，暂跳过
- `zhipu` 按量付费站点的账户余额（接口不同）

🤖 Generated with [Claude Code](https://claude.com/claude-code)