### PR TITLE
fix: 🐛 修复 DeepSeek 思考内容跨协议回传

### DIFF
--- a/server/internal/gateway/protocol_canonical.go
+++ b/server/internal/gateway/protocol_canonical.go
@@ -683,6 +683,14 @@ func canonicalMessagesFromResponsesInput(raw any) []canonicalMessage {
 				itemType = "message"
 			}
 			switch itemType {
+			case "reasoning":
+				if thinking := canonicalThinkingFromResponsesItem(entry); len(thinking) > 0 {
+					if len(messages) > 0 && messages[len(messages)-1].Type == "message" && messages[len(messages)-1].Role == "assistant" {
+						messages[len(messages)-1].Thinking = append(messages[len(messages)-1].Thinking, thinking...)
+					} else {
+						messages = append(messages, canonicalMessage{Type: "message", Role: "assistant", Thinking: thinking})
+					}
+				}
 			case "message", "":
 				role := strings.TrimSpace(anyString(entry["role"]))
 				if role == "" {

--- a/server/internal/gateway/protocol_openai_responses_test.go
+++ b/server/internal/gateway/protocol_openai_responses_test.go
@@ -1120,6 +1120,47 @@ func TestThinkingRoundtripModelDegradesToolResultWhenThinkingCacheMissing(t *tes
 	}
 }
 
+func TestDeepSeekAnthropicResponsesPreservesThinkingSignature(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := canonicalRequestFromOpenAIResponsesPayload(map[string]any{
+		"model": "deepseek-v4-flash",
+		"input": []any{
+			map[string]any{
+				"type":               "reasoning",
+				"content":            []any{map[string]any{"type": "reasoning_text", "text": "private reasoning"}},
+				"thinking_signature": "sig_deepseek",
+			},
+			map[string]any{
+				"type":    "message",
+				"role":    "assistant",
+				"content": []any{map[string]any{"type": "output_text", "text": "I will call a tool."}},
+			},
+			map[string]any{"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": `{}`},
+			map[string]any{"type": "function_call_output", "call_id": "call_1", "output": "result"},
+		},
+	}, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("canonicalRequestFromOpenAIResponsesPayload returned error: %v", err)
+	}
+
+	protocol := newProviderAnthropicMessagesProtocolAdapter("deepseek", alternateProtocolDefinition{}, canonicalProtocolOpenAIResponses)
+	payload, err := protocol.BuildUpstreamPayload(gatewayRequest{DownstreamPath: gatewayEndpointResponses, Canonical: &canonical}, routeengine.Candidate{
+		Site:  routeengine.CandidateSite{SiteType: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Model: routeengine.CandidateModel{UpstreamName: "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+
+	messages := payload["messages"].([]any)
+	content := messages[0].(map[string]any)["content"].([]any)
+	thinking := content[0].(map[string]any)
+	if thinking["type"] != "thinking" || thinking["signature"] != "sig_deepseek" {
+		t.Fatalf("thinking block = %#v, want returned signature", thinking)
+	}
+}
+
 func TestProviderAnthropicResponsesOmitsUnpairedToolCalls(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/gateway/thinking_roundtrip.go
+++ b/server/internal/gateway/thinking_roundtrip.go
@@ -21,7 +21,7 @@ func canonicalThinkingFromResponsesItem(item map[string]any) []canonicalThinking
 	itemType := strings.TrimSpace(anyString(item["type"]))
 	if itemType == "reasoning" {
 		if thinking := responsesReasoningText(item["content"]); thinking != "" {
-			return []canonicalThinkingBlock{{Type: "thinking", Thinking: thinking}}
+			return []canonicalThinkingBlock{{Type: "thinking", Thinking: thinking, Signature: firstNonEmptyGatewayString(anyString(item["thinking_signature"]), anyString(item["signature"]))}}
 		}
 	}
 	return canonicalThinkingFromChatMessage(item)
@@ -84,12 +84,19 @@ func responsesReasoningItem(blocks []canonicalThinkingBlock) map[string]any {
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}
-	return map[string]any{
+	item := map[string]any{
 		"type": "reasoning",
 		"content": []any{
 			map[string]any{"type": "reasoning_text", "text": text},
 		},
 	}
+	for _, block := range blocks {
+		if signature := strings.TrimSpace(block.Signature); signature != "" {
+			item["thinking_signature"] = signature
+			break
+		}
+	}
+	return item
 }
 
 func canonicalThinkingFromAnthropicBlock(block map[string]any) (canonicalThinkingBlock, bool) {

--- a/server/internal/gateway/thinking_roundtrip_test.go
+++ b/server/internal/gateway/thinking_roundtrip_test.go
@@ -132,6 +132,18 @@ func TestReasoningContentEncodersSkipBlankBlocks(t *testing.T) {
 	}
 }
 
+func TestResponsesReasoningItemPreservesThinkingSignature(t *testing.T) {
+	t.Parallel()
+	item := responsesReasoningItem([]canonicalThinkingBlock{{Thinking: "private", Signature: "sig_deepseek"}})
+	if item["thinking_signature"] != "sig_deepseek" {
+		t.Fatalf("thinking_signature = %#v, want sig_deepseek", item["thinking_signature"])
+	}
+	blocks := canonicalThinkingFromResponsesItem(item)
+	if len(blocks) != 1 || blocks[0].Signature != "sig_deepseek" {
+		t.Fatalf("decoded thinking blocks = %#v, want preserved signature", blocks)
+	}
+}
+
 func TestResponsesOutputContentAsAnyPreservesAnnotations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 问题
下游请求 /v1/responses 转换为 DeepSeek Anthropic Messages 协议时，历史 Responses reasoning 内容未完整进入 assistant thinking round-trip，导致 DeepSeek 返回 content[].thinking 必须回传的请求错误。

## 修复
- 将 Responses reasoning item 纳入 canonical assistant 消息。
- 保留 thinking_signature / signature，转换到 Anthropic Messages 时输出为 thinking.signature。
- 合并相邻 reasoning 与 assistant 消息，避免生成连续的 assistant turn。
- 增加跨协议回归测试。

## 验证
- go test ./internal/gateway 通过。
- go test ./...：除既存 OAuth PostgreSQL smoke test 因测试数据库 oauth_connections.raw_profile 非空约束失败外，其余通过。
- govulncheck ./... 通过，未发现代码实际调用的漏洞。