### PR TITLE
fix: 🐛 修复模型体验会话 ID 必须为 UUID

### DIFF
--- a/web/src/features/playground/lib/image-store.test.ts
+++ b/web/src/features/playground/lib/image-store.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isUUID } from '@/features/playground/lib/storage'
+import { loadImageConversationsAsync } from '@/features/playground/lib/image-store'
+
+const values = new Map<string, string>()
+
+function installIndexedDB(initial: Record<string, unknown>) {
+  const records = new Map(Object.entries(initial))
+  const database = {
+    objectStoreNames: { contains: () => true },
+    transaction: (_storeName: string, mode: IDBTransactionMode) => {
+      const transaction = {
+        objectStore: () => ({
+          get: (key: string) => {
+            const request = { result: records.get(key) } as IDBRequest<unknown>
+            queueMicrotask(() => request.onsuccess?.(new Event('success')))
+            return request
+          },
+          put: (value: unknown, key: string) => {
+            records.set(key, value)
+          },
+        }),
+      } as IDBTransaction
+      if (mode === 'readwrite') queueMicrotask(() => transaction.oncomplete?.(new Event('complete')))
+      return transaction
+    },
+    close: () => undefined,
+  } as unknown as IDBDatabase
+  vi.stubGlobal('indexedDB', {
+    open: () => {
+      const request = { result: database } as IDBOpenDBRequest
+      queueMicrotask(() => request.onsuccess?.(new Event('success')))
+      return request
+    },
+  })
+  return records
+}
+
+beforeEach(() => {
+  values.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  })
+  vi.stubGlobal('indexedDB', undefined)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('image conversation storage', () => {
+  it('migrates and persists legacy ids already stored in IndexedDB', async () => {
+    const records = installIndexedDB({
+      'image-conversations': [{
+        id: 'id-indexeddb-image',
+        title: 'Stored image',
+        entries: [],
+        createdAt: 1,
+        updatedAt: 1,
+        serverPersisted: true,
+      }],
+    })
+
+    const [conversation] = await loadImageConversationsAsync()
+    const [persisted] = records.get('image-conversations') as Array<{ id: string; serverPersisted?: boolean }>
+
+    expect(isUUID(conversation.id)).toBe(true)
+    expect(conversation.serverPersisted).toBe(false)
+    expect(persisted).toMatchObject({ id: conversation.id, serverPersisted: false })
+  })
+
+  it('migrates legacy image conversation ids while keeping entries', async () => {
+    values.set('xlyra-playground-image-conversations', JSON.stringify([{
+      id: 'id-legacy-image',
+      title: 'Legacy image',
+      entries: [{
+        id: 'entry-1',
+        mode: 'generation',
+        model: 'gpt-image',
+        prompt: 'a lighthouse',
+        images: [],
+        createdAt: 1,
+      }],
+      createdAt: 1,
+      updatedAt: 1,
+      serverPersisted: true,
+    }]))
+
+    const [conversation] = await loadImageConversationsAsync()
+
+    expect(isUUID(conversation.id)).toBe(true)
+    expect(conversation.serverPersisted).toBe(false)
+    expect(conversation.entries[0].id).toBe('entry-1')
+    expect(values.has('xlyra-playground-image-conversations')).toBe(false)
+  })
+})

--- a/web/src/features/playground/lib/image-store.test.ts
+++ b/web/src/features/playground/lib/image-store.test.ts
@@ -20,7 +20,7 @@ function installIndexedDB(initial: Record<string, unknown>) {
             records.set(key, value)
           },
         }),
-      } as IDBTransaction
+      } as unknown as IDBTransaction
       if (mode === 'readwrite') queueMicrotask(() => transaction.oncomplete?.(new Event('complete')))
       return transaction
     },

--- a/web/src/features/playground/lib/image-store.test.ts
+++ b/web/src/features/playground/lib/image-store.test.ts
@@ -86,13 +86,39 @@ describe('image conversation storage', () => {
       createdAt: 1,
       updatedAt: 1,
       serverPersisted: true,
+      lastOrdinal: 7,
+      activeRun: { id: 'run-1', status: 'running' },
     }]))
 
     const [conversation] = await loadImageConversationsAsync()
 
     expect(isUUID(conversation.id)).toBe(true)
     expect(conversation.serverPersisted).toBe(false)
+    expect(conversation.lastOrdinal).toBeUndefined()
+    expect(conversation.activeRun).toBeUndefined()
     expect(conversation.entries[0].id).toBe('entry-1')
     expect(values.has('xlyra-playground-image-conversations')).toBe(false)
+  })
+
+  it('keeps valid UUID image conversations unchanged', async () => {
+    const id = '123e4567-e89b-42d3-a456-426614174000'
+    const records = installIndexedDB({
+      'image-conversations': [{
+        id,
+        title: 'Stored image',
+        entries: [],
+        createdAt: 1,
+        updatedAt: 1,
+        serverPersisted: true,
+        lastOrdinal: 7,
+      }],
+    })
+
+    const [conversation] = await loadImageConversationsAsync()
+
+    expect(conversation.id).toBe(id)
+    expect(conversation.serverPersisted).toBe(true)
+    expect(conversation.lastOrdinal).toBe(7)
+    expect(records.get('image-conversations')).toMatchObject([{ id, serverPersisted: true }])
   })
 })

--- a/web/src/features/playground/lib/image-store.ts
+++ b/web/src/features/playground/lib/image-store.ts
@@ -1,4 +1,4 @@
-import { newId } from '@/features/playground/lib/storage'
+import { migrateConversationIds, newId } from '@/features/playground/lib/storage'
 import type { ImageConversation, ImageHistoryEntry } from '@/features/playground/lib/types'
 
 const DB_NAME = 'xlyra-playground'
@@ -70,7 +70,7 @@ function migrateFromLocalStorage(): ImageConversation[] {
   const stored = readLocalStorage<ImageConversation[]>(LEGACY_CONVERSATIONS_KEY)
   if (Array.isArray(stored) && stored.length > 0) {
     removeLocalStorageItem(LEGACY_CONVERSATIONS_KEY)
-    return stored
+    return migrateConversationIds(stored).items
   }
   const flat = readLocalStorage<ImageHistoryEntry[]>(LEGACY_FLAT_KEY)
   if (Array.isArray(flat) && flat.length > 0) {
@@ -93,7 +93,9 @@ function migrateFromLocalStorage(): ImageConversation[] {
 export async function loadImageConversationsAsync(): Promise<ImageConversation[]> {
   const stored = await idbGet<ImageConversation[]>(RECORD_KEY).catch(() => null)
   if (Array.isArray(stored) && stored.length > 0) {
-    return stored
+    const migrated = migrateConversationIds(stored)
+    if (migrated.changed) await idbSet(RECORD_KEY, migrated.items).catch(() => undefined)
+    return migrated.items
   }
   const migrated = migrateFromLocalStorage()
   if (migrated.length > 0) {

--- a/web/src/features/playground/lib/storage.test.ts
+++ b/web/src/features/playground/lib/storage.test.ts
@@ -16,6 +16,27 @@ afterEach(() => {
 })
 
 describe('newId', () => {
+  it('prefers crypto.randomUUID when available', () => {
+    const expected = '123e4567-e89b-42d3-a456-426614174000'
+    vi.stubGlobal('crypto', { randomUUID: () => expected })
+
+    expect(newId()).toBe(expected)
+  })
+
+  it('falls back when crypto.randomUUID throws', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => {
+        throw new Error('unavailable')
+      },
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(1)
+        return bytes
+      },
+    })
+
+    expect(isUUID(newId())).toBe(true)
+  })
+
   it('returns a UUID when randomUUID is unavailable in an insecure context', () => {
     vi.stubGlobal('crypto', {
       getRandomValues: (bytes: Uint8Array) => {
@@ -125,6 +146,69 @@ describe('conversation storage', () => {
     expect(conversation.activeRun).toBeUndefined()
     expect(conversation.title).toBe('Legacy')
     expect(JSON.parse(values.get('xlyra-playground-conversations') ?? '[]')[0].id).toBe(conversation.id)
+  })
+
+  it('keeps valid UUID conversations unchanged', () => {
+    const id = '123e4567-e89b-42d3-a456-426614174000'
+    values.set('xlyra-playground-conversations', JSON.stringify([{
+      id,
+      title: 'Valid',
+      model: 'gpt-test',
+      systemPrompt: '',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+      serverPersisted: true,
+      lastOrdinal: 4,
+    }]))
+
+    const [conversation] = loadConversations()
+
+    expect(conversation.id).toBe(id)
+    expect(conversation.serverPersisted).toBe(true)
+    expect(conversation.lastOrdinal).toBe(4)
+    expect(JSON.parse(values.get('xlyra-playground-conversations') ?? '[]')[0].id).toBe(id)
+  })
+
+  it('reassigns duplicated conversation ids to a fresh UUID', () => {
+    const id = '123e4567-e89b-42d3-a456-426614174000'
+    const build = (title: string) => ({
+      id,
+      title,
+      model: 'gpt-test',
+      systemPrompt: '',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+      serverPersisted: true,
+    })
+    values.set('xlyra-playground-conversations', JSON.stringify([build('First'), build('Second')]))
+
+    const [first, second] = loadConversations()
+
+    expect(first.id).toBe(id)
+    expect(first.serverPersisted).toBe(true)
+    expect(second.id).not.toBe(id)
+    expect(isUUID(second.id)).toBe(true)
+    expect(second.serverPersisted).toBe(false)
+    expect(second.title).toBe('Second')
+  })
+
+  it('keeps migrated ids stable across repeated loads', () => {
+    values.set('xlyra-playground-conversations', JSON.stringify([{
+      id: 'id-legacy-123',
+      title: 'Legacy',
+      model: 'gpt-test',
+      systemPrompt: '',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+    }]))
+
+    const [first] = loadConversations()
+    const [second] = loadConversations()
+
+    expect(second.id).toBe(first.id)
   })
 
   it('persists attachment metadata without storing the binary payload', () => {

--- a/web/src/features/playground/lib/storage.test.ts
+++ b/web/src/features/playground/lib/storage.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { loadConversations, loadSettings, saveConversations, saveSettings } from '@/features/playground/lib/storage'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isUUID, loadConversations, loadSettings, newId, saveConversations, saveSettings } from '@/features/playground/lib/storage'
 
 const values = new Map<string, string>()
 
@@ -8,6 +8,32 @@ beforeEach(() => {
   vi.stubGlobal('localStorage', {
     getItem: (key: string) => values.get(key) ?? null,
     setItem: (key: string, value: string) => values.set(key, value),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('newId', () => {
+  it('returns a UUID when randomUUID is unavailable in an insecure context', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(0)
+        return bytes
+      },
+    })
+
+    const id = newId()
+
+    expect(isUUID(id)).toBe(true)
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  it('still returns a UUID when Web Crypto is unavailable', () => {
+    vi.stubGlobal('crypto', {})
+
+    expect(isUUID(newId())).toBe(true)
   })
 })
 
@@ -77,6 +103,30 @@ describe('loadSettings', () => {
 })
 
 describe('conversation storage', () => {
+  it('migrates legacy conversation ids before they reach the server', () => {
+    values.set('xlyra-playground-conversations', JSON.stringify([{
+      id: 'id-legacy-123',
+      title: 'Legacy',
+      model: 'gpt-test',
+      systemPrompt: '',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+      serverPersisted: true,
+      lastOrdinal: 4,
+      activeRun: { id: 'run-1', status: 'running' },
+    }]))
+
+    const [conversation] = loadConversations()
+
+    expect(isUUID(conversation.id)).toBe(true)
+    expect(conversation.serverPersisted).toBe(false)
+    expect(conversation.lastOrdinal).toBeUndefined()
+    expect(conversation.activeRun).toBeUndefined()
+    expect(conversation.title).toBe('Legacy')
+    expect(JSON.parse(values.get('xlyra-playground-conversations') ?? '[]')[0].id).toBe(conversation.id)
+  })
+
   it('persists attachment metadata without storing the binary payload', () => {
     saveConversations([{
       id: 'conversation-1',

--- a/web/src/features/playground/lib/storage.ts
+++ b/web/src/features/playground/lib/storage.ts
@@ -5,11 +5,76 @@ const SETTINGS_KEY = 'xlyra-playground-settings'
 
 const MAX_CONVERSATIONS = 50
 
-export function newId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function isUUID(value: unknown): value is string {
+  return typeof value === 'string' && UUID_PATTERN.test(value)
+}
+
+function randomUUIDFromValues(): string {
+  const bytes = new Uint8Array(16)
+  const cryptoObject = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined
+  let filled = false
+  if (cryptoObject && typeof cryptoObject.getRandomValues === 'function') {
+    try {
+      cryptoObject.getRandomValues(bytes)
+      filled = true
+    } catch {
+      filled = false
+    }
   }
-  return `id-${Math.random().toString(36).slice(2)}-${Date.now()}`
+  if (!filled) {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256)
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+export function newId(): string {
+  const cryptoObject = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined
+  if (cryptoObject && typeof cryptoObject.randomUUID === 'function') {
+    try {
+      const value = cryptoObject.randomUUID()
+      if (isUUID(value)) return value
+    } catch {
+      // Continue with the UUID v4 fallback below.
+    }
+  }
+  return randomUUIDFromValues()
+}
+
+type ConversationIdentity = {
+  id: string
+  serverPersisted?: boolean
+  lastOrdinal?: number
+  activeRun?: unknown
+}
+
+export function migrateConversationIds<T extends ConversationIdentity>(items: T[]): { items: T[]; changed: boolean } {
+  const seen = new Set<string>()
+  let changed = false
+  const migrated = items.map((conversation) => {
+    if (isUUID(conversation.id) && !seen.has(conversation.id)) {
+      seen.add(conversation.id)
+      return conversation
+    }
+    let id = newId()
+    while (seen.has(id)) id = newId()
+    seen.add(id)
+    changed = true
+    return {
+      ...conversation,
+      id,
+      serverPersisted: false,
+      lastOrdinal: undefined,
+      activeRun: undefined,
+    }
+  })
+  return { items: migrated, changed }
 }
 
 function read<T>(key: string, fallback: T): T {
@@ -32,7 +97,10 @@ function write(key: string, value: unknown) {
 
 export function loadConversations(): Conversation[] {
   const items = read<Conversation[]>(CONVERSATIONS_KEY, [])
-  return Array.isArray(items) ? items : []
+  if (!Array.isArray(items)) return []
+  const migrated = migrateConversationIds(items)
+  if (migrated.changed) saveConversations(migrated.items)
+  return migrated.items
 }
 
 export function saveConversations(items: Conversation[]) {


### PR DESCRIPTION
## 改动内容

原 PR #59（已合入 test），单独摘出合入 main，内容与 #59 完全一致。

### `storage.ts`
- 新增 `isUUID` 校验与 `migrateConversationIds`：加载本地会话时对非 UUID 的旧会话 id 重新生成 UUID，`serverPersisted` 置为 `false` 强制重新同步服务端，并丢弃 `lastOrdinal`、`activeRun` 等易过期的运行态字段
- `newId` 生成的 id 改为 UUID 格式

### `image-store.ts`
- `migrateFromLocalStorage` 迁移 localStorage 旧数据时走 `migrateConversationIds`
- IndexedDB 读出的存量会话同样做 id 迁移，迁移结果写回 IndexedDB

### 测试
- 新增 `image-store.test.ts`：覆盖 IndexedDB 存量旧 id 迁移并回写、localStorage 旧数据迁移保留 entries、合法 UUID 会话不受影响三种场景
- `storage.test.ts` 补充 id 迁移的回归用例，并修正 IndexedDB mock 的类型

🤖 Generated with [Claude Code](https://claude.com/claude-code)