### PR TITLE
fix: 修复 DeepSeek thinking 与工具调用被拆分到两条消息导致 400 错误

### DIFF
--- a/server/internal/gateway/protocol_anthropic_messages.go
+++ b/server/internal/gateway/protocol_anthropic_messages.go
@@ -607,6 +607,20 @@ func encodeCanonicalMessagesAsAnthropicMessages(messages []canonicalMessage) []a
 		case "function_call":
 			next, toolUseBlocks, toolResultBlocks := encodeConsecutiveCanonicalToolRoundTrip(messages, i)
 			if len(toolUseBlocks) > 0 {
+				// If the previous output is already an assistant message (e.g. one that
+				// contains thinking blocks), merge the tool_use blocks into it rather than
+				// emitting a second consecutive assistant message. Providers like DeepSeek
+				// require thinking and tool_use to appear in the same content array.
+				if len(out) > 0 {
+					if prev, ok := out[len(out)-1].(map[string]any); ok && prev["role"] == "assistant" {
+						if prevContent, ok := prev["content"].([]any); ok {
+							prev["content"] = append(prevContent, toolUseBlocks...)
+							out = append(out, map[string]any{"role": "user", "content": toolResultBlocks})
+							i = next
+							continue
+						}
+					}
+				}
 				out = append(out,
 					map[string]any{"role": "assistant", "content": toolUseBlocks},
 					map[string]any{"role": "user", "content": toolResultBlocks},

--- a/server/internal/gateway/protocol_canonical.go
+++ b/server/internal/gateway/protocol_canonical.go
@@ -696,13 +696,22 @@ func canonicalMessagesFromResponsesInput(raw any) []canonicalMessage {
 				if role == "" {
 					role = "user"
 				}
-				messages = append(messages, canonicalMessage{
+				message := canonicalMessage{
 					Type:       "message",
 					Role:       role,
 					RawContent: entry["content"],
 					Content:    canonicalContentPartsFromResponsesContent(entry["content"]),
 					Thinking:   canonicalThinkingFromResponsesItem(entry),
-				})
+				}
+				if role == "assistant" && len(messages) > 0 {
+					previous := &messages[len(messages)-1]
+					if previous.Type == "message" && previous.Role == "assistant" && len(previous.Content) == 0 && previous.RawContent == nil {
+						message.Thinking = append(previous.Thinking, message.Thinking...)
+						messages[len(messages)-1] = message
+						break
+					}
+				}
+				messages = append(messages, message)
 			case "function_call":
 				callID := strings.TrimSpace(anyString(entry["call_id"]))
 				if callID == "" {

--- a/server/internal/gateway/protocol_openai_responses_test.go
+++ b/server/internal/gateway/protocol_openai_responses_test.go
@@ -1143,6 +1143,9 @@ func TestDeepSeekAnthropicResponsesPreservesThinkingSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonicalRequestFromOpenAIResponsesPayload returned error: %v", err)
 	}
+	if len(canonical.Messages) != 3 || canonical.Messages[0].Role != "assistant" || len(canonical.Messages[0].Thinking) != 1 || len(canonical.Messages[0].Content) != 1 {
+		t.Fatalf("canonical messages = %#v, want reasoning merged into assistant message", canonical.Messages)
+	}
 
 	protocol := newProviderAnthropicMessagesProtocolAdapter("deepseek", alternateProtocolDefinition{}, canonicalProtocolOpenAIResponses)
 	payload, err := protocol.BuildUpstreamPayload(gatewayRequest{DownstreamPath: gatewayEndpointResponses, Canonical: &canonical}, routeengine.Candidate{
@@ -1158,6 +1161,85 @@ func TestDeepSeekAnthropicResponsesPreservesThinkingSignature(t *testing.T) {
 	thinking := content[0].(map[string]any)
 	if thinking["type"] != "thinking" || thinking["signature"] != "sig_deepseek" {
 		t.Fatalf("thinking block = %#v, want returned signature", thinking)
+	}
+}
+
+func TestDeepSeekAnthropicThinkingAndToolUseInSameAssistantMessage(t *testing.T) {
+	t.Parallel()
+
+	// DeepSeek requires thinking, text, and tool_use blocks to all appear inside
+	// a single assistant message. Previously the encoder emitted two consecutive
+	// assistant messages — one with thinking+text and one with tool_use — which
+	// caused a 400 "content[].thinking must be passed back" error.
+	protocol := newProviderAnthropicMessagesProtocolAdapter("deepseek", alternateProtocolDefinition{}, canonicalProtocolOpenAIResponses)
+	payload, err := protocol.BuildUpstreamPayload(gatewayRequest{
+		DownstreamPath: gatewayEndpointResponses,
+		Canonical: &canonicalRequest{
+			SourceProtocol: canonicalProtocolOpenAIResponses,
+			Messages: []canonicalMessage{
+				{Type: "message", Role: "user", Content: []canonicalContentPart{{Type: "input_text", Text: "start"}}},
+				{
+					Type:    "message",
+					Role:    "assistant",
+					Content: []canonicalContentPart{{Type: "output_text", Text: "I will call a tool."}},
+					Thinking: []canonicalThinkingBlock{{
+						Type:      "thinking",
+						Thinking:  "private reasoning",
+						Signature: "sig_deepseek",
+					}},
+				},
+				{Type: "function_call", ID: "fc_1", ToolCallID: "call_1", Name: "lookup", Arguments: `{"q":"test"}`},
+				{Type: "function_call_output", ToolCallID: "call_1", Output: "result"},
+			},
+		},
+	}, routeengine.Candidate{
+		Site:  routeengine.CandidateSite{SiteType: "deepseek", BaseURL: "https://api.deepseek.com"},
+		Model: routeengine.CandidateModel{UpstreamName: "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpstreamPayload returned error: %v", err)
+	}
+	messages := payload["messages"].([]any)
+
+	// Must not have two consecutive assistant messages.
+	for i := 1; i < len(messages); i++ {
+		prev := messages[i-1].(map[string]any)
+		curr := messages[i].(map[string]any)
+		if prev["role"] == "assistant" && curr["role"] == "assistant" {
+			t.Fatalf("two consecutive assistant messages at index %d/%d: %#v", i-1, i, messages)
+		}
+	}
+
+	// The single assistant message must contain thinking, text, and tool_use blocks.
+	var assistantMessage map[string]any
+	for _, raw := range messages {
+		m := raw.(map[string]any)
+		if m["role"] == "assistant" {
+			assistantMessage = m
+			break
+		}
+	}
+	if assistantMessage == nil {
+		t.Fatalf("no assistant message found: %#v", messages)
+	}
+	content := assistantMessage["content"].([]any)
+	types := make([]string, 0, len(content))
+	for _, raw := range content {
+		types = append(types, raw.(map[string]any)["type"].(string))
+	}
+	hasThinking, hasText, hasToolUse := false, false, false
+	for _, typ := range types {
+		switch typ {
+		case "thinking":
+			hasThinking = true
+		case "text":
+			hasText = true
+		case "tool_use":
+			hasToolUse = true
+		}
+	}
+	if !hasThinking || !hasText || !hasToolUse {
+		t.Fatalf("assistant message content must contain thinking, text, and tool_use blocks, got types=%v content=%#v", types, content)
 	}
 }
 


### PR DESCRIPTION
## 问题

DeepSeek 的 Anthropic 兼容 API 在包含 thinking 的多轮工具调用时报 400：

```json
{"error": {"code": "invalid_request_error", "message": "The `content[].thinking` in the thinking mode must be passed back to the API."}}
```

## 根因

`encodeCanonicalMessagesAsAnthropicMessages`（`protocol_anthropic_messages.go`）的 `case "function_call"` 分支无条件创建新的 `role: assistant` 消息来放 tool_use 块。当历史消息包含 `reasoning → message(assistant) → function_call → function_call_output` 序列时，会产生两条相邻的 assistant 消息：前一条含 thinking + text，后一条含 tool_use。

DeepSeek 要求 thinking、text、tool_use 必须在同一条 assistant 消息的 `content[]` 里。

## 修复

在 `case "function_call"` 分支里，先检查 `out` 末尾是否已经是 assistant 消息，如果是则把 tool_use 块追加进去，而不是新建一条 assistant 消息。

同时在 `protocol_canonical.go` 中，已有的 reasoning item 合并逻辑也一并包含在此次提交中（Codex 会话的前半段工作）。

## 测试

新增回归测试 `TestDeepSeekAnthropicThinkingAndToolUseInSameAssistantMessage`，断言：
- 不存在两条相邻的 assistant 消息
- 单条 assistant 消息的 `content[]` 同时包含 thinking、text、tool_use 块

全量 gateway 测试通过。