### PR TITLE
feat(server,web): ✨ 推理强度档位规范、映射与前端选择器联动

### DIFF
--- a/server/internal/admin/handler_models.go
+++ b/server/internal/admin/handler_models.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 
 	"xlyra/server/internal/catalog"
+	"xlyra/server/internal/gateway"
 	"xlyra/server/internal/store"
 )
 
@@ -296,7 +297,7 @@ func (r canonicalModelRequest) toInput() catalog.UpsertCanonicalModelInput {
 }
 
 func canonicalModelPayload(model store.CanonicalModel) map[string]any {
-	return map[string]any{
+	payload := map[string]any{
 		"id":                     model.ID.String(),
 		"model_key":              model.ModelKey,
 		"display_name":           model.DisplayName,
@@ -316,6 +317,10 @@ func canonicalModelPayload(model store.CanonicalModel) map[string]any {
 		"created_at":             timeString(model.CreatedAt),
 		"updated_at":             timeString(model.UpdatedAt),
 	}
+	if effort := gateway.ReasoningEffortSpecForModel(model.ModelKey); effort != nil {
+		payload["reasoning_effort"] = effort
+	}
+	return payload
 }
 
 func canonicalModelItemPayload(item catalog.CanonicalModelItem) map[string]any {

--- a/server/internal/admin/handler_payload_site_edges_test.go
+++ b/server/internal/admin/handler_payload_site_edges_test.go
@@ -4,11 +4,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 
+	"xlyra/server/internal/gateway"
 	sitepkg "xlyra/server/internal/site"
 	"xlyra/server/internal/store"
 )
@@ -276,5 +278,24 @@ func TestSiteUsagePayloadBuildsScalarUsageShape(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("usage payload = %#v, want %#v", got, want)
+	}
+}
+
+func TestCanonicalModelPayloadExposesReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalModelPayload(store.CanonicalModel{ModelKey: "claude-opus-4-6"})
+	effort, ok := payload["reasoning_effort"].(*gateway.ReasoningEffortInfo)
+	if !ok {
+		t.Fatalf("reasoning_effort missing or wrong type: %#v", payload["reasoning_effort"])
+	}
+	want := []string{"low", "medium", "high", "max"}
+	if !slices.Equal(effort.Levels, want) {
+		t.Fatalf("levels = %v, want %v", effort.Levels, want)
+	}
+
+	unknown := canonicalModelPayload(store.CanonicalModel{ModelKey: "some-unheard-of-model"})
+	if _, present := unknown["reasoning_effort"]; present {
+		t.Fatalf("unknown model must not carry reasoning_effort: %#v", unknown["reasoning_effort"])
 	}
 }

--- a/server/internal/gateway/models_cache.go
+++ b/server/internal/gateway/models_cache.go
@@ -498,16 +498,20 @@ func applyModelEndpointTypes(item map[string]any, endpointSet map[string]struct{
 }
 
 func canonicalModelPayload(model store.CanonicalModel) map[string]any {
+	metadata := map[string]any{
+		"canonical_model_id": model.ID.String(),
+		"display_name":       defaultString(model.DisplayName, model.ModelKey),
+		"category":           defaultString(model.Category, "chat"),
+	}
+	if effort := ReasoningEffortSpecForModel(model.ModelKey); effort != nil {
+		metadata["reasoning_effort"] = effort
+	}
 	return map[string]any{
 		"id":       model.ModelKey,
 		"object":   "model",
 		"created":  model.CreatedAt.Unix(),
 		"owned_by": defaultString(model.Provider, "xlyra"),
-		"metadata": map[string]any{
-			"canonical_model_id": model.ID.String(),
-			"display_name":       defaultString(model.DisplayName, model.ModelKey),
-			"category":           defaultString(model.Category, "chat"),
-		},
+		"metadata": metadata,
 	}
 }
 

--- a/server/internal/gateway/protocol_spec_registry.go
+++ b/server/internal/gateway/protocol_spec_registry.go
@@ -20,13 +20,14 @@ type protocolSpecRegistryConfig struct {
 }
 
 type protocolSpecDefinition struct {
-	BaseProtocol  string                  `json:"base_protocol,omitempty"`
-	Events        map[string]eventMapping `json:"events,omitempty"`
-	ParamMappings []paramMappingConfig    `json:"param_mappings,omitempty"`
-	RequestParams requestParamPolicy      `json:"request_params,omitempty"`
-	Capabilities  map[string]bool         `json:"capabilities,omitempty"`
-	Reasoning     map[string]string       `json:"reasoning,omitempty"`
-	Documentation []string                `json:"documentation,omitempty"`
+	BaseProtocol    string                  `json:"base_protocol,omitempty"`
+	Events          map[string]eventMapping `json:"events,omitempty"`
+	ParamMappings   []paramMappingConfig    `json:"param_mappings,omitempty"`
+	RequestParams   requestParamPolicy      `json:"request_params,omitempty"`
+	Capabilities    map[string]bool         `json:"capabilities,omitempty"`
+	Reasoning       map[string]string       `json:"reasoning,omitempty"`
+	ReasoningEffort *reasoningEffortSpec    `json:"reasoning_effort,omitempty"`
+	Documentation   []string                `json:"documentation,omitempty"`
 }
 
 type providerSpecDefinition struct {
@@ -40,6 +41,7 @@ type providerSpecDefinition struct {
 	ProtocolRequestParams map[string]requestParamPolicy          `json:"protocol_request_params,omitempty"`
 	Capabilities          map[string]bool                        `json:"capabilities,omitempty"`
 	Reasoning             map[string]string                      `json:"reasoning,omitempty"`
+	ReasoningEffort       *reasoningEffortSpec                   `json:"reasoning_effort,omitempty"`
 	Documentation         []string                               `json:"documentation,omitempty"`
 }
 
@@ -53,7 +55,31 @@ type modelSpecDefinition struct {
 	RequestParams      requestParamPolicy                     `json:"request_params,omitempty"`
 	Capabilities       map[string]bool                        `json:"capabilities,omitempty"`
 	Reasoning          map[string]string                      `json:"reasoning,omitempty"`
+	ReasoningEffort    *reasoningEffortSpec                   `json:"reasoning_effort,omitempty"`
 	Documentation      []string                               `json:"documentation,omitempty"`
+}
+
+// reasoningEffortSpec declares which reasoning effort levels an upstream model
+// accepts and how the gateway should reconcile client-requested levels with
+// that set. Levels use the canonical ladder
+// (none < minimal < low < medium < high < xhigh < max < ultra).
+//
+// Mode "snap" (the default when the block is present) rewrites a requested
+// level to the nearest supported one; mode "passthrough" forwards the value
+// untouched for upstreams that accept the full ladder and snap server-side
+// (e.g. DeepSeek). ThinkingMandatory marks models whose thinking cannot be
+// disabled, so "none"/thinking-off requests are clamped to the lowest level
+// instead of being rejected by the upstream.
+//
+// Default is the level the gateway-level value "auto" resolves to for
+// ThinkingMandatory models (others drop "auto" so the upstream default
+// applies), and it is exposed to clients so their effort pickers can surface
+// the model's own default.
+type reasoningEffortSpec struct {
+	Levels            []string `json:"levels,omitempty"`
+	Mode              string   `json:"mode,omitempty"`
+	ThinkingMandatory bool     `json:"thinking_mandatory,omitempty"`
+	Default           string   `json:"default,omitempty"`
 }
 
 type eventMapping struct {
@@ -112,6 +138,7 @@ type resolvedProtocolSpec struct {
 	RequestParams      requestParamPolicy
 	Capabilities       map[string]bool
 	Reasoning          map[string]string
+	ReasoningEffort    *reasoningEffortSpec
 	Documentation      []string
 }
 
@@ -245,7 +272,9 @@ func applyResolvedRequestPolicy(payload map[string]any, spec resolvedProtocolSpe
 }
 
 func applyRequestPolicyForCandidate(payload map[string]any, protocol canonicalProtocol, candidate routeengine.Candidate) map[string]any {
-	return applyResolvedRequestPolicy(payload, effectiveProtocolSpec(protocol, candidate))
+	spec := effectiveProtocolSpec(protocol, candidate)
+	payload = applyResolvedRequestPolicy(payload, spec)
+	return applyReasoningEffortPolicy(payload, spec)
 }
 
 func validatePayloadParams(payload map[string]any, protocolName string, candidate routeengine.Candidate) error {
@@ -399,6 +428,9 @@ func mergeProtocolDefinition(resolved *resolvedProtocolSpec, config protocolSpec
 	mergeRequestParamPolicy(&resolved.RequestParams, def.RequestParams)
 	mergeBoolMap(resolved.Capabilities, def.Capabilities)
 	mergeStringMap(resolved.Reasoning, def.Reasoning)
+	if def.ReasoningEffort != nil {
+		resolved.ReasoningEffort = def.ReasoningEffort
+	}
 	resolved.Documentation = appendUniqueStrings(resolved.Documentation, def.Documentation...)
 }
 
@@ -414,6 +446,9 @@ func mergeProviderDefinition(resolved *resolvedProtocolSpec, def providerSpecDef
 	}
 	mergeBoolMap(resolved.Capabilities, def.Capabilities)
 	mergeStringMap(resolved.Reasoning, def.Reasoning)
+	if def.ReasoningEffort != nil {
+		resolved.ReasoningEffort = def.ReasoningEffort
+	}
 	resolved.Documentation = appendUniqueStrings(resolved.Documentation, def.Documentation...)
 }
 
@@ -426,6 +461,9 @@ func mergeModelDefinition(resolved *resolvedProtocolSpec, def modelSpecDefinitio
 	mergeRequestParamPolicy(&resolved.RequestParams, def.RequestParams)
 	mergeBoolMap(resolved.Capabilities, def.Capabilities)
 	mergeStringMap(resolved.Reasoning, def.Reasoning)
+	if def.ReasoningEffort != nil {
+		resolved.ReasoningEffort = def.ReasoningEffort
+	}
 	resolved.Documentation = appendUniqueStrings(resolved.Documentation, def.Documentation...)
 }
 
@@ -673,10 +711,16 @@ func validateProtocolSpecRegistry(config protocolSpecRegistryConfig) error {
 		if conflicts := validateRequestParamPolicyConflicts(def.RequestParams); len(conflicts) > 0 {
 			errs = append(errs, fmt.Sprintf("protocol %q: %s", name, strings.Join(conflicts, "; ")))
 		}
+		if err := validateReasoningEffortSpec(def.ReasoningEffort); err != nil {
+			errs = append(errs, fmt.Sprintf("protocol %q: %s", name, err))
+		}
 	}
 	for name, def := range config.Providers {
 		if conflicts := validateRequestParamPolicyConflicts(def.RequestParams); len(conflicts) > 0 {
 			errs = append(errs, fmt.Sprintf("provider %q: %s", name, strings.Join(conflicts, "; ")))
+		}
+		if err := validateReasoningEffortSpec(def.ReasoningEffort); err != nil {
+			errs = append(errs, fmt.Sprintf("provider %q: %s", name, err))
 		}
 		for protocol, policy := range def.ProtocolRequestParams {
 			if conflicts := validateRequestParamPolicyConflicts(policy); len(conflicts) > 0 {
@@ -687,6 +731,9 @@ func validateProtocolSpecRegistry(config protocolSpecRegistryConfig) error {
 	for name, def := range config.Models {
 		if conflicts := validateRequestParamPolicyConflicts(def.RequestParams); len(conflicts) > 0 {
 			errs = append(errs, fmt.Sprintf("model %q: %s", name, strings.Join(conflicts, "; ")))
+		}
+		if err := validateReasoningEffortSpec(def.ReasoningEffort); err != nil {
+			errs = append(errs, fmt.Sprintf("model %q: %s", name, err))
 		}
 	}
 	if len(errs) > 0 {

--- a/server/internal/gateway/reasoning_effort.go
+++ b/server/internal/gateway/reasoning_effort.go
@@ -1,0 +1,328 @@
+package gateway
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// ReasoningEffortInfo is the public, JSON-serializable view of a model's
+// reasoning_effort spec block, exposed to clients so effort pickers render
+// the levels a model actually supports.
+type ReasoningEffortInfo struct {
+	Levels            []string `json:"levels"`
+	Mode              string   `json:"mode,omitempty"`
+	ThinkingMandatory bool     `json:"thinking_mandatory,omitempty"`
+	Default           string   `json:"default,omitempty"`
+}
+
+// ReasoningEffortSpecForModel resolves the reasoning effort levels declared
+// for a model key: the longest matching model glob wins, falling back to the
+// model's provider-level block. Returns nil when nothing is declared — new
+// models in a known family inherit automatically via glob patterns, unknown
+// models simply omit the field and clients fall back to their own defaults.
+func ReasoningEffortSpecForModel(modelKey string) *ReasoningEffortInfo {
+	config, err := loadProtocolSpecRegistry()
+	if err != nil {
+		return nil
+	}
+	_, def := matchModelSpec(config.Models, modelKey)
+	spec := def.ReasoningEffort
+	if spec == nil {
+		if providerDef, ok := config.Providers[normalizeSpecKey(def.Provider)]; ok {
+			spec = providerDef.ReasoningEffort
+		}
+	}
+	if spec == nil || len(spec.Levels) == 0 {
+		return nil
+	}
+	levels := make([]string, 0, len(spec.Levels))
+	for _, level := range spec.Levels {
+		normalized := strings.ToLower(strings.TrimSpace(level))
+		if isCanonicalReasoningEffort(normalized) {
+			levels = append(levels, normalized)
+		}
+	}
+	if len(levels) == 0 {
+		return nil
+	}
+	sort.Slice(levels, func(i, j int) bool {
+		return canonicalReasoningEffortRanks[levels[i]] < canonicalReasoningEffortRanks[levels[j]]
+	})
+	defaultLevel := strings.ToLower(strings.TrimSpace(spec.Default))
+	if !slices.Contains(levels, defaultLevel) {
+		defaultLevel = ""
+	}
+	return &ReasoningEffortInfo{
+		Levels:            levels,
+		Mode:              strings.ToLower(strings.TrimSpace(spec.Mode)),
+		ThinkingMandatory: spec.ThinkingMandatory,
+		Default:           defaultLevel,
+	}
+}
+
+// canonicalReasoningEffortRanks orders every reasoning effort level the
+// gateway understands. The ladder is the superset of all upstream vendors;
+// each model declares the subset it supports via reasoning_effort spec blocks.
+var canonicalReasoningEffortRanks = map[string]int{
+	"none":    0,
+	"minimal": 1,
+	"low":     2,
+	"medium":  3,
+	"high":    4,
+	"xhigh":   5,
+	"max":     6,
+	"ultra":   7,
+}
+
+func isCanonicalReasoningEffort(effort string) bool {
+	_, ok := canonicalReasoningEffortRanks[effort]
+	return ok
+}
+
+func validateReasoningEffortSpec(spec *reasoningEffortSpec) error {
+	if spec == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(spec.Mode)) {
+	case "", "snap", "passthrough":
+	default:
+		return fmt.Errorf("reasoning_effort mode %q is not supported; must be snap or passthrough", spec.Mode)
+	}
+	if len(spec.Levels) == 0 {
+		return fmt.Errorf("reasoning_effort requires at least one level")
+	}
+	seen := map[string]bool{}
+	for _, level := range spec.Levels {
+		normalized := strings.ToLower(strings.TrimSpace(level))
+		if !isCanonicalReasoningEffort(normalized) {
+			return fmt.Errorf("reasoning_effort level %q is not a canonical effort", level)
+		}
+		if seen[normalized] {
+			return fmt.Errorf("reasoning_effort level %q is duplicated", level)
+		}
+		seen[normalized] = true
+	}
+	if spec.ThinkingMandatory && seen["none"] {
+		return fmt.Errorf("reasoning_effort marks thinking as mandatory but allows level \"none\"")
+	}
+	if defaultLevel := strings.ToLower(strings.TrimSpace(spec.Default)); defaultLevel != "" {
+		if !isCanonicalReasoningEffort(defaultLevel) {
+			return fmt.Errorf("reasoning_effort default %q is not a canonical effort", spec.Default)
+		}
+		if !seen[defaultLevel] {
+			return fmt.Errorf("reasoning_effort default %q is not in levels", spec.Default)
+		}
+	}
+	return nil
+}
+
+// snapReasoningEffort projects a requested effort onto the supported level
+// set: exact matches pass through, otherwise the nearest level by canonical
+// rank wins, ties resolve upward, and out-of-range requests clamp to the
+// closest boundary.
+func snapReasoningEffort(requested string, levels []string) string {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	requestRank, ok := canonicalReasoningEffortRanks[requested]
+	if !ok || len(levels) == 0 {
+		return ""
+	}
+	best := ""
+	bestRank := 0
+	bestDistance := 0
+	for _, level := range levels {
+		rank, ok := canonicalReasoningEffortRanks[strings.ToLower(strings.TrimSpace(level))]
+		if !ok {
+			continue
+		}
+		distance := rank - requestRank
+		if distance < 0 {
+			distance = -distance
+		}
+		if best == "" || distance < bestDistance || (distance == bestDistance && rank > bestRank) {
+			best, bestRank, bestDistance = level, rank, distance
+		}
+	}
+	return best
+}
+
+// lowestReasoningEffort returns the lowest non-"none" level, used when a
+// thinking-mandatory model receives a request that tries to disable thinking.
+func lowestReasoningEffort(levels []string) string {
+	best := ""
+	bestRank := 0
+	for _, level := range levels {
+		normalized := strings.ToLower(strings.TrimSpace(level))
+		rank, ok := canonicalReasoningEffortRanks[normalized]
+		if !ok || normalized == "none" {
+			continue
+		}
+		if best == "" || rank < bestRank {
+			best, bestRank = normalized, rank
+		}
+	}
+	return best
+}
+
+// applyReasoningEffortPolicy reconciles the effort levels present in an
+// upstream-bound payload with the model's reasoning_effort spec. It snaps
+// values in place wherever they live (reasoning_effort, reasoning.effort,
+// output_config.effort) and, for thinking-mandatory models, rewrites
+// thinking.type="disabled" to "enabled" so strict upstreams do not reject
+// the request.
+//
+// The gateway-level value "auto" is always resolved here and never forwarded:
+// it maps to the model's configured default level when the model requires an
+// explicit effort (thinking mandatory), and is dropped otherwise so the
+// upstream's own default applies.
+func applyReasoningEffortPolicy(payload map[string]any, spec resolvedProtocolSpec) map[string]any {
+	if payload == nil {
+		return payload
+	}
+	policy := spec.ReasoningEffort
+	resolveAutoReasoningEffort(payload, policy)
+	if policy == nil || len(policy.Levels) == 0 {
+		return payload
+	}
+	if strings.EqualFold(strings.TrimSpace(policy.Mode), "passthrough") {
+		return payload
+	}
+
+	// A thinking-mandatory model treats an explicit "none" as "no preference
+	// beyond keeping thinking cheap": enableMandatoryThinking below maps it
+	// to the model's default level, so the snap stage leaves it untouched.
+	skipNoneSnap := func(effort string) bool {
+		return policy.ThinkingMandatory && strings.EqualFold(strings.TrimSpace(effort), "none")
+	}
+	if raw, ok := payload["reasoning_effort"]; ok {
+		if effort, ok := raw.(string); ok && !skipNoneSnap(effort) {
+			if resolved := snapReasoningEffort(effort, policy.Levels); resolved != "" && resolved != effort {
+				payload["reasoning_effort"] = resolved
+			}
+		}
+	}
+	for _, key := range []string{"reasoning", "output_config"} {
+		nested, ok := payload[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		raw, ok := nested["effort"]
+		if !ok {
+			continue
+		}
+		effort, ok := raw.(string)
+		if !ok || skipNoneSnap(effort) {
+			continue
+		}
+		if resolved := snapReasoningEffort(effort, policy.Levels); resolved != "" && resolved != effort {
+			nested["effort"] = resolved
+		}
+	}
+
+	if policy.ThinkingMandatory {
+		enableMandatoryThinking(payload, policy)
+	}
+	return payload
+}
+
+// resolveAutoReasoningEffort rewrites the gateway-level "auto" effort value
+// in place, wherever it appears. Thinking-mandatory models get their
+// configured default (falling back to the lowest level); every other model
+// has the field removed so the upstream applies its own default. A nil policy
+// (undeclared model) always drops "auto" — upstreams do not know the value.
+func resolveAutoReasoningEffort(payload map[string]any, policy *reasoningEffortSpec) {
+	resolve := func(effort string) (string, bool) {
+		if !strings.EqualFold(strings.TrimSpace(effort), "auto") {
+			return effort, true
+		}
+		if policy != nil && policy.ThinkingMandatory {
+			if resolved := defaultReasoningEffort(policy); resolved != "" {
+				return resolved, true
+			}
+		}
+		return "", false
+	}
+	if raw, ok := payload["reasoning_effort"].(string); ok {
+		if resolved, keep := resolve(raw); keep {
+			payload["reasoning_effort"] = resolved
+		} else {
+			delete(payload, "reasoning_effort")
+		}
+	}
+	for _, key := range []string{"reasoning", "output_config"} {
+		nested, ok := payload[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		raw, ok := nested["effort"].(string)
+		if !ok {
+			continue
+		}
+		if resolved, keep := resolve(raw); keep {
+			nested["effort"] = resolved
+		} else {
+			delete(nested, "effort")
+		}
+	}
+}
+
+// defaultReasoningEffort returns the level an omitted/"auto" effort resolves
+// to for thinking-mandatory models: the configured default when valid, else
+// the lowest supported level.
+func defaultReasoningEffort(policy *reasoningEffortSpec) string {
+	if def := strings.ToLower(strings.TrimSpace(policy.Default)); def != "" {
+		if slices.Contains(policy.Levels, def) {
+			return def
+		}
+	}
+	return lowestReasoningEffort(policy.Levels)
+}
+
+// enableMandatoryThinking flips thinking off-switch requests back on for
+// models that reject disabled thinking (GLM-5.3, Kimi K3, GPT-6). The
+// resulting effort is the model's configured default — an explicit "off"
+// means "no preference beyond keeping thinking cheap", which the model's own
+// default satisfies (lowest level only when no default is declared).
+func enableMandatoryThinking(payload map[string]any, policy *reasoningEffortSpec) bool {
+	disabled := false
+	switch thinking := payload["thinking"].(type) {
+	case map[string]any:
+		if strings.EqualFold(strings.TrimSpace(anyString(thinking["type"])), "disabled") {
+			thinking["type"] = "enabled"
+			disabled = true
+		}
+	case bool:
+		if !thinking {
+			payload["thinking"] = map[string]any{"type": "enabled"}
+			disabled = true
+		}
+	}
+	if effort, ok := payload["reasoning_effort"].(string); ok && strings.EqualFold(strings.TrimSpace(effort), "none") {
+		payload["reasoning_effort"] = defaultReasoningEffort(policy)
+		disabled = true
+	}
+	if !disabled {
+		return false
+	}
+	if !payloadHasAnyEffort(payload) {
+		if resolved := defaultReasoningEffort(policy); resolved != "" {
+			payload["reasoning_effort"] = resolved
+		}
+	}
+	return true
+}
+
+func payloadHasAnyEffort(payload map[string]any) bool {
+	if effort, ok := payload["reasoning_effort"].(string); ok && strings.TrimSpace(effort) != "" {
+		return true
+	}
+	for _, key := range []string{"reasoning", "output_config"} {
+		if nested, ok := payload[key].(map[string]any); ok {
+			if effort, ok := nested["effort"].(string); ok && strings.TrimSpace(effort) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/server/internal/gateway/reasoning_effort_test.go
+++ b/server/internal/gateway/reasoning_effort_test.go
@@ -1,0 +1,540 @@
+package gateway
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	routeengine "xlyra/server/internal/router"
+	"xlyra/server/internal/store"
+)
+
+func TestSnapReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	threeLevels := []string{"low", "high", "max"}
+	tests := []struct {
+		name      string
+		requested string
+		levels    []string
+		want      string
+	}{
+		{name: "exact match passes through", requested: "high", levels: threeLevels, want: "high"},
+		{name: "below range clamps to lowest", requested: "none", levels: threeLevels, want: "low"},
+		{name: "minimal clamps to lowest", requested: "minimal", levels: threeLevels, want: "low"},
+		{name: "missing tier snaps to nearest", requested: "xhigh", levels: threeLevels, want: "max"},
+		{name: "above range clamps to highest", requested: "ultra", levels: threeLevels, want: "max"},
+		{name: "medium ties upward", requested: "medium", levels: threeLevels, want: "high"},
+		{name: "closer lower tier wins", requested: "medium", levels: []string{"low", "max"}, want: "low"},
+		{name: "unknown requested value rejected", requested: "bogus", levels: threeLevels, want: ""},
+		{name: "empty levels rejected", requested: "high", levels: nil, want: ""},
+		{name: "none kept when supported", requested: "none", levels: []string{"none", "high", "max"}, want: "none"},
+		{name: "full ladder is identity", requested: "xhigh", levels: []string{"none", "minimal", "low", "medium", "high", "xhigh"}, want: "xhigh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := snapReasoningEffort(tt.requested, tt.levels); got != tt.want {
+				t.Fatalf("snapReasoningEffort(%q, %v) = %q, want %q", tt.requested, tt.levels, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateReasoningEffortSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		spec    *reasoningEffortSpec
+		wantErr string
+	}{
+		{name: "nil spec is valid", spec: nil},
+		{name: "snap mode valid", spec: &reasoningEffortSpec{Levels: []string{"low", "high"}}},
+		{name: "passthrough mode valid", spec: &reasoningEffortSpec{Mode: "passthrough", Levels: []string{"low"}}},
+		{name: "unknown mode rejected", spec: &reasoningEffortSpec{Mode: "rewrite", Levels: []string{"low"}}, wantErr: "mode"},
+		{name: "empty levels rejected", spec: &reasoningEffortSpec{Mode: "snap"}, wantErr: "at least one level"},
+		{name: "unknown level rejected", spec: &reasoningEffortSpec{Levels: []string{"low", "turbo"}}, wantErr: "not a canonical effort"},
+		{name: "duplicate level rejected", spec: &reasoningEffortSpec{Levels: []string{"low", "LOW"}}, wantErr: "duplicated"},
+		{name: "mandatory thinking conflicts with none", spec: &reasoningEffortSpec{Levels: []string{"none", "low"}, ThinkingMandatory: true}, wantErr: "mandatory"},
+		{name: "default within levels valid", spec: &reasoningEffortSpec{Levels: []string{"low", "high"}, Default: "high"}},
+		{name: "unknown default rejected", spec: &reasoningEffortSpec{Levels: []string{"low"}, Default: "turbo"}, wantErr: "not a canonical effort"},
+		{name: "default outside levels rejected", spec: &reasoningEffortSpec{Levels: []string{"low", "high"}, Default: "max"}, wantErr: "not in levels"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateReasoningEffortSpec(tt.spec)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateReasoningEffortSpec returned unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateReasoningEffortSpec error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplyReasoningEffortPolicySnapsKnownLocations(t *testing.T) {
+	t.Parallel()
+
+	policy := &reasoningEffortSpec{Levels: []string{"low", "high", "max"}}
+	tests := []struct {
+		name    string
+		payload map[string]any
+		check   func(t *testing.T, payload map[string]any)
+	}{
+		{
+			name:    "top-level reasoning_effort",
+			payload: map[string]any{"reasoning_effort": "medium"},
+			check: func(t *testing.T, payload map[string]any) {
+				if got := payload["reasoning_effort"]; got != "high" {
+					t.Fatalf("reasoning_effort = %v, want high", got)
+				}
+			},
+		},
+		{
+			name:    "nested reasoning.effort",
+			payload: map[string]any{"reasoning": map[string]any{"effort": "xhigh", "summary": "detailed"}},
+			check: func(t *testing.T, payload map[string]any) {
+				reasoning := payload["reasoning"].(map[string]any)
+				if got := reasoning["effort"]; got != "max" {
+					t.Fatalf("reasoning.effort = %v, want max", got)
+				}
+				if got := reasoning["summary"]; got != "detailed" {
+					t.Fatalf("reasoning.summary was modified: %v", got)
+				}
+			},
+		},
+		{
+			name:    "nested output_config.effort",
+			payload: map[string]any{"output_config": map[string]any{"effort": "ultra"}},
+			check: func(t *testing.T, payload map[string]any) {
+				if got := payload["output_config"].(map[string]any)["effort"]; got != "max" {
+					t.Fatalf("output_config.effort = %v, want max", got)
+				}
+			},
+		},
+		{
+			name:    "supported value untouched",
+			payload: map[string]any{"reasoning_effort": "high"},
+			check: func(t *testing.T, payload map[string]any) {
+				if got := payload["reasoning_effort"]; got != "high" {
+					t.Fatalf("reasoning_effort = %v, want high", got)
+				}
+			},
+		},
+		{
+			name:    "payload without effort untouched",
+			payload: map[string]any{"model": "kimi-k3"},
+			check: func(t *testing.T, payload map[string]any) {
+				if _, ok := payload["reasoning_effort"]; ok {
+					t.Fatalf("reasoning_effort injected unexpectedly: %v", payload)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := applyReasoningEffortPolicy(tt.payload, resolvedProtocolSpec{ReasoningEffort: policy})
+			tt.check(t, out)
+		})
+	}
+}
+
+func TestApplyReasoningEffortPolicyPassthroughMode(t *testing.T) {
+	t.Parallel()
+
+	spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+		Levels: []string{"none", "low", "high", "max"},
+		Mode:   "passthrough",
+	}}
+	payload := map[string]any{"reasoning_effort": "medium"}
+	out := applyReasoningEffortPolicy(payload, spec)
+	if got := out["reasoning_effort"]; got != "medium" {
+		t.Fatalf("passthrough mode must not snap, reasoning_effort = %v", got)
+	}
+}
+
+func TestApplyReasoningEffortPolicyWithoutSpec(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{"reasoning_effort": "medium"}
+	out := applyReasoningEffortPolicy(payload, resolvedProtocolSpec{})
+	if got := out["reasoning_effort"]; got != "medium" {
+		t.Fatalf("missing spec must leave payload untouched, reasoning_effort = %v", got)
+	}
+}
+
+func TestApplyReasoningEffortPolicyMandatoryThinking(t *testing.T) {
+	t.Parallel()
+
+	spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+		Levels:            []string{"low", "high", "max"},
+		ThinkingMandatory: true,
+	}}
+
+	t.Run("disabled thinking flipped to enabled, falls back to lowest without a default", func(t *testing.T) {
+		payload := map[string]any{"thinking": map[string]any{"type": "disabled"}}
+		out := applyReasoningEffortPolicy(payload, spec)
+		thinking := out["thinking"].(map[string]any)
+		if got := thinking["type"]; got != "enabled" {
+			t.Fatalf("thinking.type = %v, want enabled", got)
+		}
+		if got := out["reasoning_effort"]; got != "low" {
+			t.Fatalf("reasoning_effort = %v, want low", got)
+		}
+	})
+
+	t.Run("disabled thinking maps to the configured default", func(t *testing.T) {
+		kimiLike := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels:            []string{"low", "high", "max"},
+			ThinkingMandatory: true,
+			Default:           "max",
+		}}
+		out := applyReasoningEffortPolicy(map[string]any{"thinking": map[string]any{"type": "disabled"}}, kimiLike)
+		if got := out["reasoning_effort"]; got != "max" {
+			t.Fatalf("reasoning_effort = %v, want max (configured default)", got)
+		}
+		out = applyReasoningEffortPolicy(map[string]any{"reasoning_effort": "none"}, kimiLike)
+		if got := out["reasoning_effort"]; got != "max" {
+			t.Fatalf("reasoning_effort = %v, want max (none maps to default)", got)
+		}
+	})
+
+	t.Run("bool false thinking flipped", func(t *testing.T) {
+		payload := map[string]any{"thinking": false, "reasoning_effort": "high"}
+		out := applyReasoningEffortPolicy(payload, spec)
+		thinking, ok := out["thinking"].(map[string]any)
+		if !ok || thinking["type"] != "enabled" {
+			t.Fatalf("thinking = %v, want {type: enabled}", out["thinking"])
+		}
+		if got := out["reasoning_effort"]; got != "high" {
+			t.Fatalf("explicit effort must be preserved, reasoning_effort = %v", got)
+		}
+	})
+
+	t.Run("none effort clamped to lowest", func(t *testing.T) {
+		payload := map[string]any{"reasoning_effort": "none"}
+		out := applyReasoningEffortPolicy(payload, spec)
+		if got := out["reasoning_effort"]; got != "low" {
+			t.Fatalf("reasoning_effort = %v, want low", got)
+		}
+	})
+
+	t.Run("enabled thinking untouched", func(t *testing.T) {
+		payload := map[string]any{"thinking": map[string]any{"type": "enabled"}}
+		out := applyReasoningEffortPolicy(payload, spec)
+		if _, ok := out["reasoning_effort"]; ok {
+			t.Fatalf("reasoning_effort injected unexpectedly: %v", out)
+		}
+	})
+}
+
+// TestReasoningEffortModelInheritance guards the core maintenance contract:
+// new models in a known family inherit the family's effort levels via glob
+// matching, and only models that redefine levels need their own entry.
+func TestReasoningEffortModelInheritance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		siteType  string
+		model     string
+		wantFirst string
+		wantLast  string
+		mandatory bool
+	}{
+		{name: "future kimi-k3 minor inherits k3 levels", siteType: "moonshot", model: "kimi-k3.1", wantFirst: "low", wantLast: "max", mandatory: true},
+		{name: "kimi code short name", siteType: "kimi_code", model: "k3", wantFirst: "low", wantLast: "max", mandatory: true},
+		{name: "glm-5.3 thinking locked", siteType: "zhipu", model: "glm-5.3", wantFirst: "low", wantLast: "max", mandatory: true},
+		{name: "glm-5.2 keeps none", siteType: "zhipu", model: "glm-5.2-air", wantFirst: "none", wantLast: "max", mandatory: false},
+		{name: "claude opus 4.6 lacks xhigh", siteType: "anthropic", model: "claude-opus-4-6", wantFirst: "low", wantLast: "max", mandatory: false},
+		{name: "claude opus 4.7 full ladder", siteType: "anthropic", model: "claude-opus-4-7", wantFirst: "low", wantLast: "max", mandatory: false},
+		{name: "claude opus 4.5 effort debut", siteType: "anthropic", model: "claude-opus-4-5-20251101", wantFirst: "low", wantLast: "high", mandatory: false},
+		{name: "future claude opus 5 minor inherits", siteType: "anthropic", model: "claude-opus-5.1", wantFirst: "low", wantLast: "max", mandatory: false},
+		{name: "gpt-6 drops none", siteType: "openai", model: "gpt-6-luna", wantFirst: "minimal", wantLast: "max", mandatory: true},
+		{name: "gpt-5.6 adds max", siteType: "openai", model: "gpt-5.6-luna", wantFirst: "none", wantLast: "max", mandatory: false},
+		{name: "gpt-5.6-sol exact entry adds ultra", siteType: "openai", model: "gpt-5.6-sol", wantFirst: "none", wantLast: "ultra", mandatory: false},
+		{name: "gpt-5.6-terra exact entry adds ultra", siteType: "openai", model: "gpt-5.6-terra", wantFirst: "none", wantLast: "ultra", mandatory: false},
+		{name: "gpt-6-astra exact entry adds ultra", siteType: "openai", model: "gpt-6-astra", wantFirst: "minimal", wantLast: "ultra", mandatory: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := routeengine.Candidate{
+				Site:  routeengine.CandidateSite{SiteType: tt.siteType},
+				Model: routeengine.CandidateModel{UpstreamName: tt.model},
+			}
+			spec := effectiveProtocolSpec(canonicalProtocolOpenAIChat, candidate)
+			policy := spec.ReasoningEffort
+			if policy == nil {
+				t.Fatalf("model %q resolved without reasoning_effort spec (pattern %q)", tt.model, spec.ModelPattern)
+			}
+			if got := policy.Levels[0]; got != tt.wantFirst {
+				t.Fatalf("model %q first level = %q, want %q (levels %v)", tt.model, got, tt.wantFirst, policy.Levels)
+			}
+			if got := policy.Levels[len(policy.Levels)-1]; got != tt.wantLast {
+				t.Fatalf("model %q last level = %q, want %q (levels %v)", tt.model, got, tt.wantLast, policy.Levels)
+			}
+			if policy.ThinkingMandatory != tt.mandatory {
+				t.Fatalf("model %q thinking_mandatory = %v, want %v", tt.model, policy.ThinkingMandatory, tt.mandatory)
+			}
+		})
+	}
+}
+
+func TestReasoningEffortModelInheritanceDistinguishesXhigh(t *testing.T) {
+	t.Parallel()
+
+	hasXhigh := func(model string) bool {
+		spec := effectiveProtocolSpec(canonicalProtocolAnthropicMessages, routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "anthropic"},
+			Model: routeengine.CandidateModel{UpstreamName: model},
+		})
+		if spec.ReasoningEffort == nil {
+			return false
+		}
+		return slices.Contains(spec.ReasoningEffort.Levels, "xhigh")
+	}
+
+	if hasXhigh("claude-opus-4-6") {
+		t.Fatalf("claude-opus-4-6 must not advertise xhigh")
+	}
+	if hasXhigh("claude-sonnet-4-6") {
+		t.Fatalf("claude-sonnet-4-6 must not advertise xhigh")
+	}
+	if !hasXhigh("claude-opus-4-7") {
+		t.Fatalf("claude-opus-4-7 must advertise xhigh")
+	}
+	if !hasXhigh("claude-sonnet-5") {
+		t.Fatalf("claude-sonnet-5 must advertise xhigh")
+	}
+}
+
+func TestApplyRequestPolicySnapsEffortEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("medium snapped to high for kimi-k3", func(t *testing.T) {
+		candidate := routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "moonshot"},
+			Model: routeengine.CandidateModel{UpstreamName: "kimi-k3"},
+		}
+		payload := applyRequestPolicyForCandidate(map[string]any{
+			"model":            "kimi-k3",
+			"reasoning_effort": "medium",
+		}, canonicalProtocolOpenAIChat, candidate)
+		if got := payload["reasoning_effort"]; got != "high" {
+			t.Fatalf("reasoning_effort = %v, want high", got)
+		}
+	})
+
+	t.Run("deepseek passes canonical values through", func(t *testing.T) {
+		candidate := routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "deepseek"},
+			Model: routeengine.CandidateModel{UpstreamName: "deepseek-v4-pro"},
+		}
+		payload := applyRequestPolicyForCandidate(map[string]any{
+			"model":            "deepseek-v4-pro",
+			"reasoning_effort": "medium",
+		}, canonicalProtocolOpenAIChat, candidate)
+		if got := payload["reasoning_effort"]; got != "medium" {
+			t.Fatalf("reasoning_effort = %v, want medium (upstream self-snaps)", got)
+		}
+	})
+
+	t.Run("xhigh snapped to max for claude-opus-4-6", func(t *testing.T) {
+		candidate := routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "anthropic"},
+			Model: routeengine.CandidateModel{UpstreamName: "claude-opus-4-6"},
+		}
+		payload := applyRequestPolicyForCandidate(map[string]any{
+			"model":         "claude-opus-4-6",
+			"output_config": map[string]any{"effort": "xhigh"},
+		}, canonicalProtocolAnthropicMessages, candidate)
+		outputConfig, ok := payload["output_config"].(map[string]any)
+		if !ok {
+			t.Fatalf("output_config missing after policy: %v", payload)
+		}
+		if got := outputConfig["effort"]; got != "max" {
+			t.Fatalf("output_config.effort = %v, want max", got)
+		}
+	})
+
+	t.Run("none maps to the default level for gpt-6", func(t *testing.T) {
+		candidate := routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "openai"},
+			Model: routeengine.CandidateModel{UpstreamName: "gpt-6-astra"},
+		}
+		payload := applyRequestPolicyForCandidate(map[string]any{
+			"model":            "gpt-6-astra",
+			"reasoning_effort": "none",
+		}, canonicalProtocolOpenAIChat, candidate)
+		if got := payload["reasoning_effort"]; got != "medium" {
+			t.Fatalf("reasoning_effort = %v, want medium (gpt-6 default)", got)
+		}
+	})
+
+	t.Run("unknown model left untouched", func(t *testing.T) {
+		candidate := routeengine.Candidate{
+			Site:  routeengine.CandidateSite{SiteType: "moonshot"},
+			Model: routeengine.CandidateModel{UpstreamName: "kimi-k9-experimental"},
+		}
+		payload := applyRequestPolicyForCandidate(map[string]any{
+			"model":            "kimi-k9-experimental",
+			"reasoning_effort": "medium",
+		}, canonicalProtocolOpenAIChat, candidate)
+		if got := payload["reasoning_effort"]; got != "medium" {
+			t.Fatalf("unknown model must pass through, reasoning_effort = %v", got)
+		}
+	})
+}
+
+func TestReasoningEffortSpecForModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelKey  string
+		want      []string
+		mode      string
+		mandatory bool
+		def       string
+	}{
+		{name: "kimi k3 declared levels", modelKey: "kimi-k3", want: []string{"low", "high", "max"}, mandatory: true, def: "max"},
+		{name: "future kimi minor inherits", modelKey: "kimi-k3.1", want: []string{"low", "high", "max"}, mandatory: true, def: "max"},
+		{name: "claude opus 4.6 lacks xhigh", modelKey: "claude-opus-4-6", want: []string{"low", "medium", "high", "max"}, def: "high"},
+		{name: "claude fable 5 full ladder", modelKey: "claude-fable-5", want: []string{"low", "medium", "high", "xhigh", "max"}, mandatory: true, def: "high"},
+		{name: "deepseek passthrough", modelKey: "deepseek-v4-flash", want: []string{"none", "low", "high", "max"}, mode: "passthrough", def: "high"},
+		{name: "glm 5.3 mandatory", modelKey: "glm-5.3", want: []string{"low", "high", "max"}, mandatory: true, def: "max"},
+		{name: "gpt 6 floor at minimal", modelKey: "gpt-6", want: []string{"minimal", "low", "medium", "high", "xhigh", "max"}, mandatory: true, def: "medium"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := ReasoningEffortSpecForModel(tt.modelKey)
+			if info == nil {
+				t.Fatalf("ReasoningEffortSpecForModel(%q) = nil, want levels %v", tt.modelKey, tt.want)
+			}
+			if !slices.Equal(info.Levels, tt.want) {
+				t.Fatalf("ReasoningEffortSpecForModel(%q).Levels = %v, want %v (sorted by rank)", tt.modelKey, info.Levels, tt.want)
+			}
+			if info.Mode != tt.mode {
+				t.Fatalf("ReasoningEffortSpecForModel(%q).Mode = %q, want %q", tt.modelKey, info.Mode, tt.mode)
+			}
+			if info.ThinkingMandatory != tt.mandatory {
+				t.Fatalf("ReasoningEffortSpecForModel(%q).ThinkingMandatory = %v, want %v", tt.modelKey, info.ThinkingMandatory, tt.mandatory)
+			}
+			if info.Default != tt.def {
+				t.Fatalf("ReasoningEffortSpecForModel(%q).Default = %q, want %q", tt.modelKey, info.Default, tt.def)
+			}
+		})
+	}
+
+	t.Run("undeclared model returns nil", func(t *testing.T) {
+		if info := ReasoningEffortSpecForModel("some-unheard-of-model"); info != nil {
+			t.Fatalf("ReasoningEffortSpecForModel(unknown) = %+v, want nil", info)
+		}
+	})
+}
+
+func TestCanonicalModelPayloadExposesReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalModelPayload(store.CanonicalModel{ModelKey: "kimi-k3"})
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata missing from payload: %v", payload)
+	}
+	effort, ok := metadata["reasoning_effort"].(*ReasoningEffortInfo)
+	if !ok {
+		t.Fatalf("metadata.reasoning_effort missing or wrong type: %v", metadata)
+	}
+	if !slices.Equal(effort.Levels, []string{"low", "high", "max"}) {
+		t.Fatalf("levels = %v, want [low high max]", effort.Levels)
+	}
+	if !effort.ThinkingMandatory {
+		t.Fatalf("thinking_mandatory = false, want true")
+	}
+
+	unknown := canonicalModelPayload(store.CanonicalModel{ModelKey: "some-unheard-of-model"})
+	if metadata, ok := unknown["metadata"].(map[string]any); ok {
+		if _, present := metadata["reasoning_effort"]; present {
+			t.Fatalf("unknown model must not carry reasoning_effort: %v", metadata)
+		}
+	}
+}
+
+func TestApplyReasoningEffortPolicyResolvesAuto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("auto dropped for models that accept an omitted effort", func(t *testing.T) {
+		spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels:  []string{"none", "minimal", "low", "medium", "high", "xhigh"},
+			Default: "medium",
+		}}
+		payload := map[string]any{"reasoning_effort": "auto"}
+		out := applyReasoningEffortPolicy(payload, spec)
+		if _, present := out["reasoning_effort"]; present {
+			t.Fatalf("auto must be omitted for non-mandatory models, got %v", out["reasoning_effort"])
+		}
+	})
+
+	t.Run("auto maps to the configured default for mandatory models", func(t *testing.T) {
+		spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels:            []string{"low", "high", "max"},
+			ThinkingMandatory: true,
+			Default:           "max",
+		}}
+		out := applyReasoningEffortPolicy(map[string]any{"reasoning_effort": "AUTO"}, spec)
+		if got := out["reasoning_effort"]; got != "max" {
+			t.Fatalf("reasoning_effort = %v, want max", got)
+		}
+	})
+
+	t.Run("auto falls back to the lowest level without a configured default", func(t *testing.T) {
+		spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels:            []string{"low", "high", "max"},
+			ThinkingMandatory: true,
+		}}
+		out := applyReasoningEffortPolicy(map[string]any{"reasoning_effort": "auto"}, spec)
+		if got := out["reasoning_effort"]; got != "low" {
+			t.Fatalf("reasoning_effort = %v, want low", got)
+		}
+	})
+
+	t.Run("auto dropped even in passthrough mode", func(t *testing.T) {
+		spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels: []string{"none", "low", "high", "max"},
+			Mode:   "passthrough",
+		}}
+		out := applyReasoningEffortPolicy(map[string]any{"reasoning_effort": "auto"}, spec)
+		if _, present := out["reasoning_effort"]; present {
+			t.Fatalf("auto must not leak to a passthrough upstream, got %v", out["reasoning_effort"])
+		}
+	})
+
+	t.Run("auto dropped without any spec", func(t *testing.T) {
+		out := applyReasoningEffortPolicy(map[string]any{"reasoning_effort": "auto"}, resolvedProtocolSpec{})
+		if _, present := out["reasoning_effort"]; present {
+			t.Fatalf("auto must not leak for undeclared models, got %v", out["reasoning_effort"])
+		}
+	})
+
+	t.Run("auto resolved in nested locations", func(t *testing.T) {
+		spec := resolvedProtocolSpec{ReasoningEffort: &reasoningEffortSpec{
+			Levels:            []string{"low", "high", "max"},
+			ThinkingMandatory: true,
+			Default:           "high",
+		}}
+		out := applyReasoningEffortPolicy(map[string]any{
+			"reasoning":     map[string]any{"effort": "auto"},
+			"output_config": map[string]any{"effort": "high"},
+		}, spec)
+		if got := out["reasoning"].(map[string]any)["effort"]; got != "high" {
+			t.Fatalf("reasoning.effort = %v, want high (default)", got)
+		}
+		if got := out["output_config"].(map[string]any)["effort"]; got != "high" {
+			t.Fatalf("output_config.effort = %v, want high (untouched)", got)
+		}
+	})
+}

--- a/server/internal/gateway/request_options.go
+++ b/server/internal/gateway/request_options.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const supportedReasoningEfforts = "none, minimal, low, medium, high, xhigh, max, ultra"
+const supportedReasoningEfforts = "auto, none, minimal, low, medium, high, xhigh, max, ultra"
 
 func normalizeClientRequestOptions(payload map[string]any) *chatFailure {
 	if serviceTier, ok := payload["service_tier"].(string); ok {
@@ -74,10 +74,7 @@ func unsupportedReasoningEffortError(key string, value any) error {
 }
 
 func isSupportedReasoningEffort(effort string) bool {
-	switch effort {
-	case "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra":
-		return true
-	default:
-		return false
-	}
+	// "auto" is a gateway-level directive (resolve to the model's default),
+	// never forwarded upstream; the canonical ladder covers explicit levels.
+	return effort == "auto" || isCanonicalReasoningEffort(effort)
 }

--- a/server/internal/gateway/request_options_test.go
+++ b/server/internal/gateway/request_options_test.go
@@ -8,7 +8,7 @@ import (
 func TestNormalizeClientRequestOptionsAcceptsSupportedReasoningEfforts(t *testing.T) {
 	t.Parallel()
 
-	for _, effort := range []string{"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"} {
+	for _, effort := range []string{"auto", "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"} {
 		effort := effort
 		t.Run(effort, func(t *testing.T) {
 			t.Parallel()
@@ -34,7 +34,6 @@ func TestNormalizeClientRequestOptionsRejectsUnsupportedReasoningEffort(t *testi
 
 	tests := []map[string]any{
 		{"reasoning_effort": "light"},
-		{"reasoning": map[string]any{"effort": "auto"}},
 		{"reasoning_effort": 3},
 		{"reasoning_effort": "high", "reasoning": map[string]any{"effort": "ultra"}},
 	}

--- a/server/internal/protocolspec/protocol_specs.json
+++ b/server/internal/protocolspec/protocol_specs.json
@@ -85,10 +85,24 @@
           "service_tier"
         ],
         "validation": {
-          "temperature": {"type": "number", "min": 0, "max": 2},
-          "top_p": {"type": "number", "min": 0, "max": 1},
-          "max_tokens": {"type": "integer", "min": 1},
-          "max_completion_tokens": {"type": "integer", "min": 1}
+          "temperature": {
+            "type": "number",
+            "min": 0,
+            "max": 2
+          },
+          "top_p": {
+            "type": "number",
+            "min": 0,
+            "max": 1
+          },
+          "max_tokens": {
+            "type": "integer",
+            "min": 1
+          },
+          "max_completion_tokens": {
+            "type": "integer",
+            "min": 1
+          }
         }
       },
       "capabilities": {
@@ -272,9 +286,20 @@
           "service_tier"
         ],
         "validation": {
-          "temperature": {"type": "number", "min": 0, "max": 2},
-          "top_p": {"type": "number", "min": 0, "max": 1},
-          "max_output_tokens": {"type": "integer", "min": 1}
+          "temperature": {
+            "type": "number",
+            "min": 0,
+            "max": 2
+          },
+          "top_p": {
+            "type": "number",
+            "min": 0,
+            "max": 1
+          },
+          "max_output_tokens": {
+            "type": "integer",
+            "min": 1
+          }
         }
       },
       "capabilities": {
@@ -430,10 +455,24 @@
           "output_config"
         ],
         "validation": {
-          "temperature": {"type": "number", "min": 0, "max": 1},
-          "top_p": {"type": "number", "min": 0, "max": 1},
-          "top_k": {"type": "integer", "min": 1},
-          "max_tokens": {"type": "integer", "min": 1}
+          "temperature": {
+            "type": "number",
+            "min": 0,
+            "max": 1
+          },
+          "top_p": {
+            "type": "number",
+            "min": 0,
+            "max": 1
+          },
+          "top_k": {
+            "type": "integer",
+            "min": 1
+          },
+          "max_tokens": {
+            "type": "integer",
+            "min": 1
+          }
         }
       },
       "capabilities": {
@@ -697,12 +736,12 @@
         "reasoning_summary": "metadata"
       }
     },
-  "anthropic": {
-    "protocol": "anthropic_messages",
-    "official_base_url": "https://api.anthropic.com",
-    "documentation": [
-      "https://docs.anthropic.com/en/docs/about-claude/models",
-      "https://docs.anthropic.com/en/api/messages"
+    "anthropic": {
+      "protocol": "anthropic_messages",
+      "official_base_url": "https://api.anthropic.com",
+      "documentation": [
+        "https://docs.anthropic.com/en/docs/about-claude/models",
+        "https://docs.anthropic.com/en/api/messages"
       ],
       "request_params": {
         "defaults": {
@@ -1051,8 +1090,238 @@
         "text_format": true,
         "tool_calls": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "default": "medium"
+      },
       "documentation": [
-        "https://platform.openai.com/docs/models"
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
+      ]
+    },
+    "gpt-5.6*": {
+      "provider": "openai",
+      "request_params": {
+        "supported": [
+          "model",
+          "input",
+          "messages",
+          "instructions",
+          "stream",
+          "stream_options",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "text",
+          "reasoning",
+          "include",
+          "store",
+          "metadata",
+          "service_tier"
+        ]
+      },
+      "capabilities": {
+        "reasoning_summary": true,
+        "text_format": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "medium"
+      },
+      "documentation": [
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
+      ]
+    },
+    "gpt-5.6-sol": {
+      "provider": "openai",
+      "request_params": {
+        "supported": [
+          "model",
+          "input",
+          "messages",
+          "instructions",
+          "stream",
+          "stream_options",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "text",
+          "reasoning",
+          "include",
+          "store",
+          "metadata",
+          "service_tier"
+        ]
+      },
+      "capabilities": {
+        "reasoning_summary": true,
+        "text_format": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+          "ultra"
+        ],
+        "default": "medium"
+      },
+      "documentation": [
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
+      ]
+    },
+    "gpt-5.6-terra": {
+      "provider": "openai",
+      "request_params": {
+        "supported": [
+          "model",
+          "input",
+          "messages",
+          "instructions",
+          "stream",
+          "stream_options",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "text",
+          "reasoning",
+          "include",
+          "store",
+          "metadata",
+          "service_tier"
+        ]
+      },
+      "capabilities": {
+        "reasoning_summary": true,
+        "text_format": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+          "ultra"
+        ],
+        "default": "medium"
+      },
+      "documentation": [
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
+      ]
+    },
+    "gpt-6*": {
+      "provider": "openai",
+      "request_params": {
+        "supported": [
+          "model",
+          "input",
+          "messages",
+          "instructions",
+          "stream",
+          "stream_options",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "text",
+          "reasoning",
+          "include",
+          "store",
+          "metadata",
+          "service_tier"
+        ]
+      },
+      "capabilities": {
+        "reasoning_summary": true,
+        "text_format": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "medium",
+        "thinking_mandatory": true
+      },
+      "documentation": [
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
+      ]
+    },
+    "gpt-6-astra": {
+      "provider": "openai",
+      "request_params": {
+        "supported": [
+          "model",
+          "input",
+          "messages",
+          "instructions",
+          "stream",
+          "stream_options",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "text",
+          "reasoning",
+          "include",
+          "store",
+          "metadata",
+          "service_tier"
+        ]
+      },
+      "capabilities": {
+        "reasoning_summary": true,
+        "text_format": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+          "ultra"
+        ],
+        "default": "medium",
+        "thinking_mandatory": true
+      },
+      "documentation": [
+        "https://platform.openai.com/docs/models",
+        "https://developers.openai.com/api/docs/guides/reasoning"
       ]
     },
     "gpt-4.1*": {
@@ -1107,6 +1376,69 @@
         "https://platform.openai.com/docs/models"
       ]
     },
+    "claude-opus-5*": {
+      "provider": "anthropic",
+      "capabilities": {
+        "thinking": true,
+        "thinking_signature": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "high"
+      },
+      "documentation": [
+        "https://docs.anthropic.com/en/docs/about-claude/models",
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
+      ]
+    },
+    "claude-opus-4-5*": {
+      "provider": "anthropic",
+      "capabilities": {
+        "thinking": true,
+        "thinking_signature": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "default": "high"
+      },
+      "documentation": [
+        "https://docs.anthropic.com/en/docs/about-claude/models",
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
+      ]
+    },
+    "claude-opus-4-6*": {
+      "provider": "anthropic",
+      "capabilities": {
+        "thinking": true,
+        "thinking_signature": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "default": "high"
+      },
+      "documentation": [
+        "https://docs.anthropic.com/en/docs/about-claude/models",
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
+      ]
+    },
     "claude-opus-4*": {
       "provider": "anthropic",
       "capabilities": {
@@ -1114,9 +1446,40 @@
         "thinking_signature": true,
         "tool_calls": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "high"
+      },
       "documentation": [
         "https://docs.anthropic.com/en/docs/about-claude/models",
-        "https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking"
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
+      ]
+    },
+    "claude-sonnet-4-6*": {
+      "provider": "anthropic",
+      "capabilities": {
+        "thinking": true,
+        "thinking_signature": true,
+        "tool_calls": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "default": "high"
+      },
+      "documentation": [
+        "https://docs.anthropic.com/en/docs/about-claude/models",
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
       ]
     },
     "claude-sonnet-4*": {
@@ -1138,9 +1501,19 @@
         "thinking_signature": true,
         "tool_calls": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "high"
+      },
       "documentation": [
         "https://docs.anthropic.com/en/docs/about-claude/models",
-        "https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking"
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
       ]
     },
     "claude-haiku-4*": {
@@ -1162,9 +1535,20 @@
         "thinking_signature": true,
         "tool_calls": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "default": "high",
+        "thinking_mandatory": true
+      },
       "documentation": [
         "https://docs.anthropic.com/en/docs/about-claude/models",
-        "https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking"
+        "https://platform.claude.com/docs/en/build-with-claude/effort"
       ]
     },
     "claude-3-7*": {
@@ -1208,6 +1592,43 @@
       "documentation": [
         "https://ai.google.dev/gemini-api/docs/models",
         "https://ai.google.dev/gemini-api/docs/thinking"
+      ]
+    },
+    "glm-5.3*": {
+      "provider": "zhipu",
+      "capabilities": {
+        "tool_calls": true,
+        "reasoning_summary": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "high",
+          "max"
+        ],
+        "default": "max",
+        "thinking_mandatory": true
+      },
+      "documentation": [
+        "https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3"
+      ]
+    },
+    "glm-5.2*": {
+      "provider": "zhipu",
+      "capabilities": {
+        "tool_calls": true,
+        "reasoning_summary": true
+      },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "high",
+          "max"
+        ],
+        "default": "high"
+      },
+      "documentation": [
+        "https://docs.bigmodel.cn/cn/guide/models/text/glm-5.2"
       ]
     },
     "glm-5*": {
@@ -1418,6 +1839,16 @@
         "anthropic_messages": true,
         "strict_tools_beta": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "none",
+          "low",
+          "high",
+          "max"
+        ],
+        "default": "high",
+        "mode": "passthrough"
+      },
       "documentation": [
         "https://api-docs.deepseek.com/zh-cn/guides/thinking_mode",
         "https://api-docs.deepseek.com/zh-cn/guides/tool_calls",
@@ -1611,8 +2042,18 @@
         "thinking_roundtrip": true,
         "anthropic_messages": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "high",
+          "max"
+        ],
+        "default": "max",
+        "thinking_mandatory": true
+      },
       "documentation": [
-        "https://www.kimi.com/code/docs/kimi-code/models.html"
+        "https://www.kimi.com/code/docs/kimi-code/models.html",
+        "https://platform.kimi.com/docs/guide/use-reasoning-effort"
       ]
     },
     "kimi-k3*": {
@@ -1623,8 +2064,18 @@
         "thinking_roundtrip": true,
         "anthropic_messages": true
       },
+      "reasoning_effort": {
+        "levels": [
+          "low",
+          "high",
+          "max"
+        ],
+        "default": "max",
+        "thinking_mandatory": true
+      },
       "documentation": [
-        "https://www.kimi.com/code/docs/kimi-code/models.html"
+        "https://www.kimi.com/code/docs/kimi-code/models.html",
+        "https://platform.kimi.com/docs/guide/use-reasoning-effort"
       ]
     },
     "kimi-for-coding*": {

--- a/web/src/features/playground/api/playground.ts
+++ b/web/src/features/playground/api/playground.ts
@@ -1,4 +1,5 @@
 import { apiFetch, apiFetchResponse, APIError } from '@/lib/http'
+import { parseGatewayModelReasoning } from '@/features/playground/lib/reasoning'
 import type {
   ChatProtocol,
   Conversation,
@@ -18,7 +19,7 @@ type GatewayModelPayload = {
   data?: Array<{
     id?: string
     owned_by?: string
-    metadata?: { display_name?: string; category?: string; mapped_model?: string; supported_endpoint_types?: unknown }
+    metadata?: { display_name?: string; category?: string; mapped_model?: string; supported_endpoint_types?: unknown; reasoning_effort?: unknown }
   }>
 }
 
@@ -40,6 +41,7 @@ function gatewayModelsFromPayload(payload: GatewayModelPayload): GatewayModel[] 
       category: item.metadata?.category?.trim().toLowerCase() || 'chat',
       ownedBy: item.owned_by,
       endpointTypes: normalizeEndpointTypes(item.metadata?.supported_endpoint_types),
+      reasoning: parseGatewayModelReasoning(item.metadata?.reasoning_effort),
     }))
     .sort((left, right) => left.id.localeCompare(right.id, undefined, { sensitivity: 'base' }))
 }

--- a/web/src/features/playground/lib/reasoning.test.ts
+++ b/web/src/features/playground/lib/reasoning.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   normalizeReasoningEffort,
+  parseGatewayModelReasoning,
   reasoningEffortsForModel,
   supportsMaxReasoning,
   supportsUltraReasoning,
 } from '@/features/playground/lib/reasoning'
+import type { GatewayModelReasoning, ReasoningEffort } from '@/features/playground/lib/types'
+
+const serverLevels = (levels: ReasoningEffort[]): GatewayModelReasoning => ({ levels })
 
 describe('playground reasoning effort rules', () => {
   it('offers max across the gpt-5.6 family and ultra only for sol and terra', () => {
@@ -18,6 +22,14 @@ describe('playground reasoning effort rules', () => {
     expect(reasoningEffortsForModel({ id: 'gpt-5.6-sol' })).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
     expect(reasoningEffortsForModel({ id: 'gpt-5.6-luna' })).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
     expect(reasoningEffortsForModel({ id: 'gpt-5.5' })).toEqual(['low', 'medium', 'high', 'xhigh'])
+  })
+
+  it('offers max and ultra for gpt-6-astra in the fallback rules', () => {
+    expect(supportsMaxReasoning({ id: 'gpt-6-astra' })).toBe(true)
+    expect(supportsUltraReasoning({ id: 'gpt-6-astra' })).toBe(true)
+    expect(reasoningEffortsForModel({ id: 'gpt-6-astra' })).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
+    expect(normalizeReasoningEffort({ id: 'gpt-6-astra' }, 'ultra')).toBe('ultra')
+    expect(supportsUltraReasoning({ id: 'gpt-6-astra-mini' })).toBe(false)
   })
 
   it('downgrades unsupported max and ultra to the strongest available effort', () => {
@@ -36,5 +48,51 @@ describe('playground reasoning effort rules', () => {
     expect(normalizeReasoningEffort(mappedTo56, 'ultra')).toBe('ultra')
     expect(reasoningEffortsForModel(mappedTo55)).toEqual(['low', 'medium', 'high', 'xhigh'])
     expect(normalizeReasoningEffort(mappedTo55, 'ultra')).toBe('xhigh')
+  })
+
+  it('parses the server-declared reasoning_effort block, dropping unknown levels and sorting by rank', () => {
+    expect(parseGatewayModelReasoning(undefined)).toBeUndefined()
+    expect(parseGatewayModelReasoning(null)).toBeUndefined()
+    expect(parseGatewayModelReasoning({})).toBeUndefined()
+    expect(parseGatewayModelReasoning({ levels: 'high' })).toBeUndefined()
+    expect(parseGatewayModelReasoning({ levels: ['turbo'] })).toBeUndefined()
+
+    expect(parseGatewayModelReasoning({ levels: ['MAX', ' low ', 'high', 'low', 'turbo'] }))
+      .toEqual({ levels: ['low', 'high', 'max'], thinkingMandatory: false })
+    expect(parseGatewayModelReasoning({ levels: ['low', 'high'], thinking_mandatory: true }))
+      .toEqual({ levels: ['low', 'high'], thinkingMandatory: true })
+  })
+
+  it('never offers none in the picker, even when the model supports it', () => {
+    const glm52 = { id: 'glm-5.2', reasoning: serverLevels(['none', 'high', 'max']) }
+    expect(reasoningEffortsForModel(glm52)).toEqual(['high', 'max'])
+    const gpt5 = { id: 'gpt-5.5', reasoning: serverLevels(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']) }
+    expect(reasoningEffortsForModel(gpt5)).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh'])
+  })
+
+  it('prefers server-declared levels over the hardcoded rules', () => {
+    // kimi-k3 style: server says low/high/max even though the id matches no hardcoded rule.
+    const kimi = { id: 'kimi-k3', reasoning: serverLevels(['low', 'high', 'max']) }
+    expect(reasoningEffortsForModel(kimi)).toEqual(['low', 'high', 'max'])
+    // A gpt-5.6 variant whose server levels exclude ultra wins over the fallback.
+    const gated = { id: 'gpt-5.6-sol', reasoning: serverLevels(['low', 'medium', 'high', 'xhigh', 'max']) }
+    expect(reasoningEffortsForModel(gated)).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
+  })
+
+  it('snaps to server levels by rank: exact passes, ties resolve upward, out-of-range clamps', () => {
+    const model = { id: 'glm-5.3', reasoning: serverLevels(['low', 'high', 'max']) }
+    expect(normalizeReasoningEffort(model, 'high')).toBe('high')
+    expect(normalizeReasoningEffort(model, 'medium')).toBe('high') // equidistant tie goes up
+    expect(normalizeReasoningEffort(model, 'xhigh')).toBe('max') // equidistant tie goes up
+    expect(normalizeReasoningEffort(model, 'ultra')).toBe('max')
+    expect(normalizeReasoningEffort(model, 'none')).toBe('low')
+    expect(normalizeReasoningEffort(model, 'minimal')).toBe('low')
+  })
+
+  it('snaps minimal-gap misses to the nearest level either way', () => {
+    const opus46 = { id: 'claude-opus-4-6', reasoning: serverLevels(['low', 'medium', 'high', 'max']) }
+    expect(normalizeReasoningEffort(opus46, 'xhigh')).toBe('max') // equidistant tie goes up
+    expect(normalizeReasoningEffort(opus46, 'ultra')).toBe('max')
+    expect(normalizeReasoningEffort(opus46, 'minimal')).toBe('low')
   })
 })

--- a/web/src/features/playground/lib/reasoning.ts
+++ b/web/src/features/playground/lib/reasoning.ts
@@ -1,30 +1,84 @@
-import type { GatewayModel, ReasoningEffort } from '@/features/playground/lib/types'
+import type { GatewayModel, GatewayModelReasoning, ReasoningEffort } from '@/features/playground/lib/types'
 
 const BASE_REASONING_EFFORTS: ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh']
-type ReasoningModel = Pick<GatewayModel, 'id' | 'mappedModel'>
+
+// Canonical ladder shared with the gateway (server/internal/gateway/reasoning_effort.go):
+// server-declared levels are a subset of this list, and snapping walks it by rank.
+const EFFORT_RANKS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+
+type ReasoningModel = Pick<GatewayModel, 'id' | 'mappedModel' | 'reasoning'>
 
 function normalizedReasoningModel(model: ReasoningModel | null | undefined): string {
   return (model?.mappedModel || model?.id || '').trim().toLowerCase()
 }
 
+/**
+ * Parses the reasoning_effort block the gateway exposes on model payloads
+ * (metadata.reasoning_effort on /v1/models, reasoning_effort on /api/v1/models).
+ * Returns undefined when the server declares nothing usable, so callers fall
+ * back to the hardcoded rules below.
+ */
+export function parseGatewayModelReasoning(value: unknown): GatewayModelReasoning | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const rawLevels = (value as { levels?: unknown }).levels
+  if (!Array.isArray(rawLevels)) return undefined
+  const levels = rawLevels
+    .map((item) => (typeof item === 'string' ? item.trim().toLowerCase() : ''))
+    .filter((item): item is ReasoningEffort => (EFFORT_RANKS as string[]).includes(item))
+  const unique = [...new Set(levels)].sort((a, b) => EFFORT_RANKS.indexOf(a) - EFFORT_RANKS.indexOf(b))
+  if (unique.length === 0) return undefined
+  const thinkingMandatory = (value as { thinking_mandatory?: unknown }).thinking_mandatory === true
+  return { levels: unique, thinkingMandatory }
+}
+
+/** Snaps an effort onto the supported level set by rank: exact match passes,
+ * otherwise nearest by rank, ties resolve upward, out-of-range clamps. Mirrors
+ * the gateway's snapReasoningEffort. */
+function snapToLevels(effort: ReasoningEffort, levels: ReasoningEffort[]): ReasoningEffort {
+  if (levels.includes(effort)) return effort
+  const rank = EFFORT_RANKS.indexOf(effort)
+  let best = levels[0] ?? effort
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const level of levels) {
+    const distance = Math.abs(EFFORT_RANKS.indexOf(level) - rank)
+    if (distance < bestDistance || (distance === bestDistance && EFFORT_RANKS.indexOf(level) > EFFORT_RANKS.indexOf(best))) {
+      best = level
+      bestDistance = distance
+    }
+  }
+  return best
+}
+
+// ---- Hardcoded fallback rules, used only when the server declares no levels ----
+
 export function supportsMaxReasoning(model: ReasoningModel | null | undefined): boolean {
   const normalized = normalizedReasoningModel(model)
-  return normalized === 'gpt-5.6' || normalized.startsWith('gpt-5.6-')
+  return normalized === 'gpt-5.6' || normalized.startsWith('gpt-5.6-') || normalized === 'gpt-6-astra'
 }
 
 export function supportsUltraReasoning(model: ReasoningModel | null | undefined): boolean {
   const normalized = normalizedReasoningModel(model)
-  return normalized === 'gpt-5.6-sol' || normalized === 'gpt-5.6-terra'
+  return normalized === 'gpt-5.6-sol' || normalized === 'gpt-5.6-terra' || normalized === 'gpt-6-astra'
 }
 
-export function reasoningEffortsForModel(model: ReasoningModel | null | undefined): ReasoningEffort[] {
+function fallbackReasoningEffortsForModel(model: ReasoningModel | null | undefined): ReasoningEffort[] {
   const efforts = [...BASE_REASONING_EFFORTS]
   if (supportsMaxReasoning(model)) efforts.push('max')
   if (supportsUltraReasoning(model)) efforts.push('ultra')
   return efforts
 }
 
+/** Levels offered in the picker. "none" (thinking off) is never shown —
+ * disabling thinking is not a choice the UI exposes. */
+export function reasoningEffortsForModel(model: ReasoningModel | null | undefined): ReasoningEffort[] {
+  const levels = model?.reasoning?.levels ?? fallbackReasoningEffortsForModel(model)
+  return levels.filter((level) => level !== 'none')
+}
+
 export function normalizeReasoningEffort(model: ReasoningModel | null | undefined, effort: ReasoningEffort): ReasoningEffort {
+  if (model?.reasoning) {
+    return snapToLevels(effort, model.reasoning.levels)
+  }
   if (effort === 'ultra' && !supportsUltraReasoning(model)) {
     return supportsMaxReasoning(model) ? 'max' : 'xhigh'
   }

--- a/web/src/features/playground/lib/storage.ts
+++ b/web/src/features/playground/lib/storage.ts
@@ -63,7 +63,7 @@ export function loadSettings(): PlaygroundSettings {
   const stored = read<Partial<PlaygroundSettings>>(SETTINGS_KEY, {})
   const rawReasoningEffort = stored.reasoningEffort as string | undefined
   const migratedReasoningEffort = rawReasoningEffort === 'light' ? 'low' : rawReasoningEffort
-  const storedReasoningEffort = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'].includes(migratedReasoningEffort ?? '')
+  const storedReasoningEffort = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'].includes(migratedReasoningEffort ?? '')
     ? migratedReasoningEffort as PlaygroundSettings['reasoningEffort']
     : defaults.reasoningEffort
   return { ...defaults, ...stored, reasoningEffort: storedReasoningEffort }

--- a/web/src/features/playground/lib/types.ts
+++ b/web/src/features/playground/lib/types.ts
@@ -50,11 +50,18 @@ export type GatewayModel = {
   category: string
   ownedBy?: string
   endpointTypes: string[]
+  reasoning?: GatewayModelReasoning
 }
 
 export type ChatProtocol = 'chat' | 'responses' | 'messages'
 
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+
+/** Server-declared reasoning effort spec for a model (from protocol_specs.json via the gateway). */
+export type GatewayModelReasoning = {
+  levels: ReasoningEffort[]
+  thinkingMandatory?: boolean
+}
 
 export type ImageResultItem = {
   id: string

--- a/web/src/features/sites/api/sites.ts
+++ b/web/src/features/sites/api/sites.ts
@@ -266,6 +266,8 @@ export type CanonicalModel = {
   status: string
   created_at: string
   updated_at: string
+  /** Gateway-declared reasoning effort spec (levels/mode/thinking_mandatory); absent when undeclared. */
+  reasoning_effort?: unknown
 }
 
 export type CanonicalModelAlias = {

--- a/web/src/locales/en/playground.json
+++ b/web/src/locales/en/playground.json
@@ -93,6 +93,8 @@
     "noModels": "No models available"
   },
   "effort": {
+    "none": "Off",
+    "minimal": "Minimal",
     "low": "Low",
     "medium": "Medium",
     "high": "High",

--- a/web/src/locales/jp/playground.json
+++ b/web/src/locales/jp/playground.json
@@ -93,6 +93,8 @@
     "noModels": "利用可能なモデルがありません"
   },
   "effort": {
+    "none": "オフ",
+    "minimal": "極低",
     "low": "低",
     "medium": "中",
     "high": "高",

--- a/web/src/locales/zh/playground.json
+++ b/web/src/locales/zh/playground.json
@@ -93,6 +93,8 @@
     "noModels": "暂无可用模型"
   },
   "effort": {
+    "none": "关闭",
+    "minimal": "极低",
     "low": "低",
     "medium": "中",
     "high": "高",


### PR DESCRIPTION
## 改动内容

### 档位规范(protocol_specs.json)
- 按模型族 glob 声明 `reasoning_effort` 块,字段含 `levels` / `mode` / `thinking_mandatory` / `default`;匹配走精确优先 + 最长 glob,新型号自动继承上一代家族配置,零配置接入
- `default` 表示该模型的默认推理档位:gpt-5*/5.6*/6* → medium,claude 全系 → high,glm-5.2/deepseek-v4 → high,kimi-k3/glm-5.3 → max
- `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-6-astra` 以精确条目补满档 `ultra`(精确条目为家族块完整拷贝,仅 levels 不同)

### 网关请求策略(reasoning_effort.go)
- `snap` 模式就近吸附:精确命中透传,未命中按档位秩取最近、平局向上、越界钳制;`passthrough` 模式原样透传(DeepSeek 上游自行吸附)
- wire 值 `auto` 永不透传上游:thinking_mandatory 模型映射到 `default`(未配置则回落最低档),其余模型删除该字段、由上游默认生效
- thinking_mandatory 模型收到显式关闭(`none` / `thinking.type=disabled` / `thinking=false`)时翻转并映射到模型默认档;snap 阶段为此保留 `none` 不抢先重写
- 九条协议编码路径(chat/responses/messages/codex/images/audio/canonical)统一经过该策略

### 元数据暴露
- `/v1/models` 与 `/api/v1/models` 的模型负载携带 `reasoning_effort`(levels/mode/thinking_mandatory/default),别名继承目标模型元数据

### 前端(模型体验页)
- 选择器只展示模型实际支持的档位,不提供 `none` 与 `auto` 选项
- 服务端下发档位优先;未下发时回退到硬编码规则(兜底名单覆盖 sol/terra/astra)
- 归一化逻辑与服务端 snap 语义一致(就近吸附、平局向上)

### 测试
- 后端新增 reasoning_effort_test.go:snap 语义、spec 校验、mandatory 翻转/默认档映射、auto 解析、glob/精确条目继承、端到端策略应用、元数据暴露
- 前端:档位解析、服务端优先、兜底规则、归一化共 29 例;go build / go test / vitest / tsc / eslint 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)