### PR TITLE
feat: 🎸 Kimi 与 GLM 订阅额度耗尽时自动暂停调用直至额度重置

### DIFF
--- a/server/internal/site/quota_probe.go
+++ b/server/internal/site/quota_probe.go
@@ -88,8 +88,13 @@ func (s *Service) runQuotaProbes(ctx context.Context, item store.Site) store.Sit
 		if probeType == QuotaProbeTypeSub2API && result.Status == "ok" {
 			s.recoverSub2APISubscriptionCooldown(ctx, item.ID, credential.ID, result)
 		}
+		freshOK := result.Status == "ok"
 		if result.Status != "ok" {
 			result = preserveQuotaProbeResult(credential.Meta, result)
+		}
+		// 只对本次新鲜成功的探测同步冷却；失败时保留的旧数据不用于冷却判断
+		if freshOK && (probeType == QuotaProbeTypeKimi || probeType == QuotaProbeTypeGLM) {
+			s.syncCodingPlanQuotaCooldown(ctx, item.ID, credential.ID, result)
 		}
 		if result.Status == "ok" {
 			okCount++
@@ -275,6 +280,61 @@ func sub2APISubscriptionQuotaEntry(result QuotaProbeResult, limitWindow string) 
 		}
 	}
 	return QuotaProbeEntry{}, false
+}
+
+// syncCodingPlanQuotaCooldown 按 Kimi/GLM Coding Plan 探测结果冷却或解冻凭据：
+// 5 小时或周额度耗尽（remaining 为 0）且带未来重置时间时，把凭据冷却到最晚的
+// 重置时间，不在没额度的时候继续调用；所有窗口都有额度时解除探测冷却（窗口
+// 提前重置或升档都能及时恢复）。只动探测自己设置的冷却，网关因鉴权/限流设置
+// 的冷却不受影响。Best-effort。
+func (s *Service) syncCodingPlanQuotaCooldown(ctx context.Context, siteID uuid.UUID, credentialID uuid.UUID, result QuotaProbeResult) {
+	if result.Status != "ok" || credentialID == uuid.Nil {
+		return
+	}
+	repo := store.NewRouteCooldownRepository(s.db.DB())
+	deadline, windows := codingPlanQuotaCooldownDeadline(result, time.Now())
+	if deadline.IsZero() {
+		_, _ = repo.ClearActiveMatching(ctx, store.ClearActiveCooldownFilter{
+			SiteID:           siteID,
+			SiteCredentialID: uuid.NullUUID{UUID: credentialID, Valid: true},
+			Reasons:          []string{store.CooldownReasonCodingPlanQuotaExhausted},
+		})
+		return
+	}
+	_, _ = repo.Activate(ctx, store.ActivateRouteCooldownParams{
+		SiteID:           siteID,
+		SiteCredentialID: credentialID,
+		Scope:            "credential",
+		Source:           "quota_probe",
+		Reason:           store.CooldownReasonCodingPlanQuotaExhausted,
+		ActiveUntil:      deadline,
+		Metadata: store.JSON(jsonBytes(map[string]any{
+			"exhausted_windows": windows,
+			"reset_at":          deadline.UTC().Format(time.RFC3339),
+		})),
+	})
+}
+
+// codingPlanQuotaCooldownDeadline 从探测结果里找出已耗尽的窗口（remaining 为 0 且
+// 带未来重置时间），返回最晚的重置时间作为冷却截止——所有窗口都有额度时站点才
+// 可用，所以要等到最后一个耗尽窗口重置。没有耗尽窗口时返回零值。
+func codingPlanQuotaCooldownDeadline(result QuotaProbeResult, now time.Time) (time.Time, []string) {
+	var deadline time.Time
+	windows := []string{}
+	for _, entry := range result.Entries {
+		if entry.Remaining == nil || *entry.Remaining > 0 || entry.ResetAt == nil {
+			continue
+		}
+		resetAt, err := time.Parse(time.RFC3339, *entry.ResetAt)
+		if err != nil || !resetAt.After(now) {
+			continue
+		}
+		windows = append(windows, entry.Label)
+		if resetAt.After(deadline) {
+			deadline = resetAt
+		}
+	}
+	return deadline, windows
 }
 
 func quotaProbeCredentialEligible(credentialType string) bool {

--- a/server/internal/site/quota_probe_test.go
+++ b/server/internal/site/quota_probe_test.go
@@ -1067,3 +1067,137 @@ func TestGLMPlanName(t *testing.T) {
 		t.Fatalf("glmPlanName(旗舰版) = %q, want valid non-empty UTF-8", got)
 	}
 }
+
+func TestCodingPlanQuotaCooldownDeadline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	zero := 0.0
+	positive := 42.0
+	future1h := now.Add(time.Hour).Format(time.RFC3339)
+	future3d := now.Add(3 * 24 * time.Hour).Format(time.RFC3339)
+	past := now.Add(-time.Hour).Format(time.RFC3339)
+
+	// 两个窗口都耗尽时，冷却截止取最晚的重置时间（所有窗口都有额度才可用）
+	deadline, windows := codingPlanQuotaCooldownDeadline(QuotaProbeResult{Entries: []QuotaProbeEntry{
+		{Label: "five_hour", Remaining: &zero, ResetAt: &future1h},
+		{Label: "weekly", Remaining: &zero, ResetAt: &future3d},
+	}}, now)
+	if !deadline.Equal(now.Add(3*24*time.Hour)) || len(windows) != 2 {
+		t.Fatalf("deadline = %v windows = %v, want 3d deadline with both windows", deadline, windows)
+	}
+
+	// 只有 5 小时窗耗尽时按 5 小时窗重置时间冷却
+	deadline, windows = codingPlanQuotaCooldownDeadline(QuotaProbeResult{Entries: []QuotaProbeEntry{
+		{Label: "five_hour", Remaining: &zero, ResetAt: &future1h},
+		{Label: "weekly", Remaining: &positive, ResetAt: &future3d},
+	}}, now)
+	if !deadline.Equal(now.Add(time.Hour)) || len(windows) != 1 || windows[0] != "five_hour" {
+		t.Fatalf("deadline = %v windows = %v, want 1h deadline with five_hour only", deadline, windows)
+	}
+
+	// 耗尽但没有重置时间、重置时间已过、重置时间无法解析：都不冷却
+	for name, entries := range map[string][]QuotaProbeEntry{
+		"no reset":      {{Label: "five_hour", Remaining: &zero}},
+		"past reset":    {{Label: "five_hour", Remaining: &zero, ResetAt: &past}},
+		"invalid reset": {{Label: "five_hour", Remaining: &zero, ResetAt: new("soon")}},
+		"quota remains": {{Label: "five_hour", Remaining: &positive, ResetAt: &future1h}},
+		"nil remaining": {{Label: "five_hour", ResetAt: &future1h}},
+	} {
+		if deadline, windows := codingPlanQuotaCooldownDeadline(QuotaProbeResult{Entries: entries}, now); !deadline.IsZero() || len(windows) != 0 {
+			t.Fatalf("%s: deadline = %v windows = %v, want zero", name, deadline, windows)
+		}
+	}
+}
+
+func TestSyncCodingPlanQuotaCooldownActivatesOnExhaustedWindow(t *testing.T) {
+	t.Parallel()
+
+	credentialID := uuid.New()
+	reset := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+	resetStr := reset.Format(time.RFC3339)
+	zero := 0.0
+
+	var created *store.RouteCooldown
+	db := siteTransactionPostgresGorm(t)
+	siteReplaceUpdateCallback(t, db, func(tx *gorm.DB) {
+		tx.RowsAffected = 1
+		tx.Statement.RowsAffected = 1
+	})
+	siteReplaceCreateCallback(t, db, func(tx *gorm.DB) {
+		item, ok := tx.Statement.Dest.(*store.RouteCooldown)
+		if !ok {
+			tx.AddError(gorm.ErrInvalidData)
+			return
+		}
+		copied := *item
+		created = &copied
+		tx.RowsAffected = 1
+		tx.Statement.RowsAffected = 1
+	})
+	service := NewService(siteStoreWithGorm(t, db), siteTestMasterKey)
+
+	service.syncCodingPlanQuotaCooldown(context.Background(), uuid.New(), credentialID, QuotaProbeResult{
+		Status:  "ok",
+		Entries: []QuotaProbeEntry{{Label: "five_hour", Remaining: &zero, ResetAt: &resetStr}},
+	})
+
+	if created == nil {
+		t.Fatal("expected a credential cooldown to be activated")
+	}
+	if !created.SiteCredentialID.Valid || created.SiteCredentialID.UUID != credentialID {
+		t.Fatalf("cooldown credential = %+v, want %v", created.SiteCredentialID, credentialID)
+	}
+	if created.Scope != "credential" || created.Source != "quota_probe" || created.Reason != store.CooldownReasonCodingPlanQuotaExhausted {
+		t.Fatalf("cooldown scope/source/reason = %q/%q/%q", created.Scope, created.Source, created.Reason)
+	}
+	if !created.ActiveUntil.Equal(reset) {
+		t.Fatalf("cooldown active_until = %v, want %v", created.ActiveUntil, reset)
+	}
+	meta := siteMustJSONMap(t, created.Metadata)
+	if meta["reset_at"] != resetStr {
+		t.Fatalf("cooldown metadata reset_at = %v, want %v", meta["reset_at"], resetStr)
+	}
+	windows, ok := meta["exhausted_windows"].([]any)
+	if !ok || len(windows) != 1 || windows[0] != "five_hour" {
+		t.Fatalf("cooldown metadata exhausted_windows = %v, want [five_hour]", meta["exhausted_windows"])
+	}
+}
+
+func TestSyncCodingPlanQuotaCooldownClearsWhenQuotaRecovers(t *testing.T) {
+	t.Parallel()
+
+	updates := 0
+	service := siteServiceWithCallbacks(t, siteGormCallbacks{
+		update: func(tx *gorm.DB) {
+			updates++
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+	})
+	positive := 80.0
+	service.syncCodingPlanQuotaCooldown(context.Background(), uuid.New(), uuid.New(), QuotaProbeResult{
+		Status:  "ok",
+		Entries: []QuotaProbeEntry{{Label: "five_hour", Remaining: &positive}},
+	})
+	if updates != 1 {
+		t.Fatalf("cooldown clears = %d, want 1 (clear probe-set cooldown on recovery)", updates)
+	}
+}
+
+func TestSyncCodingPlanQuotaCooldownSkipsFailedProbe(t *testing.T) {
+	t.Parallel()
+
+	updates := 0
+	service := siteServiceWithCallbacks(t, siteGormCallbacks{
+		update: func(tx *gorm.DB) {
+			updates++
+			tx.RowsAffected = 1
+			tx.Statement.RowsAffected = 1
+		},
+	})
+	service.syncCodingPlanQuotaCooldown(context.Background(), uuid.New(), uuid.New(), QuotaProbeResult{Status: "error"})
+	if updates != 0 {
+		t.Fatalf("cooldown writes = %d, want 0 for failed probe", updates)
+	}
+}

--- a/server/internal/store/route_cooldown_repository.go
+++ b/server/internal/store/route_cooldown_repository.go
@@ -41,6 +41,10 @@ const (
 	CooldownReasonUpstreamCredentialLimited         = "upstream_credential_limited"
 	CooldownReasonUpstreamSubscriptionLimitExceeded = "upstream_subscription_limit_exceeded"
 	CooldownReasonOpenCodeGoUsageLimitReached       = "opencode_go_usage_limit_reached"
+	// CooldownReasonCodingPlanQuotaExhausted marks a cooldown created by a Kimi/GLM
+	// Coding Plan quota probe that observed an exhausted 5-hour or weekly window
+	// with a known reset time, so the credential is skipped until the window resets.
+	CooldownReasonCodingPlanQuotaExhausted = "coding_plan_quota_exhausted"
 )
 
 func TransientRouteCooldown(item RouteCooldown) bool {


### PR DESCRIPTION
## 改动内容

**订阅额度耗尽自动冷却**（`server/internal/site/quota_probe.go`）

- 改前：Kimi / GLM Coding Plan 的额度探测只展示剩余量；额度耗尽后请求仍会继续打到站点，直到被上游拒绝才被动冷却。
- 改后：每次站点刷新探测成功后，若 5 小时或周窗口 `remaining` 为 0 且带未来重置时间，给该凭据设置 credential 级冷却，截止时间为所有耗尽窗口中**最晚**的重置时间（所有窗口都有额度时站点才可用）。冷却到期后路由层自动恢复，不依赖下次探测。
- 主动恢复：探测发现所有窗口都有额度（官方提前重置、用户升档）时，立即清除探测冷却，不等重置时间到达。
- 隔离性：只新增/清除探测自己设置的冷却（新冷却原因 `coding_plan_quota_exhausted`，source=`quota_probe`，重复探测时同 scope 同 source 先清后建、自我替换）；网关因鉴权、限流等原因设置的冷却不受影响。
- 冷却粒度为凭据级：多 key 站点只冷却耗尽的那把 key，单 key 站点效果等同整站冷却，与 Codex / sub2api 的既有冷却粒度一致。

**边界处理**

- 探测失败时保留的历史数据不参与冷却判断，只有本次新鲜成功的探测才会同步冷却。
- 窗口耗尽但拿不到重置时间、重置时间已过、重置时间无法解析时不冷却——宁可放过不可猜错。

**测试**（`server/internal/site/quota_probe_test.go`，4 个新用例）

- 冷却截止时间判定表测试：双窗耗尽取最晚、单窗耗尽、无重置时间/重置已过/非法重置/额度充足/remaining 缺失均不冷却。
- 冷却创建断言：credential 绑定、scope/source/reason、active_until 与 metadata（耗尽窗口列表 + 重置时间）。
- 额度恢复时清除探测冷却；失败探测不写任何冷却。

## 依赖关系

堆叠在 #55 之上（用到 GLM 探测产出的窗口数据与重置时间），#55 合并后本 PR 的 diff 会自动收窄为冷却机制本身。

## 验证

- `go build`、`go test ./...` 通过（`internal/oauth` 一个失败在 main 上同样存在，与本改动无关）
- `govulncheck` 0 个受影响漏洞

🤖 Generated with [Claude Code](https://claude.com/claude-code)